### PR TITLE
url_downloader: Set a 10 sec. timeout when downloading files

### DIFF
--- a/src/client/cmd/animated_spinner.cpp
+++ b/src/client/cmd/animated_spinner.cpp
@@ -64,8 +64,8 @@ void mp::AnimatedSpinner::stop()
         lock.unlock();
         if (t.joinable())
             t.join();
-        clear_line(cout);
     }
+    clear_line(cout);
 }
 
 void mp::AnimatedSpinner::draw()


### PR DESCRIPTION
QNetworkAccessManager has no built in QNetworkReply timeout, so need to use a
QTimer to do the dirty work.

Fixes #108