### PR TITLE
cli: rename `connect` to `shell` to align with lxd (Fixes: #115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,5 +66,5 @@ sudo <multipass>/build/bin/multipassd &
 ## Connect to a running instance
 
 ```
-<multipass>/build/bin/multipass connect foo
+<multipass>/build/bin/multipass shell foo
 ```

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -28,13 +28,13 @@ _multipass_complete()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     cmd="${COMP_WORDS[1]}"
-    multipass_cmds="connect delete exec find help info launch list mount purge \
+    multipass_cmds="shell delete exec find help info launch list mount purge \
                     recover start stop umount version"
 
 
     if [[ ${cur} == -* ]]; then
         case "${cmd}" in
-            "connect"|"exec"|"find"|"help"|"info"|"list"|"purge"|"umount"|"version")
+            "shell"|"exec"|"find"|"help"|"info"|"list"|"purge"|"umount"|"version")
                 opts="--help --verbose"
             ;;
             "delete")
@@ -55,7 +55,7 @@ _multipass_complete()
         esac
     else
         case "${cmd}" in
-            "connect"|"exec"|"stop")
+            "shell"|"exec"|"stop")
                 _multipass_instances "RUNNING"
             ;;
             "start")

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -17,7 +17,6 @@
  *
  */
 #include "client.h"
-#include "cmd/connect.h"
 #include "cmd/create.h"
 #include "cmd/empty_trash.h"
 #include "cmd/exec.h"
@@ -27,6 +26,7 @@
 #include "cmd/list.h"
 #include "cmd/mount.h"
 #include "cmd/recover.h"
+#include "cmd/shell.h"
 #include "cmd/start.h"
 #include "cmd/stop.h"
 #include "cmd/trash.h"
@@ -68,7 +68,6 @@ mp::Client::Client(const ClientConfig& config)
       cout{config.cout},
       cerr{config.cerr}
 {
-    add_command<cmd::Connect>();
     add_command<cmd::Create>();
     add_command<cmd::EmptyTrash>();
     add_command<cmd::Exec>();
@@ -78,6 +77,7 @@ mp::Client::Client(const ClientConfig& config)
     add_command<cmd::List>();
     add_command<cmd::Mount>();
     add_command<cmd::Recover>();
+    add_command<cmd::Shell>();
     add_command<cmd::Start>();
     add_command<cmd::Stop>();
     add_command<cmd::Trash>();

--- a/src/client/cmd/CMakeLists.txt
+++ b/src/client/cmd/CMakeLists.txt
@@ -16,7 +16,6 @@
 
 add_library(commands STATIC
   animated_spinner.cpp
-  connect.cpp
   create.cpp
   empty_trash.cpp
   exec.cpp
@@ -26,6 +25,7 @@ add_library(commands STATIC
   list.cpp
   mount.cpp
   recover.cpp
+  shell.cpp
   start.cpp
   stop.cpp
   trash.cpp

--- a/src/client/cmd/shell.cpp
+++ b/src/client/cmd/shell.cpp
@@ -17,7 +17,7 @@
  *
  */
 
-#include "connect.h"
+#include "shell.h"
 
 #include <multipass/cli/argparser.h>
 #include <multipass/ssh/ssh_client.h>
@@ -26,7 +26,7 @@ namespace mp = multipass;
 namespace cmd = multipass::cmd;
 using RpcMethod = mp::Rpc::Stub;
 
-mp::ReturnCode cmd::Connect::run(mp::ArgParser* parser)
+mp::ReturnCode cmd::Shell::run(mp::ArgParser* parser)
 {
     auto ret = parse_args(parser);
     if (ret != ParseCode::Ok)
@@ -52,35 +52,40 @@ mp::ReturnCode cmd::Connect::run(mp::ArgParser* parser)
         }
         catch (const std::exception& e)
         {
-            cerr << "connect failed: " << e.what() << "\n";
+            cerr << "shell failed: " << e.what() << "\n";
             return ReturnCode::CommandFail;
         }
         return ReturnCode::Ok;
     };
 
     auto on_failure = [this](grpc::Status& status) {
-        cerr << "connect failed: " << status.error_message() << "\n";
+        cerr << "shell failed: " << status.error_message() << "\n";
         return ReturnCode::CommandFail;
     };
 
     return dispatch(&RpcMethod::ssh_info, request, on_success, on_failure);
 }
 
-std::string cmd::Connect::name() const { return "connect"; }
+std::string cmd::Shell::name() const { return "shell"; }
 
-QString cmd::Connect::short_help() const
+std::vector<std::string> cmd::Shell::aliases() const
 {
-    return QStringLiteral("Connect to a running instance");
+    return {name(), "sh", "connect"};
 }
 
-QString cmd::Connect::description() const
+QString cmd::Shell::short_help() const
 {
-    return QStringLiteral("Open a prompt on the instance.");
+    return QStringLiteral("Open a shell on a running instance");
 }
 
-mp::ParseCode cmd::Connect::parse_args(mp::ArgParser* parser)
+QString cmd::Shell::description() const
 {
-    parser->addPositionalArgument("name", "Name of instance to connect to", "<name>");
+    return QStringLiteral("Open a shell prompt on the instance.");
+}
+
+mp::ParseCode cmd::Shell::parse_args(mp::ArgParser* parser)
+{
+    parser->addPositionalArgument("name", "Name of the instance to open a shell on", "<name>");
 
     auto status = parser->commandParse(this);
 

--- a/src/client/cmd/shell.h
+++ b/src/client/cmd/shell.h
@@ -26,13 +26,14 @@ namespace multipass
 {
 namespace cmd
 {
-class Connect final : public Command
+class Shell final : public Command
 {
 public:
     using Command::Command;
     ReturnCode run(ArgParser *parser) override;
 
     std::string name() const override;
+    std::vector<std::string> aliases() const override;
     QString short_help() const override;
     QString description() const override;
 

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -84,15 +84,15 @@ TEST_F(Client, no_command_help_ok)
     EXPECT_THAT(send_command({"-h"}), Eq(mp::ReturnCode::Ok));
 }
 
-// connect cli test
-TEST_F(Client, connect_cmd_good_arguments)
+// shell cli test
+TEST_F(Client, shell_cmd_good_arguments)
 {
-    EXPECT_THAT(send_command({"connect", "foo"}), Eq(mp::ReturnCode::Ok));
+    EXPECT_THAT(send_command({"shell", "foo"}), Eq(mp::ReturnCode::Ok));
 }
 
-TEST_F(Client, connect_cmd_help_ok)
+TEST_F(Client, shell_cmd_help_ok)
 {
-    EXPECT_THAT(send_command({"connect", "-h"}), Eq(mp::ReturnCode::Ok));
+    EXPECT_THAT(send_command({"shell", "-h"}), Eq(mp::ReturnCode::Ok));
 }
 
 // create cli tests


### PR DESCRIPTION
The `lxc` command line has a (non-advertised yet) `shell` command, let's
rename our `connect` to align. It's a better name as well.

I've left `connect` as an alias to not break people's muscle memory.