### PR TITLE
qemu: Use qmp to get VM events and detect VM reboots

### DIFF
--- a/include/multipass/optional.h
+++ b/include/multipass/optional.h
@@ -26,6 +26,7 @@
 namespace multipass
 {
 using std::optional;
+using std::nullopt;
 }
 
 #elif __has_include(<experimental/optional>)
@@ -34,6 +35,7 @@ using std::optional;
 namespace multipass
 {
 using std::experimental::optional;
+using std::experimental::nullopt;
 }
 
 #else

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -34,6 +34,7 @@ public:
         off,
         stopped,
         starting,
+        restarting,
         running,
         unknown
     };

--- a/include/multipass/vm_status_monitor.h
+++ b/include/multipass/vm_status_monitor.h
@@ -19,6 +19,9 @@
 
 #ifndef MULTIPASS_VM_STATUS_MONITOR_H
 #define MULTIPASS_VM_STATUS_MONITOR_H
+
+#include <string>
+
 namespace multipass
 {
 class VMStatusMonitor
@@ -28,6 +31,7 @@ public:
     virtual void on_resume() = 0;
     virtual void on_stop() = 0;
     virtual void on_shutdown() = 0;
+    virtual void on_restart(const std::string& name) = 0;
 
 protected:
     VMStatusMonitor() = default;

--- a/src/client/formatter/format_utils.cpp
+++ b/src/client/formatter/format_utils.cpp
@@ -37,6 +37,9 @@ std::string mp::format::status_string_for(const mp::InstanceStatus& status)
     case mp::InstanceStatus::STARTING:
         status_val = "STARTING";
         break;
+    case mp::InstanceStatus::RESTARTING:
+        status_val = "RESTARTING";
+        break;
     default:
         status_val = "UNKNOWN";
         break;

--- a/src/client/formatter/table_formatter.cpp
+++ b/src/client/formatter/table_formatter.cpp
@@ -68,11 +68,12 @@ std::string mp::TableFormatter::format(const ListReply& reply) const
     if (reply.instances().empty())
         return "No instances found.\n";
 
-    out.write("{:<24}{:<9}{:<17}{:<}\n", "Name", "State", "IPv4", "Release");
+    out.write("{:<24}{:<12}{:<17}{:<}\n", "Name", "State", "IPv4", "Release");
 
     for (const auto& instance : reply.instances())
     {
-        out.write("{:<24}{:<9}{:<17}{:<}\n", instance.name(), mp::format::status_string_for(instance.instance_status()),
+        out.write("{:<24}{:<12}{:<17}{:<}\n", instance.name(),
+                  mp::format::status_string_for(instance.instance_status()),
                   instance.ipv4().empty() ? "--" : instance.ipv4(), instance.current_release());
     }
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -72,6 +72,7 @@ protected:
     void on_resume() override;
     void on_stop() override;
     void on_shutdown() override;
+    void on_restart(const std::string& name) override;
 
 public slots:
     grpc::Status create(grpc::ServerContext* context, const CreateRequest* request,

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -27,12 +27,11 @@
 
 #include <QCoreApplication>
 #include <QDebug>
-#include <QDir>
 #include <QFile>
-#include <QHostAddress>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QObject>
 #include <QProcess>
-#include <QProcessEnvironment>
 #include <QString>
 #include <QStringList>
 
@@ -71,7 +70,7 @@ auto make_qemu_process(const mp::VirtualMachineDescription& desc, const std::str
     args << "-netdev";
     args << QString("tap,id=hostnet0,ifname=%1,script=no,downscript=no").arg(QString::fromStdString(tap_device_name));
     // Control interface
-    args << "-monitor"
+    args << "-qmp"
          << "stdio";
     // No console
     args << "-chardev"
@@ -104,6 +103,13 @@ void remove_tap_device(const QString& tap_device_name)
         mp::utils::run_cmd_for_status("ip", {"link", "delete", tap_device_name});
     }
 }
+
+auto qmp_execute_json(const QString& cmd)
+{
+    QJsonObject qmp;
+    qmp.insert("execute", cmd);
+    return QJsonDocument(qmp).toJson();
+}
 }
 
 mp::QemuVirtualMachine::QemuVirtualMachine(const VirtualMachineDescription& desc, optional<mp::IPAddress> address,
@@ -111,6 +117,7 @@ mp::QemuVirtualMachine::QemuVirtualMachine(const VirtualMachineDescription& desc
                                            DNSMasqServer& dnsmasq_server, VMStatusMonitor& monitor)
     : state{State::off},
       ip{address},
+      is_legacy_ip{ip ? true : false},
       tap_device_name{tap_device_name},
       mac_addr{mac_addr},
       vm_name{desc.vm_name},
@@ -122,8 +129,27 @@ mp::QemuVirtualMachine::QemuVirtualMachine(const VirtualMachineDescription& desc
         qDebug() << "QProcess::started";
         on_started();
     });
-    QObject::connect(vm_process.get(), &QProcess::readyReadStandardOutput,
-                     [this]() { qDebug("qemu.out: %s", vm_process->readAllStandardOutput().data()); });
+    QObject::connect(vm_process.get(), &QProcess::readyReadStandardOutput, [this]() {
+        auto qmp_output = QJsonDocument::fromJson(vm_process->readAllStandardOutput()).object();
+        auto event = qmp_output["event"];
+
+        if (!event.isNull())
+        {
+            if (event.toString() == "RESET" && state != State::restarting)
+            {
+                qDebug() << "monitor: Instance" << QString::fromStdString(vm_name) << "restarting";
+                on_restart();
+            }
+            else if (event.toString() == "POWERDOWN")
+            {
+                qDebug() << "monitor: Instance" << QString::fromStdString(vm_name) << "powering down";
+            }
+            else if (event.toString() == "SHUTDOWN")
+            {
+                qDebug() << "monitor: Instance" << QString::fromStdString(vm_name) << "shut down";
+            }
+        }
+    });
 
     QObject::connect(vm_process.get(), &QProcess::readyReadStandardError, [this]() {
         saved_error_msg = vm_process->readAllStandardError().data();
@@ -166,6 +192,8 @@ void mp::QemuVirtualMachine::start()
 
     if (!started)
         throw std::runtime_error("failed to start qemu instance");
+
+    vm_process->write(qmp_execute_json("qmp_capabilities"));
 }
 
 void mp::QemuVirtualMachine::stop()
@@ -177,7 +205,7 @@ void mp::QemuVirtualMachine::shutdown()
 {
     if (state == State::running && vm_process->processId() > 0)
     {
-        vm_process->write("system_powerdown\n");
+        vm_process->write(qmp_execute_json("system_powerdown"));
         vm_process->waitForFinished();
     }
 }
@@ -207,6 +235,16 @@ void mp::QemuVirtualMachine::on_shutdown()
 {
     state = State::off;
     monitor->on_shutdown();
+}
+
+void mp::QemuVirtualMachine::on_restart()
+{
+    state = State::restarting;
+
+    if (!is_legacy_ip)
+        ip = nullopt;
+
+    monitor->on_restart(vm_name);
 }
 
 std::string mp::QemuVirtualMachine::ssh_hostname()

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -57,8 +57,10 @@ private:
     void on_started();
     void on_error();
     void on_shutdown();
+    void on_restart();
     VirtualMachine::State state;
     optional<IPAddress> ip;
+    bool is_legacy_ip;
     const std::string tap_device_name;
     const std::string mac_addr;
     const std::string vm_name;

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -116,9 +116,10 @@ message InstanceStatus {
     enum Status {
         RUNNING = 0;
         STARTING = 1;
-        STOPPED = 2;
-        TRASHED = 3;
-        UNKNOWN = 4;
+        RESTARTING = 2;
+        STOPPED = 3;
+        TRASHED = 4;
+        UNKNOWN = 5;
     }
     Status status = 1;
 }

--- a/src/ssh/ssh_session.cpp
+++ b/src/ssh/ssh_session.cpp
@@ -93,9 +93,12 @@ mp::SSHSession::SSHSession(const std::string& host, int port, const SSHKeyProvid
     if (session == nullptr)
         throw std::runtime_error("Could not allocate ssh session");
 
+    const auto timeout = 1;
+
     SSH::throw_on_error(ssh_options_set, session, SSH_OPTIONS_HOST, host.c_str());
     SSH::throw_on_error(ssh_options_set, session, SSH_OPTIONS_PORT, &port);
     SSH::throw_on_error(ssh_options_set, session, SSH_OPTIONS_USER, "ubuntu");
+    SSH::throw_on_error(ssh_options_set, session, SSH_OPTIONS_TIMEOUT, &timeout);
     SSH::throw_on_error(ssh_connect, session);
     if (key_provider)
         SSH::throw_on_error(ssh_userauth_publickey, session, nullptr, key_provider->private_key());

--- a/tests/mock_status_monitor.h
+++ b/tests/mock_status_monitor.h
@@ -32,6 +32,7 @@ struct MockVMStatusMonitor : public VMStatusMonitor
     MOCK_METHOD0(on_resume, void());
     MOCK_METHOD0(on_stop, void());
     MOCK_METHOD0(on_shutdown, void());
+    MOCK_METHOD1(on_restart, void(const std::string&));
 };
 }
 }

--- a/tests/stub_status_monitor.h
+++ b/tests/stub_status_monitor.h
@@ -31,6 +31,7 @@ struct StubVMStatusMonitor : public multipass::VMStatusMonitor
     void on_resume() override{};
     void on_stop() override{};
     void on_shutdown() override{};
+    void on_restart(const std::string& name) override{};
 };
 }
 }

--- a/tests/test_format_utils.cpp
+++ b/tests/test_format_utils.cpp
@@ -53,7 +53,7 @@ TEST(InstanceStatusString, deleted_status_returns_DELETED)
 TEST(InstanceStatusString, bogus_status_returns_UNKNOWN)
 {
     mp::InstanceStatus status;
-    status.set_status(static_cast<mp::InstanceStatus_Status>(4));
+    status.set_status(static_cast<mp::InstanceStatus_Status>(10));
     auto status_string = mp::format::status_string_for(status);
 
     EXPECT_THAT(status_string, Eq("UNKNOWN"));

--- a/tests/test_output_formatter.cpp
+++ b/tests/test_output_formatter.cpp
@@ -124,8 +124,8 @@ TEST(TableFormatter, single_instance_list_output)
 {
     auto list_reply = construct_single_instance_list_reply();
 
-    auto expected_table_output = "Name                    State    IPv4             Release\n"
-                                 "foo                     RUNNING  10.168.32.2      Ubuntu 16.04 LTS\n";
+    auto expected_table_output = "Name                    State       IPv4             Release\n"
+                                 "foo                     RUNNING     10.168.32.2      Ubuntu 16.04 LTS\n";
 
     mp::TableFormatter table_formatter;
     auto output = table_formatter.format(list_reply);
@@ -137,9 +137,9 @@ TEST(TableFormatter, multiple_instance_list_output)
 {
     auto list_reply = construct_multiple_instances_list_reply();
 
-    auto expected_table_output = "Name                    State    IPv4             Release\n"
-                                 "bogus-instance          RUNNING  10.21.124.56     Ubuntu 16.04 LTS\n"
-                                 "bombastic               STOPPED  --               Ubuntu 18.04 LTS\n";
+    auto expected_table_output = "Name                    State       IPv4             Release\n"
+                                 "bogus-instance          RUNNING     10.21.124.56     Ubuntu 16.04 LTS\n"
+                                 "bombastic               STOPPED     --               Ubuntu 18.04 LTS\n";
 
     mp::TableFormatter table_formatter;
     auto output = table_formatter.format(list_reply);


### PR DESCRIPTION
Use the QEMU Machine Protocol (QMP) interface for getting asynchronous events and
sending commands.

Fixes #50