### PR TITLE
virtual_machine: Add new `starting` and `unknown` status

### DIFF
--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -33,7 +33,9 @@ public:
     {
         off,
         stopped,
-        running
+        starting,
+        running,
+        unknown
     };
 
     using UPtr = std::unique_ptr<VirtualMachine>;

--- a/src/client/formatter/format_utils.cpp
+++ b/src/client/formatter/format_utils.cpp
@@ -34,6 +34,9 @@ std::string mp::format::status_string_for(const mp::InstanceStatus& status)
     case mp::InstanceStatus::TRASHED:
         status_val = "DELETED";
         break;
+    case mp::InstanceStatus::STARTING:
+        status_val = "STARTING";
+        break;
     default:
         status_val = "UNKNOWN";
         break;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -653,8 +653,12 @@ try // clang-format on
             auto status_for = [](mp::VirtualMachine::State state) {
                 switch (state)
                 {
+                case mp::VirtualMachine::State::starting:
+                    return mp::InstanceStatus::STARTING;
                 case mp::VirtualMachine::State::running:
                     return mp::InstanceStatus::RUNNING;
+                case mp::VirtualMachine::State::unknown:
+                    return mp::InstanceStatus::UNKNOWN;
                 default:
                     return mp::InstanceStatus::STOPPED;
                 }
@@ -728,8 +732,12 @@ try // clang-format on
     auto status_for = [](mp::VirtualMachine::State state) {
         switch (state)
         {
+        case mp::VirtualMachine::State::starting:
+            return mp::InstanceStatus::STARTING;
         case mp::VirtualMachine::State::running:
             return mp::InstanceStatus::RUNNING;
+        case mp::VirtualMachine::State::unknown:
+            return mp::InstanceStatus::UNKNOWN;
         default:
             return mp::InstanceStatus::STOPPED;
         }

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -115,8 +115,10 @@ message MountInfo {
 message InstanceStatus {
     enum Status {
         RUNNING = 0;
-        STOPPED = 1;
-        TRASHED = 2;
+        STARTING = 1;
+        STOPPED = 2;
+        TRASHED = 3;
+        UNKNOWN = 4;
     }
     Status status = 1;
 }


### PR DESCRIPTION
Add these new statuses for finer control of what output should be shown in
`list` and `info`.

Fixes #121