### PR TITLE
[travis] Disable default depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: required
 
 language: cpp
 
+git:
+  depth: false
+
 branches:
   only:
   - staging


### PR DESCRIPTION
Travis uses a default of 50 commits when cloning. If we go over
50 commits after the last tag however, the snapcraft build will fail
since our snapcraft recipe uses git describe to compute the version.
git describe fails if it doesn't find a tag in the history.