### PR TITLE
daemon/start: Assume '--all' when no vm names are sent by the client

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -962,7 +962,7 @@ try // clang-format on
         vms.push_back(name);
     }
 
-    if (vms.empty())
+    if (request->instance_name().empty())
     {
         for (auto& pair : vm_instances)
         {


### PR DESCRIPTION
If no instance names are provided by the client, then assume all instances are to be started.
Fixes #182