### PR TITLE
Add platform logger

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -101,6 +101,7 @@ parts:
     - build-essential
     - cmake-extras
     - golang
+    - libsystemd-dev
     source: .
     configflags:
     - -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/src/daemon/daemon_config.cpp
+++ b/src/daemon/daemon_config.cpp
@@ -40,6 +40,9 @@ std::unique_ptr<const mp::DaemonConfig> mp::DaemonConfigBuilder::build()
     if (data_directory.isEmpty())
         data_directory = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     if (logger == nullptr)
+        logger = platform::make_logger(logging::Level::info);
+    // Fallback when platform does not have a logger
+    if (logger == nullptr)
         logger = std::make_unique<mpl::StandardLogger>(mpl::Level::info);
     if (url_downloader == nullptr)
         url_downloader = std::make_unique<URLDownloader>(cache_directory);

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -17,8 +17,11 @@
 add_library(platform STATIC
   platform.cpp)
 
-target_link_libraries(platform qemu_backend)
+target_link_libraries(platform
+  qemu_backend
+  journaldlogger)
 
 add_subdirectory(backends)
-add_subdirectory(console)
 add_subdirectory(client)
+add_subdirectory(console)
+add_subdirectory(logger)

--- a/src/platform/logger/CMakeLists.txt
+++ b/src/platform/logger/CMakeLists.txt
@@ -1,0 +1,22 @@
+#Copyright © 2018 Canonical Ltd.
+#
+#This program is free software : you can redistribute it and / or modify
+#it under the terms of the GNU General Public License version 3 as
+#published by the Free Software Foundation.
+#
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.If not, see < http: // www.gnu.org/licenses/>.
+#
+
+find_package(PkgConfig)
+pkg_check_modules(JOURNALD libsystemd REQUIRED)
+
+add_library(journaldlogger STATIC journald_logger.cpp)
+target_include_directories(journaldlogger PRIVATE
+        ${JOURNALD_INCLUDE_DIRS})
+target_link_libraries(journaldlogger fmt ${JOURNALD_LIBRARIES})

--- a/src/platform/logger/journald_logger.cpp
+++ b/src/platform/logger/journald_logger.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "journald_logger.h"
+
+#define SD_JOURNAL_SUPPRESS_LOCATION
+#include <syslog.h>
+#include <systemd/sd-journal.h>
+
+namespace mpl = multipass::logging;
+
+namespace
+{
+constexpr auto to_syslog_priority(const mpl::Level& level) noexcept
+{
+    switch (level)
+    {
+    case mpl::Level::debug:
+        return LOG_DEBUG;
+    case mpl::Level::error:
+        return LOG_ERR;
+    case mpl::Level::info:
+        return LOG_INFO;
+    case mpl::Level::warning:
+        return LOG_WARNING;
+    }
+    return 42;
+}
+} // namespace
+
+mpl::JournaldLogger::JournaldLogger(mpl::Level level) : logging_level{level}
+{
+}
+
+void mpl::JournaldLogger::log(mpl::Level level, CString category, CString message) const
+{
+    if (level <= logging_level)
+    {
+        sd_journal_send("MESSAGE=%s", message.c_str(), "PRIORITY=%i", to_syslog_priority(level), "CATEGORY=%s",
+                        category.c_str(), nullptr);
+    }
+}

--- a/src/platform/logger/journald_logger.h
+++ b/src/platform/logger/journald_logger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -13,28 +13,26 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
-#ifndef MULTIPASS_PLATFORM_H
-#define MULTIPASS_PLATFORM_H
+#ifndef MULTIPASS_JOURNALD_LOGGER_H
+#define MULTIPASS_JOURNALD_LOGGER_H
 
 #include <multipass/logging/logger.h>
-#include <multipass/virtual_machine_factory.h>
-
-#include <string>
 
 namespace multipass
 {
-namespace platform
+namespace logging
 {
-std::string default_server_address();
-VirtualMachineFactory::UPtr vm_backend(const Path& data_dir);
-logging::Logger::UPtr make_logger(logging::Level level);
-int chown(const char* path, unsigned int uid, unsigned int gid);
-bool symlink(const char* target, const char* link, bool is_dir);
-bool link(const char* target, const char* link);
-} // namespace platform
-}
-#endif // MULTIPASS_PLATFORM_H
+class JournaldLogger : public Logger
+{
+public:
+    JournaldLogger(Level level);
+    void log(Level level, CString category, CString message) const override;
+
+private:
+    Level logging_level;
+};
+} // namespace logging
+} // namespace multipass
+#endif // MULTIPASS_JOURNALD_LOGGER_H

--- a/src/platform/platform.cpp
+++ b/src/platform/platform.cpp
@@ -18,9 +18,11 @@
  */
 
 #include <multipass/platform.h>
+
 #include <multipass/virtual_machine_factory.h>
 
 #include "backends/qemu/qemu_virtual_machine_factory.h"
+#include "logger/journald_logger.h"
 
 #include <unistd.h>
 
@@ -34,6 +36,11 @@ std::string mp::platform::default_server_address()
 mp::VirtualMachineFactory::UPtr mp::platform::vm_backend(const mp::Path& data_dir)
 {
     return std::make_unique<QemuVirtualMachineFactory>(data_dir);
+}
+
+mp::logging::Logger::UPtr mp::platform::make_logger(mp::logging::Level level)
+{
+    return std::make_unique<logging::JournaldLogger>(level);
 }
 
 int mp::platform::chown(const char* path, unsigned int uid, unsigned int gid)

--- a/tests/travis-Coverage.patch
+++ b/tests/travis-Coverage.patch
@@ -1,9 +1,9 @@
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
-@@ -92,11 +92,11 @@ parts:
-     - build-essential
+@@ -102,11 +102,11 @@ parts:
      - cmake-extras
      - golang
+     - libsystemd-dev
 +    - lcov
      source: .
      configflags:


### PR DESCRIPTION
The default platform logger logs to journald.

The logs can be filtered through "journalctl _COMM=multipassd"
A CATEGORY field is recorded which can be the name of an instance,
"daemon", "rpc", among others.

To filter by category: "journalctl _COMM=multipassd CATEGORY=<value>"

Fixes #156