### PR TITLE
[sshfsmount] Simplify shutdown

### DIFF
--- a/include/multipass/ssh/ssh_session.h
+++ b/include/multipass/ssh/ssh_session.h
@@ -43,6 +43,7 @@ public:
                                   std::function<void()> precondition_check);
 
     SSHProcess exec(const std::vector<std::string>& args);
+    void force_shutdown();
 
 private:
     operator ssh_session() const;

--- a/include/multipass/sshfs_mount/sshfs_mount.h
+++ b/include/multipass/sshfs_mount/sshfs_mount.h
@@ -48,10 +48,8 @@ signals:
     void finished();
 
 private:
-    std::function<SSHSession()> make_session;
     SSHSession ssh_session;
     SSHProcess sshfs_process;
-    const QString sshfs_pid;
     const std::unordered_map<int, int> gid_map;
     const std::unordered_map<int, int> uid_map;
     std::thread mount_thread;

--- a/src/ssh/ssh_session.cpp
+++ b/src/ssh/ssh_session.cpp
@@ -24,6 +24,7 @@
 #include <multipass/utils.h>
 
 #include <libssh/callbacks.h>
+#include <libssh/socket.h>
 
 #include <array>
 #include <mutex>
@@ -115,6 +116,14 @@ mp::SSHSession::SSHSession(const std::string& host, int port) : SSHSession(host,
 mp::SSHProcess mp::SSHSession::exec(const std::vector<std::string>& args)
 {
     return {session.get(), utils::to_cmd(args, utils::QuoteType::no_quotes)};
+}
+
+void mp::SSHSession::force_shutdown()
+{
+    auto socket = ssh_get_fd(session.get());
+
+    const int shutdown_read_and_writes = 2;
+    shutdown(socket, shutdown_read_and_writes);
 }
 
 void mp::SSHSession::wait_until_ssh_up(const std::string& host, int port, std::chrono::milliseconds timeout,


### PR DESCRIPTION
Unblock the sftp server thread by adding a way to forcefully shut
down an ssh session. This simplifies stopping an sshfs mount, no
longer needing to access potentially dead objects (indirectly
through the session factory).

Fixes #82.