### PR TITLE
qemu: Catch if the qemu process is not running during start

### DIFF
--- a/include/multipass/start_exception.h
+++ b/include/multipass/start_exception.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_START_EXCEPTION_H
+#define MULTIPASS_START_EXCEPTION_H
+
+#include <stdexcept>
+#include <string>
+
+namespace multipass
+{
+class StartException : public std::runtime_error
+{
+public:
+    StartException(const std::string& instance_name, const std::string& what)
+        : runtime_error(what), instance_name(instance_name)
+    {
+    }
+
+    std::string name() const
+    {
+        return instance_name;
+    }
+
+private:
+    const std::string instance_name;
+};
+}
+#endif // MULTIPASS_START_EXCEPTION_H

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -61,6 +61,7 @@ private:
     optional<IPAddress> ip;
     const std::string tap_device_name;
     const std::string mac_addr;
+    const std::string vm_name;
     DNSMasqServer* dnsmasq_server;
     VMStatusMonitor* monitor;
     std::unique_ptr<QProcess> vm_process;


### PR DESCRIPTION
Catch if the qemu process is not running during IP discovery and wait for ssh. Fixes #64