### PR TITLE
sshfs_mount: Fix issue with rename in the sftp server. Fixes #71

### DIFF
--- a/src/sshfs_mount/sshfs_mount.cpp
+++ b/src/sshfs_mount/sshfs_mount.cpp
@@ -632,6 +632,15 @@ private:
 
     void handle_rename(sftp_client_message msg)
     {
+        if (QFile::exists(ssh_string_get_char(msg->data)))
+        {
+            if (!QFile::remove(ssh_string_get_char(msg->data)))
+            {
+                reply_status(msg);
+                return;
+            }
+        }
+
         if (!QFile::rename(sanitize_path_name(QString(msg->filename)), ssh_string_get_char(msg->data)))
         {
             reply_status(msg);


### PR DESCRIPTION
When handling a rename from sshfs and the new path already exists, then remove
the existing file first before calling rename().