### PR TITLE
Use std::optional if c++17 is enabled.

### DIFF
--- a/include/multipass/ip_address_pool.h
+++ b/include/multipass/ip_address_pool.h
@@ -22,11 +22,11 @@
 
 #include "ip_address.h"
 
+#include <multipass/optional.h>
 #include <multipass/path.h>
 
 #include <QDir>
 
-#include <experimental/optional>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -38,7 +38,7 @@ class IPAddressPool
 public:
     IPAddressPool(const Path& data_dir, const IPAddress& start, const IPAddress& end);
     IPAddress obtain_ip_for(const std::string& name);
-    std::experimental::optional<IPAddress> check_ip_for(const std::string& name);
+    optional<IPAddress> check_ip_for(const std::string& name);
     IPAddress first_free_ip();
     void remove_ip_for(const std::string& name);
 

--- a/include/multipass/optional.h
+++ b/include/multipass/optional.h
@@ -13,36 +13,31 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
+ * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
+ *
  */
 
-#ifndef MULTIPASS_DNSMASQ_SERVER_H
-#define MULTIPASS_DNSMASQ_SERVER_H
+#ifndef MULTIPASS_OPTIONAL_H
+#define MULTIPASS_OPTIONAL_H
 
-#include <multipass/ip_address.h>
-#include <multipass/optional.h>
-#include <multipass/path.h>
+#if __has_include(<optional>) && __cplusplus > 201402L
 
-#include <QDir>
-#include <QProcess>
-
-#include <memory>
-#include <string>
-
+#include <optional>
 namespace multipass
 {
-class DNSMasqServer
-{
-public:
-    DNSMasqServer(const Path& path, const IPAddress& start, const IPAddress& end);
-    virtual ~DNSMasqServer();
-
-    optional<IPAddress> get_ip_for(const std::string& hw_addr);
-
-private:
-    const IPAddress start_ip;
-    const IPAddress end_ip;
-    const QDir data_dir;
-    std::unique_ptr<QProcess> dnsmasq_cmd;
-};
+using std::optional;
 }
-#endif // MULTIPASS_DNSMASQ_SERVER_H
+
+#elif __has_include(<experimental/optional>)
+
+#include <experimental/optional>
+namespace multipass
+{
+using std::experimental::optional;
+}
+
+#else
+#error "no optional implementation found!"
+#endif
+
+#endif // MULTIPASS_OPTIONAL_H

--- a/src/network/ip_address_pool.cpp
+++ b/src/network/ip_address_pool.cpp
@@ -112,7 +112,7 @@ mp::IPAddress mp::IPAddressPool::obtain_ip_for(const std::string& name)
     return it->second;
 }
 
-std::experimental::optional<mp::IPAddress> mp::IPAddressPool::check_ip_for(const std::string& name)
+mp::optional<mp::IPAddress> mp::IPAddressPool::check_ip_for(const std::string& name)
 {
     const auto it = ip_map.find(name);
     if (it == ip_map.end())
@@ -120,7 +120,7 @@ std::experimental::optional<mp::IPAddress> mp::IPAddressPool::check_ip_for(const
         return {};
     }
 
-    return std::experimental::optional<mp::IPAddress>{it->second};
+    return mp::optional<mp::IPAddress>{it->second};
 }
 
 mp::IPAddress mp::IPAddressPool::first_free_ip()

--- a/src/platform/backends/qemu/dnsmasq_server.cpp
+++ b/src/platform/backends/qemu/dnsmasq_server.cpp
@@ -60,7 +60,7 @@ mp::DNSMasqServer::~DNSMasqServer()
     dnsmasq_cmd->waitForFinished();
 }
 
-std::experimental::optional<mp::IPAddress> mp::DNSMasqServer::get_ip_for(const std::string& hw_addr)
+mp::optional<mp::IPAddress> mp::DNSMasqServer::get_ip_for(const std::string& hw_addr)
 {
     QProcess cmd;
 
@@ -77,5 +77,5 @@ std::experimental::optional<mp::IPAddress> mp::DNSMasqServer::get_ip_for(const s
     if (ip_addr.isEmpty())
         return {};
     else
-        return std::experimental::optional<mp::IPAddress>{mp::IPAddress{ip_addr.toStdString()}};
+        return mp::optional<mp::IPAddress>{mp::IPAddress{ip_addr.toStdString()}};
 }

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -96,8 +96,7 @@ auto make_qemu_process(const mp::VirtualMachineDescription& desc, const std::str
 }
 }
 
-mp::QemuVirtualMachine::QemuVirtualMachine(const VirtualMachineDescription& desc,
-                                           std::experimental::optional<mp::IPAddress> address,
+mp::QemuVirtualMachine::QemuVirtualMachine(const VirtualMachineDescription& desc, optional<mp::IPAddress> address,
                                            const std::string& tap_device_name, const std::string& mac_addr,
                                            DNSMasqServer& dnsmasq_server, VMStatusMonitor& monitor)
     : state{State::off},

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -23,9 +23,8 @@
 #include "dnsmasq_server.h"
 
 #include <multipass/ip_address.h>
+#include <multipass/optional.h>
 #include <multipass/virtual_machine.h>
-
-#include <experimental/optional>
 
 class QProcess;
 class QFile;
@@ -39,7 +38,7 @@ class VirtualMachineDescription;
 class QemuVirtualMachine final : public VirtualMachine
 {
 public:
-    QemuVirtualMachine(const VirtualMachineDescription& desc, std::experimental::optional<IPAddress> address,
+    QemuVirtualMachine(const VirtualMachineDescription& desc, optional<IPAddress> address,
                        const std::string& tap_device_name, const std::string& mac_addr, DNSMasqServer& dnsmasq_server,
                        VMStatusMonitor& monitor);
     ~QemuVirtualMachine();
@@ -59,7 +58,7 @@ private:
     void on_error();
     void on_shutdown();
     VirtualMachine::State state;
-    std::experimental::optional<IPAddress> ip;
+    optional<IPAddress> ip;
     const std::string tap_device_name;
     const std::string mac_addr;
     DNSMasqServer* dnsmasq_server;


### PR DESCRIPTION
When c++17 support is enabled, use std::optional, instead of
std::experimental::optional.