### PR TITLE
sshfs_mount: Force a flush() after write. Fixes #77, Fixes #83.

### DIFF
--- a/src/sshfs_mount/sshfs_mount.cpp
+++ b/src/sshfs_mount/sshfs_mount.cpp
@@ -776,6 +776,8 @@ private:
                 return;
             }
 
+            handle->file->flush();
+
             data_ptr += r;
             len -= r;
         } while (len > 0);


### PR DESCRIPTION
There is a race when using QFile where if a write has not made it to disk before an ensuing instantiation of QFile occurs, then the new QFile will get the older file information and use that even when the write does make it to disk.

This was exposed by git and how it handles its pack file.  git will write out a bunch of data to the pack file, and then turn right around and begin reading from it from new threads via a new open().  This is exacerbated further when multiple CPU's are defined in a VM and git uses multiple read threads.

The easy solution for now is to flush() after each write() to ensure the data is on disk.  This does impact performance a bit, but performance is already bad due to other reasons.  I plan on making the flush() unnecessary in a later PR by trying to use POSIX open()/read()/write()/lseek() instead. 