### PR TITLE
sftpserver: Support extended SFTP methods

### DIFF
--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -32,6 +32,7 @@ std::string default_server_address();
 VirtualMachineFactory::UPtr vm_backend(const Path& data_dir);
 int chown(const char* path, unsigned int uid, unsigned int gid);
 bool symlink(const char* target, const char* link, bool is_dir);
+bool link(const char* target, const char* link);
 } // namespace platform
 }
 #endif // MULTIPASS_PLATFORM_H

--- a/include/multipass/sshfs_mount/sftp_server.h
+++ b/include/multipass/sshfs_mount/sftp_server.h
@@ -64,6 +64,7 @@ private:
     int handle_stat(sftp_client_message msg, bool follow);
     int handle_symlink(sftp_client_message msg);
     int handle_write(sftp_client_message msg);
+    int handle_extended(sftp_client_message msg);
 
     SSHSession ssh_session;
     const SSHSessionUptr sftp_ssh_session;

--- a/src/platform/platform.cpp
+++ b/src/platform/platform.cpp
@@ -45,3 +45,8 @@ bool mp::platform::symlink(const char* target, const char* link, bool is_dir)
 {
     return ::symlink(target, link) == 0;
 }
+
+bool mp::platform::link(const char* target, const char* link)
+{
+    return ::link(target, link) == 0;
+}


### PR DESCRIPTION
Support the "hardlink@openssh.com" and "posix-rename@openssh.com" extended methods.
Fixes #144