### PR TITLE
snap: use plain source-type

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,7 +93,6 @@ parts:
     - cmake-extras
     - golang
     source: .
-    source-type: git
     configflags:
     - -DCMAKE_BUILD_TYPE=RelWithDebInfo
     - -DCMAKE_INSTALL_PREFIX=/

--- a/tests/travis-Coverage.patch
+++ b/tests/travis-Coverage.patch
@@ -1,12 +1,11 @@
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
-@@ -92,12 +92,12 @@ parts:
+@@ -92,11 +92,11 @@ parts:
      - build-essential
      - cmake-extras
      - golang
 +    - lcov
      source: .
-     source-type: git
      configflags:
 -    - -DCMAKE_BUILD_TYPE=RelWithDebInfo
 +    - -DCMAKE_BUILD_TYPE=Coverage


### PR DESCRIPTION
Since we're in a git checkout already, using `source-type: git` only
really hurts us, because it pulls all the submodules from the network
instead locally, and that's 500MB of git repos at the moment...