### PR TITLE
Rename classes to match cmd names

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -17,6 +17,7 @@
  *
  */
 #include "client.h"
+#include "cmd/delete.h"
 #include "cmd/exec.h"
 #include "cmd/find.h"
 #include "cmd/help.h"
@@ -29,7 +30,6 @@
 #include "cmd/shell.h"
 #include "cmd/start.h"
 #include "cmd/stop.h"
-#include "cmd/trash.h"
 #include "cmd/umount.h"
 #include "cmd/version.h"
 
@@ -80,7 +80,7 @@ mp::Client::Client(const ClientConfig& config)
     add_command<cmd::Shell>();
     add_command<cmd::Start>();
     add_command<cmd::Stop>();
-    add_command<cmd::Trash>();
+    add_command<cmd::Delete>();
     add_command<cmd::Umount>();
     add_command<cmd::Version>();
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -17,7 +17,6 @@
  *
  */
 #include "client.h"
-#include "cmd/empty_trash.h"
 #include "cmd/exec.h"
 #include "cmd/find.h"
 #include "cmd/help.h"
@@ -25,6 +24,7 @@
 #include "cmd/launch.h"
 #include "cmd/list.h"
 #include "cmd/mount.h"
+#include "cmd/purge.h"
 #include "cmd/recover.h"
 #include "cmd/shell.h"
 #include "cmd/start.h"
@@ -69,7 +69,7 @@ mp::Client::Client(const ClientConfig& config)
       cerr{config.cerr}
 {
     add_command<cmd::Launch>();
-    add_command<cmd::EmptyTrash>();
+    add_command<cmd::Purge>();
     add_command<cmd::Exec>();
     add_command<cmd::Find>();
     add_command<cmd::Help>();

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -17,12 +17,12 @@
  *
  */
 #include "client.h"
-#include "cmd/create.h"
 #include "cmd/empty_trash.h"
 #include "cmd/exec.h"
 #include "cmd/find.h"
 #include "cmd/help.h"
 #include "cmd/info.h"
+#include "cmd/launch.h"
 #include "cmd/list.h"
 #include "cmd/mount.h"
 #include "cmd/recover.h"
@@ -68,7 +68,7 @@ mp::Client::Client(const ClientConfig& config)
       cout{config.cout},
       cerr{config.cerr}
 {
-    add_command<cmd::Create>();
+    add_command<cmd::Launch>();
     add_command<cmd::EmptyTrash>();
     add_command<cmd::Exec>();
     add_command<cmd::Find>();

--- a/src/client/cmd/CMakeLists.txt
+++ b/src/client/cmd/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 add_library(commands STATIC
   animated_spinner.cpp
-  create.cpp
+  launch.cpp
   empty_trash.cpp
   exec.cpp
   find.cpp

--- a/src/client/cmd/CMakeLists.txt
+++ b/src/client/cmd/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(commands STATIC
   shell.cpp
   start.cpp
   stop.cpp
-  trash.cpp
+  delete.cpp
   umount.cpp
   version.cpp
 

--- a/src/client/cmd/CMakeLists.txt
+++ b/src/client/cmd/CMakeLists.txt
@@ -17,7 +17,7 @@
 add_library(commands STATIC
   animated_spinner.cpp
   launch.cpp
-  empty_trash.cpp
+  purge.cpp
   exec.cpp
   find.cpp
   help.cpp

--- a/src/client/cmd/delete.cpp
+++ b/src/client/cmd/delete.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -13,11 +13,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
-#include "trash.h"
+#include "delete.h"
 
 #include <multipass/cli/argparser.h>
 
@@ -25,7 +23,7 @@ namespace mp = multipass;
 namespace cmd = multipass::cmd;
 using RpcMethod = mp::Rpc::Stub;
 
-mp::ReturnCode cmd::Trash::run(mp::ArgParser* parser)
+mp::ReturnCode cmd::Delete::run(mp::ArgParser* parser)
 {
     auto ret = parse_args(parser);
     if (ret != ParseCode::Ok)
@@ -33,32 +31,33 @@ mp::ReturnCode cmd::Trash::run(mp::ArgParser* parser)
         return parser->returnCodeFrom(ret);
     }
 
-    auto on_success = [](mp::TrashReply& reply) {
-        return mp::ReturnCode::Ok;
-    };
+    auto on_success = [](mp::DeleteReply& reply) { return mp::ReturnCode::Ok; };
 
     auto on_failure = [this](grpc::Status& status) {
         cerr << "delete failed: " << status.error_message() << "\n";
         return mp::ReturnCode::CommandFail;
     };
 
-    return dispatch(&RpcMethod::trash, request, on_success, on_failure);
+    return dispatch(&RpcMethod::delet, request, on_success, on_failure);
 }
 
-std::string cmd::Trash::name() const { return "delete"; }
+std::string cmd::Delete::name() const
+{
+    return "delete";
+}
 
-QString cmd::Trash::short_help() const
+QString cmd::Delete::short_help() const
 {
     return QStringLiteral("Delete instances");
 }
 
-QString cmd::Trash::description() const
+QString cmd::Delete::description() const
 {
     return QStringLiteral("Delete instances, to be purged with the \"purge\" command,\n"
                           "or recovered with the \"recover\" command.");
 }
 
-mp::ParseCode cmd::Trash::parse_args(mp::ArgParser* parser)
+mp::ParseCode cmd::Delete::parse_args(mp::ArgParser* parser)
 {
     parser->addPositionalArgument("name", "Names of instances to delete", "<name> [<name> ...]");
 

--- a/src/client/cmd/delete.h
+++ b/src/client/cmd/delete.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -13,12 +13,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
-#ifndef MULTIPASS_TRASH_H
-#define MULTIPASS_TRASH_H
+#ifndef MULTIPASS_DELETE_H
+#define MULTIPASS_DELETE_H
 
 #include <multipass/cli/command.h>
 
@@ -26,21 +24,21 @@ namespace multipass
 {
 namespace cmd
 {
-class Trash final : public Command
+class Delete final : public Command
 {
 public:
     using Command::Command;
-    ReturnCode run(ArgParser *parser) override;
+    ReturnCode run(ArgParser* parser) override;
 
     std::string name() const override;
     QString short_help() const override;
     QString description() const override;
 
 private:
-    TrashRequest request;
+    DeleteRequest request;
 
-    ParseCode parse_args(ArgParser *parser) override;
+    ParseCode parse_args(ArgParser* parser) override;
 };
-}
-}
-#endif // MULTIPASS_TRASH_H
+} // namespace cmd
+} // namespace multipass
+#endif // MULTIPASS_DELETE_H

--- a/src/client/cmd/launch.cpp
+++ b/src/client/cmd/launch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,8 +12,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
  *
  */
 

--- a/src/client/cmd/launch.h
+++ b/src/client/cmd/launch.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -13,12 +13,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
-#ifndef MULTIPASS_CREATE_H
-#define MULTIPASS_CREATE_H
+#ifndef MULTIPASS_LAUNCH_H
+#define MULTIPASS_LAUNCH_H
 
 #include <multipass/cli/command.h>
 
@@ -26,21 +24,21 @@ namespace multipass
 {
 namespace cmd
 {
-class Create final : public Command
+class Launch final : public Command
 {
 public:
     using Command::Command;
-    ReturnCode run(ArgParser *parser) override;
+    ReturnCode run(ArgParser* parser) override;
 
     std::string name() const override;
     QString short_help() const override;
     QString description() const override;
 
 private:
-    ParseCode parse_args(ArgParser *parser) override;
+    ParseCode parse_args(ArgParser* parser) override;
 
-    CreateRequest request;
+    LaunchRequest request;
 };
-}
-}
-#endif // MULTIPASS_CREATE_H
+} // namespace cmd
+} // namespace multipass
+#endif // MULTIPASS_LAUNCH_H

--- a/src/client/cmd/purge.cpp
+++ b/src/client/cmd/purge.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -13,11 +13,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
-#include "empty_trash.h"
+#include "purge.h"
 
 #include <multipass/cli/argparser.h>
 
@@ -25,7 +23,7 @@ namespace mp = multipass;
 namespace cmd = multipass::cmd;
 using RpcMethod = mp::Rpc::Stub;
 
-mp::ReturnCode cmd::EmptyTrash::run(mp::ArgParser* parser)
+mp::ReturnCode cmd::Purge::run(mp::ArgParser* parser)
 {
     auto ret = parse_args(parser);
     if (ret != ParseCode::Ok)
@@ -33,32 +31,33 @@ mp::ReturnCode cmd::EmptyTrash::run(mp::ArgParser* parser)
         return parser->returnCodeFrom(ret);
     }
 
-    auto on_success = [](mp::EmptyTrashReply& reply) {
-        return mp::ReturnCode::Ok;
-    };
+    auto on_success = [](mp::PurgeReply& reply) { return mp::ReturnCode::Ok; };
 
     auto on_failure = [this](grpc::Status& status) {
         cerr << "purge failed: " << status.error_message() << "\n";
         return mp::ReturnCode::CommandFail;
     };
 
-    mp::EmptyTrashRequest request;
-    return dispatch(&RpcMethod::empty_trash, request, on_success, on_failure);
+    mp::PurgeRequest request;
+    return dispatch(&RpcMethod::purge, request, on_success, on_failure);
 }
 
-std::string cmd::EmptyTrash::name() const { return "purge"; }
+std::string cmd::Purge::name() const
+{
+    return "purge";
+}
 
-QString cmd::EmptyTrash::short_help() const
+QString cmd::Purge::short_help() const
 {
     return QStringLiteral("Purge all deleted instances permanently");
 }
 
-QString cmd::EmptyTrash::description() const
+QString cmd::Purge::description() const
 {
     return QStringLiteral("Purge all deleted instances permanently, including all their data.");
 }
 
-mp::ParseCode cmd::EmptyTrash::parse_args(mp::ArgParser* parser)
+mp::ParseCode cmd::Purge::parse_args(mp::ArgParser* parser)
 {
     auto status = parser->commandParse(this);
 

--- a/src/client/cmd/purge.h
+++ b/src/client/cmd/purge.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -13,12 +13,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
-#ifndef MULTIPASS_EMPTY_TRASH_H
-#define MULTIPASS_EMPTY_TRASH_H
+#ifndef MULTIPASS_PURGE_H
+#define MULTIPASS_PURGE_H
 
 #include <multipass/cli/command.h>
 
@@ -26,19 +24,19 @@ namespace multipass
 {
 namespace cmd
 {
-class EmptyTrash final : public Command
+class Purge final : public Command
 {
 public:
     using Command::Command;
-    ReturnCode run(ArgParser *parser) override;
+    ReturnCode run(ArgParser* parser) override;
 
     std::string name() const override;
     QString short_help() const override;
     QString description() const override;
 
 private:
-    ParseCode parse_args(ArgParser *parser) override;
+    ParseCode parse_args(ArgParser* parser) override;
 };
-}
-}
-#endif // MULTIPASS_EMPTY_TRASH_H
+} // namespace cmd
+} // namespace multipass
+#endif // MULTIPASS_PURGE_H

--- a/src/client/formatter/format_utils.cpp
+++ b/src/client/formatter/format_utils.cpp
@@ -31,7 +31,7 @@ std::string mp::format::status_string_for(const mp::InstanceStatus& status)
     case mp::InstanceStatus::STOPPED:
         status_val = "STOPPED";
         break;
-    case mp::InstanceStatus::TRASHED:
+    case mp::InstanceStatus::DELETED:
         status_val = "DELETED";
         break;
     case mp::InstanceStatus::STARTING:

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -277,8 +277,7 @@ auto grpc_status_for(fmt::MemoryWriter& errors)
 auto connect_rpc(mp::DaemonRpc& rpc, mp::Daemon& daemon)
 {
     QObject::connect(&rpc, &mp::DaemonRpc::on_launch, &daemon, &mp::Daemon::launch, Qt::BlockingQueuedConnection);
-    QObject::connect(&rpc, &mp::DaemonRpc::on_empty_trash, &daemon, &mp::Daemon::empty_trash,
-                     Qt::BlockingQueuedConnection);
+    QObject::connect(&rpc, &mp::DaemonRpc::on_purge, &daemon, &mp::Daemon::purge, Qt::BlockingQueuedConnection);
     QObject::connect(&rpc, &mp::DaemonRpc::on_find, &daemon, &mp::Daemon::find, Qt::BlockingQueuedConnection);
     QObject::connect(&rpc, &mp::DaemonRpc::on_info, &daemon, &mp::Daemon::info, Qt::BlockingQueuedConnection);
     QObject::connect(&rpc, &mp::DaemonRpc::on_list, &daemon, &mp::Daemon::list, Qt::BlockingQueuedConnection);
@@ -477,8 +476,8 @@ catch (const std::exception& e)
     return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), "");
 }
 
-grpc::Status mp::Daemon::empty_trash(grpc::ServerContext* context, const EmptyTrashRequest* request,
-                                     EmptyTrashReply* response) // clang-format off
+grpc::Status mp::Daemon::purge(grpc::ServerContext* context, const PurgeRequest* request,
+                               PurgeReply* response) // clang-format off
 try // clang-format on
 {
     std::vector<decltype(vm_instance_trash)::key_type> keys_to_delete;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -62,8 +62,8 @@ protected:
     void on_restart(const std::string& name) override;
 
 public slots:
-    grpc::Status create(grpc::ServerContext* context, const CreateRequest* request,
-                        grpc::ServerWriter<CreateReply>* reply) override;
+    grpc::Status launch(grpc::ServerContext* context, const LaunchRequest* request,
+                        grpc::ServerWriter<LaunchReply>* reply) override;
 
     grpc::Status empty_trash(grpc::ServerContext* context, const EmptyTrashRequest* request,
                              EmptyTrashReply* response) override;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -65,8 +65,7 @@ public slots:
     grpc::Status launch(grpc::ServerContext* context, const LaunchRequest* request,
                         grpc::ServerWriter<LaunchReply>* reply) override;
 
-    grpc::Status empty_trash(grpc::ServerContext* context, const EmptyTrashRequest* request,
-                             EmptyTrashReply* response) override;
+    grpc::Status purge(grpc::ServerContext* context, const PurgeRequest* request, PurgeReply* response) override;
 
     grpc::Status find(grpc::ServerContext* context, const FindRequest* request, FindReply* response) override;
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -83,7 +83,7 @@ public slots:
 
     grpc::Status stop(grpc::ServerContext* context, const StopRequest* request, StopReply* response) override;
 
-    grpc::Status trash(grpc::ServerContext* context, const TrashRequest* request, TrashReply* response) override;
+    grpc::Status delet(grpc::ServerContext* context, const DeleteRequest* request, DeleteReply* response) override;
 
     grpc::Status umount(grpc::ServerContext* context, const UmountRequest* request, UmountReply* response) override;
 
@@ -97,7 +97,7 @@ private:
     std::unique_ptr<const DaemonConfig> config;
     std::unordered_map<std::string, VMSpecs> vm_instance_specs;
     std::unordered_map<std::string, VirtualMachine::UPtr> vm_instances;
-    std::unordered_map<std::string, VirtualMachine::UPtr> vm_instance_trash;
+    std::unordered_map<std::string, VirtualMachine::UPtr> deleted_instances;
     std::unordered_map<std::string, std::unordered_map<std::string, std::unique_ptr<SshfsMount>>> mount_threads;
     DaemonRpc daemon_rpc;
     QTimer source_images_maintenance_task;

--- a/src/daemon/daemon_rpc.cpp
+++ b/src/daemon/daemon_rpc.cpp
@@ -123,9 +123,9 @@ grpc::Status mp::DaemonRpc::stop(grpc::ServerContext* context, const StopRequest
     return emit on_stop(context, request, response); // must block until slot returns
 }
 
-grpc::Status mp::DaemonRpc::trash(grpc::ServerContext* context, const TrashRequest* request, TrashReply* response)
+grpc::Status mp::DaemonRpc::delet(grpc::ServerContext* context, const DeleteRequest* request, DeleteReply* response)
 {
-    return emit on_trash(context, request, response); // must block until slot returns
+    return emit on_delete(context, request, response); // must block until slot returns
 }
 
 grpc::Status mp::DaemonRpc::umount(grpc::ServerContext* context, const UmountRequest* request, UmountReply* response)

--- a/src/daemon/daemon_rpc.cpp
+++ b/src/daemon/daemon_rpc.cpp
@@ -77,10 +77,9 @@ grpc::Status mp::DaemonRpc::launch(grpc::ServerContext* context, const LaunchReq
     return emit on_launch(context, request, reply); // must block until slot returns
 }
 
-grpc::Status mp::DaemonRpc::empty_trash(grpc::ServerContext* context, const EmptyTrashRequest* request,
-                                        EmptyTrashReply* response)
+grpc::Status mp::DaemonRpc::purge(grpc::ServerContext* context, const PurgeRequest* request, PurgeReply* response)
 {
-    return emit on_empty_trash(context, request, response); // must block until slot returns
+    return emit on_purge(context, request, response); // must block until slot returns
 }
 
 grpc::Status mp::DaemonRpc::find(grpc::ServerContext* context, const FindRequest* request, FindReply* response)

--- a/src/daemon/daemon_rpc.cpp
+++ b/src/daemon/daemon_rpc.cpp
@@ -71,10 +71,10 @@ mp::DaemonRpc::DaemonRpc(const std::string& server_address, std::ostream& cout, 
     cout << fmt::format("gRPC listening on {}\n", server_address);
 }
 
-grpc::Status mp::DaemonRpc::create(grpc::ServerContext* context, const CreateRequest* request,
-                                   grpc::ServerWriter<CreateReply>* reply)
+grpc::Status mp::DaemonRpc::launch(grpc::ServerContext* context, const LaunchRequest* request,
+                                   grpc::ServerWriter<LaunchReply>* reply)
 {
-    return emit on_create(context, request, reply); // must block until slot returns
+    return emit on_launch(context, request, reply); // must block until slot returns
 }
 
 grpc::Status mp::DaemonRpc::empty_trash(grpc::ServerContext* context, const EmptyTrashRequest* request,

--- a/src/daemon/daemon_rpc.h
+++ b/src/daemon/daemon_rpc.h
@@ -39,8 +39,8 @@ public:
 
 signals:
     // All these signals must be connected to with a BlockingQueuedConnection!!!
-    grpc::Status on_create(grpc::ServerContext* context, const CreateRequest* request,
-                           grpc::ServerWriter<CreateReply>* reply);
+    grpc::Status on_launch(grpc::ServerContext* context, const LaunchRequest* request,
+                           grpc::ServerWriter<LaunchReply>* reply);
     grpc::Status on_empty_trash(grpc::ServerContext* context, const EmptyTrashRequest* request,
                                 EmptyTrashReply* response);
     grpc::Status on_find(grpc::ServerContext* context, const FindRequest* request, FindReply* response);
@@ -62,8 +62,8 @@ private:
     std::ostream& cerr;
 
 protected:
-    grpc::Status create(grpc::ServerContext* context, const CreateRequest* request,
-                        grpc::ServerWriter<CreateReply>* reply) override;
+    grpc::Status launch(grpc::ServerContext* context, const LaunchRequest* request,
+                        grpc::ServerWriter<LaunchReply>* reply) override;
     grpc::Status empty_trash(grpc::ServerContext* context, const EmptyTrashRequest* request,
                              EmptyTrashReply* response) override;
     grpc::Status find(grpc::ServerContext* context, const FindRequest* request, FindReply* response) override;

--- a/src/daemon/daemon_rpc.h
+++ b/src/daemon/daemon_rpc.h
@@ -50,7 +50,7 @@ signals:
     grpc::Status on_ssh_info(grpc::ServerContext* context, const SSHInfoRequest* request, SSHInfoReply* response);
     grpc::Status on_start(grpc::ServerContext* context, const StartRequest* request, StartReply* response);
     grpc::Status on_stop(grpc::ServerContext* context, const StopRequest* request, StopReply* response);
-    grpc::Status on_trash(grpc::ServerContext* context, const TrashRequest* request, TrashReply* response);
+    grpc::Status on_delete(grpc::ServerContext* context, const DeleteRequest* request, DeleteReply* response);
     grpc::Status on_umount(grpc::ServerContext* context, const UmountRequest* request, UmountReply* response);
     grpc::Status on_version(grpc::ServerContext* context, const VersionRequest* request, VersionReply* response);
 
@@ -72,7 +72,7 @@ protected:
     grpc::Status ssh_info(grpc::ServerContext* context, const SSHInfoRequest* request, SSHInfoReply* response) override;
     grpc::Status start(grpc::ServerContext* context, const StartRequest* request, StartReply* response) override;
     grpc::Status stop(grpc::ServerContext* context, const StopRequest* request, StopReply* response) override;
-    grpc::Status trash(grpc::ServerContext* context, const TrashRequest* request, TrashReply* response) override;
+    grpc::Status delet(grpc::ServerContext* context, const DeleteRequest* request, DeleteReply* response) override;
     grpc::Status umount(grpc::ServerContext* context, const UmountRequest* request, UmountReply* response) override;
     grpc::Status version(grpc::ServerContext* context, const VersionRequest* request, VersionReply* response) override;
     grpc::Status ping(grpc::ServerContext* context, const PingRequest* request, PingReply* response) override;

--- a/src/daemon/daemon_rpc.h
+++ b/src/daemon/daemon_rpc.h
@@ -41,8 +41,7 @@ signals:
     // All these signals must be connected to with a BlockingQueuedConnection!!!
     grpc::Status on_launch(grpc::ServerContext* context, const LaunchRequest* request,
                            grpc::ServerWriter<LaunchReply>* reply);
-    grpc::Status on_empty_trash(grpc::ServerContext* context, const EmptyTrashRequest* request,
-                                EmptyTrashReply* response);
+    grpc::Status on_purge(grpc::ServerContext* context, const PurgeRequest* request, PurgeReply* response);
     grpc::Status on_find(grpc::ServerContext* context, const FindRequest* request, FindReply* response);
     grpc::Status on_info(grpc::ServerContext* context, const InfoRequest* request, InfoReply* response);
     grpc::Status on_list(grpc::ServerContext* context, const ListRequest* request, ListReply* response);
@@ -64,8 +63,7 @@ private:
 protected:
     grpc::Status launch(grpc::ServerContext* context, const LaunchRequest* request,
                         grpc::ServerWriter<LaunchReply>* reply) override;
-    grpc::Status empty_trash(grpc::ServerContext* context, const EmptyTrashRequest* request,
-                             EmptyTrashReply* response) override;
+    grpc::Status purge(grpc::ServerContext* context, const PurgeRequest* request, PurgeReply* response) override;
     grpc::Status find(grpc::ServerContext* context, const FindRequest* request, FindReply* response) override;
     grpc::Status info(grpc::ServerContext* context, const InfoRequest* request, InfoReply* response) override;
     grpc::Status list(grpc::ServerContext* context, const ListRequest* request, ListReply* response) override;

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -18,7 +18,7 @@ syntax = "proto3";
 package multipass;
 
 service Rpc {
-    rpc create (CreateRequest) returns (stream CreateReply);
+    rpc launch (LaunchRequest) returns (stream LaunchReply);
     rpc empty_trash (EmptyTrashRequest) returns (EmptyTrashReply);
     rpc find (FindRequest) returns (FindReply);
     rpc info (InfoRequest) returns (InfoReply);
@@ -34,7 +34,7 @@ service Rpc {
     rpc version (VersionRequest) returns (VersionReply);
 }
 
-message CreateRequest {
+message LaunchRequest {
     string instance_name = 1;
     string image = 2;
     string kernel_name = 3;
@@ -46,7 +46,7 @@ message CreateRequest {
     string remote_name = 9;
 }
 
-message CreateError {
+message LaunchError {
     enum ErrorCodes {
         OK = 0;
         INSTANCE_EXISTS = 1;
@@ -67,7 +67,7 @@ message DownloadProgress {
     string percent_complete = 2;
 }
 
-message CreateReply {
+message LaunchReply {
     oneof create_oneof {
         string vm_instance_name = 1;
         DownloadProgress download_progress = 2;

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -29,7 +29,7 @@ service Rpc {
     rpc ssh_info (SSHInfoRequest) returns (SSHInfoReply);
     rpc start (StartRequest) returns (StartReply);
     rpc stop (StopRequest) returns (StopReply);
-    rpc trash (TrashRequest) returns (TrashReply);
+    rpc delet (DeleteRequest) returns (DeleteReply);
     rpc umount (UmountRequest) returns (UmountReply);
     rpc version (VersionRequest) returns (VersionReply);
 }
@@ -118,7 +118,7 @@ message InstanceStatus {
         STARTING = 1;
         RESTARTING = 2;
         STOPPED = 3;
-        TRASHED = 4;
+        DELETED = 4;
         UNKNOWN = 5;
     }
     Status status = 1;
@@ -239,12 +239,12 @@ message StopRequest {
 message StopReply {
 }
 
-message TrashRequest {
+message DeleteRequest {
     repeated string instance_name = 1;
     bool purge = 2;
 }
 
-message TrashReply {
+message DeleteReply {
 }
 
 message UmountRequest {

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -19,7 +19,7 @@ package multipass;
 
 service Rpc {
     rpc launch (LaunchRequest) returns (stream LaunchReply);
-    rpc empty_trash (EmptyTrashRequest) returns (EmptyTrashReply);
+    rpc purge (PurgeRequest) returns (PurgeReply);
     rpc find (FindRequest) returns (FindReply);
     rpc info (InfoRequest) returns (InfoReply);
     rpc list (ListRequest) returns (ListReply);
@@ -75,10 +75,10 @@ message LaunchReply {
     }
 }
 
-message EmptyTrashRequest {
+message PurgeRequest {
 }
 
-message EmptyTrashReply {
+message PurgeReply {
 }
 
 message FindRequest {

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -63,7 +63,7 @@ struct MockDaemon : public mp::Daemon
     MOCK_METHOD3(ssh_info, grpc::Status(grpc::ServerContext*, const mp::SSHInfoRequest*, mp::SSHInfoReply*));
     MOCK_METHOD3(start, grpc::Status(grpc::ServerContext*, const mp::StartRequest*, mp::StartReply*));
     MOCK_METHOD3(stop, grpc::Status(grpc::ServerContext*, const mp::StopRequest*, mp::StopReply*));
-    MOCK_METHOD3(trash, grpc::Status(grpc::ServerContext*, const mp::TrashRequest*, mp::TrashReply*));
+    MOCK_METHOD3(delet, grpc::Status(grpc::ServerContext*, const mp::DeleteRequest*, mp::DeleteReply*));
     MOCK_METHOD3(version, grpc::Status(grpc::ServerContext*, const mp::VersionRequest*, mp::VersionReply*));
 };
 
@@ -167,7 +167,7 @@ TEST_F(Daemon, receives_commands)
     EXPECT_CALL(daemon, recover(_, _, _));
     EXPECT_CALL(daemon, start(_, _, _));
     EXPECT_CALL(daemon, stop(_, _, _));
-    EXPECT_CALL(daemon, trash(_, _, _));
+    EXPECT_CALL(daemon, delet(_, _, _));
     EXPECT_CALL(daemon, version(_, _, _));
 
     send_commands({{"launch", "foo"},

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -57,13 +57,19 @@ struct MockDaemon : public mp::Daemon
     MOCK_METHOD3(launch,
                  grpc::Status(grpc::ServerContext*, const mp::LaunchRequest*, grpc::ServerWriter<mp::LaunchReply>*));
     MOCK_METHOD3(purge, grpc::Status(grpc::ServerContext*, const mp::PurgeRequest*, mp::PurgeReply*));
+    MOCK_METHOD3(find,
+                 grpc::Status(grpc::ServerContext* context, const mp::FindRequest* request, mp::FindReply* response));
     MOCK_METHOD3(info, grpc::Status(grpc::ServerContext*, const mp::InfoRequest*, mp::InfoReply*));
     MOCK_METHOD3(list, grpc::Status(grpc::ServerContext*, const mp::ListRequest*, mp::ListReply*));
+    MOCK_METHOD3(mount,
+                 grpc::Status(grpc::ServerContext* context, const mp::MountRequest* request, mp::MountReply* response));
     MOCK_METHOD3(recover, grpc::Status(grpc::ServerContext*, const mp::RecoverRequest*, mp::RecoverReply*));
     MOCK_METHOD3(ssh_info, grpc::Status(grpc::ServerContext*, const mp::SSHInfoRequest*, mp::SSHInfoReply*));
     MOCK_METHOD3(start, grpc::Status(grpc::ServerContext*, const mp::StartRequest*, mp::StartReply*));
     MOCK_METHOD3(stop, grpc::Status(grpc::ServerContext*, const mp::StopRequest*, mp::StopReply*));
     MOCK_METHOD3(delet, grpc::Status(grpc::ServerContext*, const mp::DeleteRequest*, mp::DeleteReply*));
+    MOCK_METHOD3(umount, grpc::Status(grpc::ServerContext* context, const mp::UmountRequest* request,
+                                      mp::UmountReply* response));
     MOCK_METHOD3(version, grpc::Status(grpc::ServerContext*, const mp::VersionRequest*, mp::VersionReply*));
 };
 
@@ -161,6 +167,7 @@ TEST_F(Daemon, receives_commands)
 
     EXPECT_CALL(daemon, launch(_, _, _));
     EXPECT_CALL(daemon, purge(_, _, _));
+    EXPECT_CALL(daemon, find(_, _, _));
     EXPECT_CALL(daemon, ssh_info(_, _, _));
     EXPECT_CALL(daemon, info(_, _, _));
     EXPECT_CALL(daemon, list(_, _, _));
@@ -169,17 +176,22 @@ TEST_F(Daemon, receives_commands)
     EXPECT_CALL(daemon, stop(_, _, _));
     EXPECT_CALL(daemon, delet(_, _, _));
     EXPECT_CALL(daemon, version(_, _, _));
+    EXPECT_CALL(daemon, mount(_, _, _));
+    EXPECT_CALL(daemon, umount(_, _, _));
 
     send_commands({{"launch", "foo"},
-                   {"delete", "foo"}, // name argument is required
+                   {"delete", "foo"},
                    {"exec", "foo", "--", "cmd"},
-                   {"info", "foo"}, // name argument is required
+                   {"info", "foo"},
                    {"list"},
                    {"purge"},
-                   {"recover", "foo"}, // name argument is required
-                   {"start", "foo"},   // name argument is required
-                   {"stop", "foo"},    // name argument is required
-                   {"version"}});
+                   {"recover", "foo"},
+                   {"start", "foo"},
+                   {"stop", "foo"},
+                   {"version"},
+                   {"find", "something"},
+                   {"mount", ".", "target"},
+                   {"umount", "instance"}});
 }
 
 TEST_F(Daemon, creates_virtual_machines)

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -54,8 +54,8 @@ namespace
 struct MockDaemon : public mp::Daemon
 {
     using mp::Daemon::Daemon;
-    MOCK_METHOD3(create,
-                 grpc::Status(grpc::ServerContext*, const mp::CreateRequest*, grpc::ServerWriter<mp::CreateReply>*));
+    MOCK_METHOD3(launch,
+                 grpc::Status(grpc::ServerContext*, const mp::LaunchRequest*, grpc::ServerWriter<mp::LaunchReply>*));
     MOCK_METHOD3(empty_trash, grpc::Status(grpc::ServerContext*, const mp::EmptyTrashRequest*, mp::EmptyTrashReply*));
     MOCK_METHOD3(info, grpc::Status(grpc::ServerContext*, const mp::InfoRequest*, mp::InfoReply*));
     MOCK_METHOD3(list, grpc::Status(grpc::ServerContext*, const mp::ListRequest*, mp::ListReply*));
@@ -159,9 +159,9 @@ TEST_F(Daemon, receives_commands)
 {
     MockDaemon daemon{config_builder.build()};
 
-    EXPECT_CALL(daemon, create(_, _, _));
+    EXPECT_CALL(daemon, launch(_, _, _));
     EXPECT_CALL(daemon, empty_trash(_, _, _));
-    EXPECT_CALL(daemon, ssh_info(_, _, _)).Times(2);
+    EXPECT_CALL(daemon, ssh_info(_, _, _));
     EXPECT_CALL(daemon, info(_, _, _));
     EXPECT_CALL(daemon, list(_, _, _));
     EXPECT_CALL(daemon, recover(_, _, _));
@@ -170,11 +170,10 @@ TEST_F(Daemon, receives_commands)
     EXPECT_CALL(daemon, trash(_, _, _));
     EXPECT_CALL(daemon, version(_, _, _));
 
-    send_commands({{"connect", "foo"},
-                   {"delete", "foo"},   // name argument is required
+    send_commands({{"launch", "foo"},
+                   {"delete", "foo"}, // name argument is required
                    {"exec", "foo", "--", "cmd"},
                    {"info", "foo"}, // name argument is required
-                   {"launch"},
                    {"list"},
                    {"purge"},
                    {"recover", "foo"}, // name argument is required

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -56,7 +56,7 @@ struct MockDaemon : public mp::Daemon
     using mp::Daemon::Daemon;
     MOCK_METHOD3(launch,
                  grpc::Status(grpc::ServerContext*, const mp::LaunchRequest*, grpc::ServerWriter<mp::LaunchReply>*));
-    MOCK_METHOD3(empty_trash, grpc::Status(grpc::ServerContext*, const mp::EmptyTrashRequest*, mp::EmptyTrashReply*));
+    MOCK_METHOD3(purge, grpc::Status(grpc::ServerContext*, const mp::PurgeRequest*, mp::PurgeReply*));
     MOCK_METHOD3(info, grpc::Status(grpc::ServerContext*, const mp::InfoRequest*, mp::InfoReply*));
     MOCK_METHOD3(list, grpc::Status(grpc::ServerContext*, const mp::ListRequest*, mp::ListReply*));
     MOCK_METHOD3(recover, grpc::Status(grpc::ServerContext*, const mp::RecoverRequest*, mp::RecoverReply*));
@@ -160,7 +160,7 @@ TEST_F(Daemon, receives_commands)
     MockDaemon daemon{config_builder.build()};
 
     EXPECT_CALL(daemon, launch(_, _, _));
-    EXPECT_CALL(daemon, empty_trash(_, _, _));
+    EXPECT_CALL(daemon, purge(_, _, _));
     EXPECT_CALL(daemon, ssh_info(_, _, _));
     EXPECT_CALL(daemon, info(_, _, _));
     EXPECT_CALL(daemon, list(_, _, _));

--- a/tests/test_format_utils.cpp
+++ b/tests/test_format_utils.cpp
@@ -44,7 +44,7 @@ TEST(InstanceStatusString, stopped_status_returns_STOPPED)
 TEST(InstanceStatusString, deleted_status_returns_DELETED)
 {
     mp::InstanceStatus status;
-    status.set_status(mp::InstanceStatus::TRASHED);
+    status.set_status(mp::InstanceStatus::DELETED);
     auto status_string = mp::format::status_string_for(status);
 
     EXPECT_THAT(status_string, Eq("DELETED"));


### PR DESCRIPTION
Depends on #147

Use [this diff view instead](https://github.com/albaguirre/multipass/compare/fix-daemon-tests...rename-classes-to-match-cmds) before #147 is merged
