### PR TITLE
[sftpserver] Avoid creating extra ssh_session

### DIFF
--- a/include/multipass/ssh/ssh_session.h
+++ b/include/multipass/ssh/ssh_session.h
@@ -49,6 +49,7 @@ private:
     std::unique_ptr<ssh_session_struct, void(*)(ssh_session)> session;
 
     friend class SSHClient;
+    friend class SftpServer;
 };
 }
 #endif // MULTIPASS_SSH_H

--- a/include/multipass/sshfs_mount/sftp_server.h
+++ b/include/multipass/sshfs_mount/sftp_server.h
@@ -68,7 +68,6 @@ private:
     int handle_extended(sftp_client_message msg);
 
     SSHSession ssh_session;
-    const SSHSessionUptr sftp_ssh_session;
     const SftpSessionUptr sftp_server_session;
     const std::string source_path;
     std::unordered_map<void*, std::unique_ptr<QFileInfoList>> open_dir_handles;


### PR DESCRIPTION
The sftp server does not need an extra ssh session object.