### PR TITLE
ignore shell aliases when determining instances for autocomplete

### DIFF
--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -19,9 +19,9 @@ _multipass_complete()
         local state=$1
 
         local cmd="multipass list"
-        [ -n "$state" ] && cmd="$cmd | grep -E '$state'"
+        [ -n "$state" ] && cmd="$cmd | \grep -E '$state'"
 
-        opts=$( eval $cmd | grep -Ev '(\+--|Name)' | awk '{print $1}' )
+        opts=$( eval $cmd | \grep -Ev '(\+--|Name)' | awk '{print $1}' )
     }
 
     local cur cmd opts


### PR DESCRIPTION
This changes the calls to "grep" to use the unaliased form. "\grep"
This helps me because I tend to "alias grep='grep --color -nI'" which ends up putting the line numbers in front of the instance list. By using '\grep' it avoids my aliases.
