### PR TITLE
[snap] Allow proxy configuration via "snap set"

### DIFF
--- a/snap/bin/launch-multipassd
+++ b/snap/bin/launch-multipassd
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+export http_proxy="$(snapctl get proxy.http)"
+export https_proxy="$(snapctl get proxy.https)"
+
+exec $SNAP/bin/multipassd

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+# Just a placeholder, however validation of the proxy.{http,https}
+# configuration could be made here

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,7 @@ confinement: classic
 
 apps:
   multipassd:
-    command: bin/multipassd
+    command: bin/launch-multipassd
     environment:
       LD_LIBRARY_PATH: $SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu::$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu
       PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
@@ -134,3 +134,7 @@ parts:
     plugin: nil
     stage-packages:
     - msr-tools
+
+  glue:
+    plugin: dump
+    source: snap


### PR DESCRIPTION
Allow proxy configuration via "snap set proxy.{http,https}=...". Fixes #53