### PR TITLE
[travis] run tests inside the container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,13 @@ jobs:
 
     - env: BUILD_TYPE=Debug
       script:
-      - sg lxd -c 'env PATH=/snap/bin:$PATH SNAPCRAFT_CONTAINER_BUILDS=1 /snap/bin/snapcraft'
-      - sudo snap install --dangerous --classic multipass_*.snap
-      - snap run --shell multipass -c parts/multipass/build/bin/multipass_tests
+      - sg lxd -c 'env PATH=/snap/bin:$PATH SNAPCRAFT_CONTAINER_BUILDS=1 /snap/bin/snapcraft build multipass'
+      - sg lxd -c '/snap/bin/lxc start snapcraft-multipass'
+      - sg lxd -c
+          '/snap/bin/lxc exec snapcraft-multipass --
+             env CTEST_OUTPUT_ON_FAILURE=1
+                 LD_LIBRARY_PATH=/root/build_multipass/stage/usr/lib/x86_64-linux-gnu/
+                 /root/build_multipass/parts/multipass/build/bin/multipass_tests'
 
     - env: BUILD_TYPE=Coverage
       script:


### PR DESCRIPTION
A classic snap has too much to do with the host it runs on, run the
tests in the lxc container instead.