### PR TITLE
utils: Match one or more leading '/' when invalidating target paths

### DIFF
--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -56,7 +56,7 @@ bool mp::utils::valid_hostname(const QString& name_string)
 bool mp::utils::invalid_target_path(const QString& target_path)
 {
     QString sanitized_path{QDir::cleanPath(target_path)};
-    QRegExp matcher("/|/(dev|proc|sys)(/.*)*|/home/ubuntu/*");
+    QRegExp matcher("/+|/+(dev|proc|sys)(/.*)*|/+home/ubuntu/*");
 
     return matcher.exactMatch(sanitized_path);
 }


### PR DESCRIPTION
This fixes some cases where QDir::cleanPath() does not sanitize the leading '/'.