### PR TITLE
 qemu: Sanitize units for --disk option during launch

### DIFF
--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
@@ -241,6 +241,9 @@ void mp::QemuVirtualMachineFactory::prepare_instance_image(const mp::VMImage& in
     if (!desc.disk_space.empty())
     {
         disk_size = QString::fromStdString(desc.disk_space);
+
+        if (disk_size.endsWith("B"))
+            disk_size.chop(1);
     }
 
     QProcess resize_image;


### PR DESCRIPTION
Sanitize unit if it ends with 'B' such as 'GB'. Fixes #67