### PR TITLE
Fix intermittent failures in daemon tests

### DIFF
--- a/include/multipass/ssh/ssh_session.h
+++ b/include/multipass/ssh/ssh_session.h
@@ -38,9 +38,6 @@ public:
     SSHSession(const std::string& host, int port);
     SSHSession(const std::string& host, int port, const SSHKeyProvider& key_provider);
 
-    static void wait_until_ssh_up(const std::string& host, int port, std::chrono::milliseconds timeout,
-                                  std::function<void()> precondition_check);
-
     SSHProcess exec(const std::string& cmd);
 
     void force_shutdown();

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -51,6 +51,7 @@ public:
     virtual std::string ipv4() = 0;
     virtual std::string ipv6() = 0;
     virtual void wait_until_ssh_up(std::chrono::milliseconds timeout) = 0;
+    virtual void wait_for_cloud_init(std::chrono::milliseconds timeout) = 0;
 
 protected:
     VirtualMachine() = default;

--- a/include/multipass/virtual_machine_description.h
+++ b/include/multipass/virtual_machine_description.h
@@ -25,6 +25,7 @@
 
 namespace multipass
 {
+class SSHKeyProvider;
 class VirtualMachineDescription
 {
 public:
@@ -36,6 +37,7 @@ public:
     std::string vm_name;
     VMImage image;
     Path cloud_init_iso;
+    const SSHKeyProvider& key_provider;
 };
 }
 #endif // MULTIPASS_VIRTUAL_MACHINE_DESCRIPTION_H

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -20,7 +20,6 @@
 #ifndef MULTIPASS_DAEMON_H
 #define MULTIPASS_DAEMON_H
 
-#include "auto_join_thread.h"
 #include "daemon_config.h"
 #include "daemon_rpc.h"
 #include <multipass/virtual_machine.h>
@@ -47,18 +46,6 @@ struct VMSpecs
     std::string mem_size;
     std::string disk_space;
     std::unordered_map<std::string, VMMount> mounts;
-};
-
-class Daemon;
-class DaemonRunner
-{
-public:
-    DaemonRunner(std::unique_ptr<const DaemonConfig>& config, Daemon* daemon);
-    ~DaemonRunner();
-
-private:
-    DaemonRpc daemon_rpc;
-    AutoJoinThread daemon_thread;
 };
 
 struct DaemonConfig;
@@ -113,7 +100,7 @@ private:
     std::unordered_map<std::string, VirtualMachine::UPtr> vm_instances;
     std::unordered_map<std::string, VirtualMachine::UPtr> vm_instance_trash;
     std::unordered_map<std::string, std::unordered_map<std::string, std::unique_ptr<SshfsMount>>> mount_threads;
-    DaemonRunner runner;
+    DaemonRpc daemon_rpc;
     QTimer source_images_maintenance_task;
 
     Daemon(const Daemon&) = delete;

--- a/src/daemon/daemon_rpc.cpp
+++ b/src/daemon/daemon_rpc.cpp
@@ -68,17 +68,7 @@ auto make_server(const std::string& server_address, multipass::Rpc::Service* ser
 mp::DaemonRpc::DaemonRpc(const std::string& server_address, std::ostream& cout, std::ostream& cerr)
     : server_address{server_address}, server{make_server(server_address, this)}, cout{cout}, cerr{cerr}
 {
-}
-
-void mp::DaemonRpc::run()
-{
     cout << fmt::format("gRPC listening on {}\n", server_address);
-    server->Wait();
-}
-
-void mp::DaemonRpc::shutdown()
-{
-    server->Shutdown();
 }
 
 grpc::Status mp::DaemonRpc::create(grpc::ServerContext* context, const CreateRequest* request,

--- a/src/daemon/daemon_rpc.h
+++ b/src/daemon/daemon_rpc.h
@@ -36,8 +36,6 @@ class DaemonRpc : public QObject, public multipass::Rpc::Service
     Q_OBJECT
 public:
     DaemonRpc(const std::string& server_address, std::ostream& cout, std::ostream& cerr);
-    void run();
-    void shutdown();
 
 signals:
     // All these signals must be connected to with a BlockingQueuedConnection!!!

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -32,6 +32,7 @@ class QString;
 
 namespace multipass
 {
+class SSHKeyProvider;
 class VMStatusMonitor;
 class VirtualMachineDescription;
 
@@ -52,12 +53,14 @@ public:
     std::string ipv4() override;
     std::string ipv6() override;
     void wait_until_ssh_up(std::chrono::milliseconds timeout) override;
+    void wait_for_cloud_init(std::chrono::milliseconds timeout) override;
 
 private:
     void on_started();
     void on_error();
     void on_shutdown();
     void on_restart();
+    void ensure_vm_is_running();
     VirtualMachine::State state;
     optional<IPAddress> ip;
     bool is_legacy_ip;
@@ -65,6 +68,7 @@ private:
     const std::string mac_addr;
     const std::string vm_name;
     DNSMasqServer* dnsmasq_server;
+    const SSHKeyProvider& key_provider;
     VMStatusMonitor* monitor;
     std::unique_ptr<QProcess> vm_process;
     std::string saved_error_msg;

--- a/src/ssh/ssh_session.cpp
+++ b/src/ssh/ssh_session.cpp
@@ -126,32 +126,7 @@ void mp::SSHSession::force_shutdown()
     shutdown(socket, shutdown_read_and_writes);
 }
 
-void mp::SSHSession::wait_until_ssh_up(const std::string& host, int port, std::chrono::milliseconds timeout,
-                                       std::function<void()> precondition_check)
-{
-    using namespace std::literals::chrono_literals;
-
-    auto deadline = std::chrono::steady_clock::now() + timeout;
-    while (std::chrono::steady_clock::now() < deadline)
-    {
-        precondition_check();
-
-        try
-        {
-            mp::SSHSession session{host, port};
-            return;
-        }
-        catch (const std::exception&)
-        {
-            std::this_thread::sleep_for(1s);
-        }
-    }
-
-    throw std::runtime_error("timed out waiting for ssh service to start");
-}
-
 mp::SSHSession::operator ssh_session() const
 {
     return session.get();
 }
-

--- a/tests/stub_virtual_machine.h
+++ b/tests/stub_virtual_machine.h
@@ -68,6 +68,10 @@ struct StubVirtualMachine final : public multipass::VirtualMachine
     void wait_until_ssh_up(std::chrono::milliseconds) override
     {
     }
+
+    void wait_for_cloud_init(std::chrono::milliseconds) override
+    {
+    }
 };
 }
 }

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -20,7 +20,6 @@
 #include "path.h"
 
 #include <src/client/client.h>
-#include <src/daemon/auto_join_thread.h>
 #include <src/daemon/daemon_rpc.h>
 
 #include <QEventLoop>
@@ -35,15 +34,6 @@ using namespace testing;
 class Client : public Test
 {
 public:
-    Client() : daemon_thread{[this] { stub_daemon.run(); }}
-    {
-    }
-
-    ~Client()
-    {
-        stub_daemon.shutdown();
-    }
-
     int send_command(std::vector<std::string> command)
     {
         return send_command(command, null_stream);
@@ -69,8 +59,6 @@ public:
 #endif
     std::stringstream null_stream;
     mp::DaemonRpc stub_daemon{server_address, null_stream, null_stream};
-    mp::AutoJoinThread daemon_thread;
-
 };
 
 // Tests for no postional args given

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <src/client/client.h>
+#include <src/daemon/auto_join_thread.h>
 #include <src/daemon/daemon.h>
 #include <src/daemon/daemon_config.h>
 
@@ -129,7 +130,7 @@ struct Daemon : public Test
     {
         // Commands need to be sent from a thread different from that the QEventLoop is on.
         // Event loop is started/stopped to ensure all signals are delivered
-        std::thread t([this, &commands, &cout]() {
+        mp::AutoJoinThread t([this, &commands, &cout] {
             mp::ClientConfig client_config{server_address, cout, std::cerr};
             mp::Client client{client_config};
             for (const auto& command : commands)
@@ -145,11 +146,10 @@ struct Daemon : public Test
             loop.quit();
         });
         loop.exec();
-        t.join();
     }
 
     std::string server_address{"unix:/tmp/test-multipassd.socket"};
-    QEventLoop loop; // needed as cross-thread signal/slots used internally by mp::Daemon
+    QEventLoop loop; // needed as signal/slots used internally by mp::Daemon
     QTemporaryDir cache_dir;
     mp::DaemonConfigBuilder config_builder;
     std::stringstream null_stream;

--- a/tests/test_qemu_backend.cpp
+++ b/tests/test_qemu_backend.cpp
@@ -21,6 +21,7 @@
 
 #include "mock_status_monitor.h"
 #include "path.h"
+#include "stub_ssh_key_provider.h"
 #include "stub_status_monitor.h"
 #include "temp_file.h"
 
@@ -70,8 +71,10 @@ struct QemuBackend : public testing::Test
 
     mpt::TempFile dummy_image;
     mpt::TempFile dummy_cloud_init_iso;
+    mpt::StubSSHKeyProvider key_provider;
     mp::VirtualMachineDescription default_description{
-        2, "3M", "", "pied-piper-valley", {dummy_image.name(), "", "", "", {}}, dummy_cloud_init_iso.name()};
+        2,           "3M", "", "pied-piper-valley", {dummy_image.name(), "", "", "", {}}, dummy_cloud_init_iso.name(),
+        key_provider};
     QTemporaryDir data_dir;
     mp::QemuVirtualMachineFactory backend{data_dir.path()};
     std::string old_path;


### PR DESCRIPTION
Daemon's constructor could return before the rpc signals where connected to the daemon's slots. 
Remove unnecessary threading that removes that condition. 

In addition, daemon tests tried to make an ssh connection. To avoid that, moved the wait for cloud init into the VirtualMachine interface instead (which has the upside of letting the backend decide how to check for cloud-init).

I refactored the timeout code (which waits for a deadline) into common code in utils as it was replicated in a few places.