### PR TITLE
[ssh client] Check for EOF before event poll

### DIFF
--- a/src/ssh/ssh_client.cpp
+++ b/src/ssh/ssh_client.cpp
@@ -96,7 +96,7 @@ void mp::SSHClient::handle_ssh_events()
     ssh_connector_set_in_channel(connector_err.get(), channel.get(), SSH_CONNECTOR_STDERR);
     ssh_event_add_connector(event.get(), connector_err.get());
 
-    while (ssh_channel_is_open(channel.get()))
+    while (ssh_channel_is_open(channel.get()) && !ssh_channel_is_eof(channel.get()))
     {
         if (console->is_window_size_changed())
             change_ssh_pty_size(console->get_window_geometry());


### PR DESCRIPTION
Prevent hangs by checking for ssh channel EOF before blocking
waiting for the next event which won't occur. Fixes #16