### PR TITLE
qemu: Use dnsmasq for DNS and DHCP of VM's. Fixes #1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -115,3 +115,8 @@ parts:
       usr/share/seabios/vgabios-stdvga.bin: qemu/vgabios-stdvga.bin
       usr/share/seabios/kvmvapic.bin: qemu/kvmvapic.bin
       usr/lib/ipxe/qemu/efi-virtio.rom: qemu/efi-virtio.rom
+
+  dnsmasq:
+    plugin: nil
+    stage-packages:
+    - dnsmasq

--- a/src/network/ip_address_pool.cpp
+++ b/src/network/ip_address_pool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -110,6 +110,25 @@ mp::IPAddress mp::IPAddressPool::obtain_ip_for(const std::string& name)
         return ip;
     }
     return it->second;
+}
+
+std::experimental::optional<mp::IPAddress> mp::IPAddressPool::check_ip_for(const std::string& name)
+{
+    const auto it = ip_map.find(name);
+    if (it == ip_map.end())
+    {
+        return {};
+    }
+
+    return std::experimental::optional<mp::IPAddress>{it->second};
+}
+
+mp::IPAddress mp::IPAddressPool::first_free_ip()
+{
+    if (ips_in_use.empty())
+        return start_ip;
+
+    return *ips_in_use.crbegin() + 1;
 }
 
 void mp::IPAddressPool::remove_ip_for(const std::string& name)

--- a/src/platform/backends/qemu/CMakeLists.txt
+++ b/src/platform/backends/qemu/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017 Canonical Ltd.
+# Copyright © 2017-2018 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -15,6 +15,7 @@
 # Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
 
 add_library(qemu_backend STATIC
+  dnsmasq_server.cpp
   qemu_virtual_machine_factory.cpp
   qemu_virtual_machine.cpp)
 

--- a/src/platform/backends/qemu/dnsmasq_server.cpp
+++ b/src/platform/backends/qemu/dnsmasq_server.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "dnsmasq_server.h"
+
+#include <QFile>
+
+namespace mp = multipass;
+
+namespace
+{
+auto start_dnsmasq_process(const QDir& data_dir, const mp::IPAddress& start_ip, const mp::IPAddress& end_ip)
+{
+    auto cmd = std::make_unique<QProcess>();
+    cmd->start("dnsmasq",
+               QStringList() << "--keep-in-foreground"
+                             << "--strict-order"
+                             << "--bind-interfaces"
+                             << "--except-interface=lo"
+                             << "--interface=mpbr0"
+                             << "--listen-address=10.122.122.1"
+                             << "--dhcp-no-override"
+                             << "--dhcp-authoritative"
+                             << QString("--dhcp-leasefile=%1").arg(data_dir.filePath("dnsmasq.leases"))
+                             << QString("--dhcp-hostsfile=%1").arg(data_dir.filePath("dnsmasq.hosts")) << "--dhcp-range"
+                             << QString("%1,%2,infinite")
+                                    .arg(QString::fromStdString(start_ip.as_string()))
+                                    .arg(QString::fromStdString(end_ip.as_string())));
+
+    cmd->waitForStarted();
+    return cmd;
+}
+}
+
+mp::DNSMasqServer::DNSMasqServer(const Path& path, const IPAddress& start, const IPAddress& end)
+    : start_ip{start},
+      end_ip{end},
+      data_dir{QDir(path + "/vm-ips")},
+      dnsmasq_cmd{start_dnsmasq_process(data_dir, start_ip, end_ip)}
+{
+}
+
+mp::DNSMasqServer::~DNSMasqServer()
+{
+    dnsmasq_cmd->kill();
+    dnsmasq_cmd->waitForFinished();
+}
+
+std::experimental::optional<mp::IPAddress> mp::DNSMasqServer::get_ip_for(const std::string& hw_addr)
+{
+    QProcess cmd;
+
+    cmd.start("bash",
+              QStringList() << "-c"
+                            << QString("grep \"%1\" %2 | cut -d ' ' -f3")
+                                   .arg(QString::fromStdString(hw_addr))
+                                   .arg(data_dir.filePath("dnsmasq.leases")));
+
+    cmd.waitForFinished();
+
+    auto ip_addr = cmd.readAll().trimmed();
+
+    if (ip_addr.isEmpty())
+        return {};
+    else
+        return std::experimental::optional<mp::IPAddress>{mp::IPAddress{ip_addr.toStdString()}};
+}

--- a/src/platform/backends/qemu/dnsmasq_server.h
+++ b/src/platform/backends/qemu/dnsmasq_server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -13,43 +13,36 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
-#ifndef MULTIPASS_IP_ADDRESS_POOL_H
-#define MULTIPASS_IP_ADDRESS_POOL_H
+#ifndef MULTIPASS_DNSMASQ_SERVER_H
+#define MULTIPASS_DNSMASQ_SERVER_H
 
-#include "ip_address.h"
-
+#include <multipass/ip_address.h>
 #include <multipass/path.h>
 
 #include <QDir>
+#include <QProcess>
 
 #include <experimental/optional>
-#include <set>
+#include <memory>
 #include <string>
-#include <unordered_map>
 
 namespace multipass
 {
-class IPAddressPool
+class DNSMasqServer
 {
 public:
-    IPAddressPool(const Path& data_dir, const IPAddress& start, const IPAddress& end);
-    IPAddress obtain_ip_for(const std::string& name);
-    std::experimental::optional<IPAddress> check_ip_for(const std::string& name);
-    IPAddress first_free_ip();
-    void remove_ip_for(const std::string& name);
+    DNSMasqServer(const Path& path, const IPAddress& start, const IPAddress& end);
+    virtual ~DNSMasqServer();
+
+    std::experimental::optional<IPAddress> get_ip_for(const std::string& hw_addr);
 
 private:
-    IPAddress obtain_free_ip();
-    void persist_ips();
     const IPAddress start_ip;
     const IPAddress end_ip;
     const QDir data_dir;
-    std::unordered_map<std::string, IPAddress> ip_map;
-    std::set<IPAddress> ips_in_use;
+    std::unique_ptr<QProcess> dnsmasq_cmd;
 };
 }
-#endif // MULTIPASS_IP_ADDRESS_POOL_H
+#endif // MULTIPASS_DNSMASQ_SERVER_H

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -20,8 +20,12 @@
 #ifndef MULTIPASS_QEMU_VIRTUAL_MACHINE_H
 #define MULTIPASS_QEMU_VIRTUAL_MACHINE_H
 
+#include "dnsmasq_server.h"
+
 #include <multipass/ip_address.h>
 #include <multipass/virtual_machine.h>
+
+#include <experimental/optional>
 
 class QProcess;
 class QFile;
@@ -35,8 +39,9 @@ class VirtualMachineDescription;
 class QemuVirtualMachine final : public VirtualMachine
 {
 public:
-    QemuVirtualMachine(const VirtualMachineDescription& desc, const IPAddress& address,
-                       const std::string& tap_device_name, const std::string& mac_addr, VMStatusMonitor& monitor);
+    QemuVirtualMachine(const VirtualMachineDescription& desc, std::experimental::optional<IPAddress> address,
+                       const std::string& tap_device_name, const std::string& mac_addr, DNSMasqServer& dnsmasq_server,
+                       VMStatusMonitor& monitor);
     ~QemuVirtualMachine();
 
     void start() override;
@@ -54,9 +59,10 @@ private:
     void on_error();
     void on_shutdown();
     VirtualMachine::State state;
-    const IPAddress ip;
+    std::experimental::optional<IPAddress> ip;
     const std::string tap_device_name;
     const std::string mac_addr;
+    DNSMasqServer* dnsmasq_server;
     VMStatusMonitor* monitor;
     std::unique_ptr<QProcess> vm_process;
     std::string saved_error_msg;

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,6 +18,8 @@
  */
 #ifndef MULTIPASS_QEMU_VIRTUAL_MACHINE_FACTORY_H
 #define MULTIPASS_QEMU_VIRTUAL_MACHINE_FACTORY_H
+
+#include "dnsmasq_server.h"
 
 #include <multipass/ip_address_pool.h>
 #include <multipass/virtual_machine_factory.h>
@@ -39,6 +41,7 @@ public:
 
 private:
     IPAddressPool ip_pool;
+    DNSMasqServer dnsmasq_server;
 };
 }
 


### PR DESCRIPTION
- This also supports VM's that have already been created with the old static IP method.