### PR TITLE
console: Change ssh pty size from within the console class

### DIFF
--- a/include/multipass/auto_join_thread.h
+++ b/include/multipass/auto_join_thread.h
@@ -22,13 +22,14 @@
 #include <memory>
 #include <thread>
 
-namespace multipass {
+namespace multipass
+{
 
 class AutoJoinThread
 {
 public:
     template <typename Callable, typename... Args>
-    AutoJoinThread(Callable &&f, Args &&... args) : thread{std::forward<Callable>(f), std::forward<Args>(args)...}
+    AutoJoinThread(Callable&& f, Args&&... args) : thread{std::forward<Callable>(f), std::forward<Args>(args)...}
     {
     }
     ~AutoJoinThread()

--- a/include/multipass/console.h
+++ b/include/multipass/console.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,6 +18,8 @@
 #ifndef MULTIPASS_CONSOLE_H
 #define MULTIPASS_CONSOLE_H
 
+#include <libssh/libssh.h>
+
 #include <array>
 #include <functional>
 #include <memory>
@@ -29,31 +31,19 @@ class Console
 public:
     using UPtr = std::unique_ptr<Console>;
 
-    struct WindowGeometry
-    {
-        int rows;
-        int columns;
-    };
-
     virtual ~Console() = default;
 
     virtual int read_console(std::array<char, 512>& buffer) = 0;
     virtual void write_console(const char* buffer, int bytes) = 0;
     virtual void signal_console() = 0;
-    virtual bool is_window_size_changed() = 0;
-    virtual bool is_interactive() = 0;
-    virtual WindowGeometry get_window_geometry() = 0;
 
-    static UPtr make_console();
+    static UPtr make_console(ssh_channel channel);
+    static void setup_environment();
 
 protected:
     explicit Console() = default;
     Console(const Console&) = delete;
     Console& operator=(const Console&) = delete;
-
-private:
-    virtual void setup_console() = 0;
-    virtual void restore_console() = 0;
 };
 }
 #endif // MULTIPASS_CONSOLE_H

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/include/multipass/platform_unix.h
+++ b/include/multipass/platform_unix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -13,28 +13,21 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
-#include "client.h"
+#ifndef MULTIPASS_PLATFORM_UNIX_H
+#define MULTIPASS_PLATFORM_UNIX_H
 
-#include <multipass/cli/cli.h>
-#include <multipass/console.h>
-#include <multipass/platform.h>
+#include <vector>
 
-#include <QCoreApplication>
+#include <signal.h>
 
-namespace mp = multipass;
-
-int main(int argc, char* argv[])
+namespace multipass
 {
-    QCoreApplication app(argc, argv);
-    app.setApplicationName("multipass");
-    mp::Console::setup_environment();
-
-    mp::ClientConfig config{mp::platform::default_server_address(), std::cout, std::cerr};
-    mp::Client client{config};
-
-    return client.run(app.arguments());
+namespace platform
+{
+sigset_t make_sigset(std::vector<int> sigs);
+sigset_t make_and_block_signals(std::vector<int> sigs);
+} // namespace platform
 }
+#endif // MULTIPASS_PLATFORM_UNIX_H

--- a/include/multipass/ssh/ssh_client.h
+++ b/include/multipass/ssh/ssh_client.h
@@ -44,7 +44,6 @@ public:
 
 private:
     void handle_ssh_events();
-    void change_ssh_pty_size(Console::WindowGeometry window_geometry);
 
     SSHSessionUPtr ssh_session;
     ChannelUPtr channel;

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -15,7 +15,8 @@
 # Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
 
 add_library(platform STATIC
-  platform.cpp)
+  platform_linux.cpp
+  platform_unix.cpp)
 
 target_link_libraries(platform
   qemu_backend

--- a/src/platform/console/console.cpp
+++ b/src/platform/console/console.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,7 +21,12 @@
 
 namespace mp = multipass;
 
-mp::Console::UPtr mp::Console::make_console()
+mp::Console::UPtr mp::Console::make_console(ssh_channel channel)
 {
-    return std::make_unique<UnixConsole>();
+    return std::make_unique<UnixConsole>(channel);
+}
+
+void mp::Console::setup_environment()
+{
+    UnixConsole::setup_environment();
 }

--- a/src/platform/console/unix_console.h
+++ b/src/platform/console/unix_console.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,14 +20,20 @@
 
 #include <multipass/console.h>
 
+#include <libssh/libssh.h>
+
+#include <vector>
+
+#include <signal.h>
 #include <termios.h>
 
 namespace multipass
 {
+class WindowChangedSignalHandler;
 class UnixConsole final : public Console
 {
 public:
-    UnixConsole();
+    UnixConsole(ssh_channel channel);
     ~UnixConsole();
 
     int read_console(std::array<char, 512>& buffer) override
@@ -36,16 +42,17 @@ public:
     };
     void write_console(const char* buffer, int bytes) override{};
     void signal_console() override{};
-    bool is_window_size_changed() override;
-    bool is_interactive() override;
-    WindowGeometry get_window_geometry() override;
+
+    static void setup_environment();
 
 private:
-    void setup_console() override;
-    void restore_console() override;
+    void setup_console();
+    void restore_console();
 
     bool interactive{false};
     struct termios saved_terminal;
+
+    std::unique_ptr<WindowChangedSignalHandler> handler;
 };
 }
 #endif // MULTIPASS_UNIX_CONSOLE_H

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -17,24 +17,26 @@
  *
  */
 
-#include "client.h"
-
-#include <multipass/cli/cli.h>
-#include <multipass/console.h>
 #include <multipass/platform.h>
 
-#include <QCoreApplication>
+#include <multipass/virtual_machine_factory.h>
+
+#include "backends/qemu/qemu_virtual_machine_factory.h"
+#include "logger/journald_logger.h"
 
 namespace mp = multipass;
 
-int main(int argc, char* argv[])
+std::string mp::platform::default_server_address()
 {
-    QCoreApplication app(argc, argv);
-    app.setApplicationName("multipass");
-    mp::Console::setup_environment();
+    return {"unix:/run/multipass_socket"};
+}
 
-    mp::ClientConfig config{mp::platform::default_server_address(), std::cout, std::cerr};
-    mp::Client client{config};
+mp::VirtualMachineFactory::UPtr mp::platform::vm_backend(const mp::Path& data_dir)
+{
+    return std::make_unique<QemuVirtualMachineFactory>(data_dir);
+}
 
-    return client.run(app.arguments());
+mp::logging::Logger::UPtr mp::platform::make_logger(mp::logging::Level level)
+{
+    return std::make_unique<logging::JournaldLogger>(level);
 }

--- a/src/ssh/ssh_client.cpp
+++ b/src/ssh/ssh_client.cpp
@@ -21,9 +21,19 @@
 
 #include "ssh_client_key_provider.h"
 
-#include <libssh/libssh.h>
-
 namespace mp = multipass;
+
+namespace
+{
+mp::SSHClient::ChannelUPtr make_channel(ssh_session session)
+{
+    mp::SSHClient::ChannelUPtr channel{ssh_channel_new(session), ssh_channel_free};
+
+    mp::SSH::throw_on_error(ssh_channel_open_session, channel);
+
+    return channel;
+}
+}
 
 mp::SSHClient::SSHClient(const std::string& host, int port, const std::string& priv_key_blob)
     : SSHClient{std::make_unique<mp::SSHSession>(host, port, mp::SSHClientKeyProvider(priv_key_blob))}
@@ -32,8 +42,8 @@ mp::SSHClient::SSHClient(const std::string& host, int port, const std::string& p
 
 mp::SSHClient::SSHClient(SSHSessionUPtr ssh_session, Console::UPtr console)
     : ssh_session{std::move(ssh_session)},
-      channel{ssh_channel_new(*this->ssh_session), ssh_channel_free},
-      console{(console == nullptr) ? Console::make_console() : std::move(console)}
+      channel{make_channel(*this->ssh_session)},
+      console{(console == nullptr) ? Console::make_console(channel.get()) : std::move(console)}
 {
 }
 
@@ -44,14 +54,6 @@ void mp::SSHClient::connect()
 
 int mp::SSHClient::exec(const std::vector<std::string>& args)
 {
-    SSH::throw_on_error(ssh_channel_open_session, channel);
-
-    if (console->is_interactive())
-    {
-        SSH::throw_on_error(ssh_channel_request_pty, channel);
-        change_ssh_pty_size(console->get_window_geometry());
-    }
-
     if (args.empty())
         SSH::throw_on_error(ssh_channel_request_shell, channel);
     else
@@ -88,18 +90,10 @@ void mp::SSHClient::handle_ssh_events()
 
     while (ssh_channel_is_open(channel.get()) && !ssh_channel_is_eof(channel.get()))
     {
-        if (console->is_window_size_changed())
-            change_ssh_pty_size(console->get_window_geometry());
-
         ssh_event_dopoll(event.get(), 60000);
     }
 
     ssh_event_remove_connector(event.get(), connector_in.get());
     ssh_event_remove_connector(event.get(), connector_out.get());
     ssh_event_remove_connector(event.get(), connector_err.get());
-}
-
-void mp::SSHClient::change_ssh_pty_size(mp::Console::WindowGeometry window_geometry)
-{
-    SSH::throw_on_error(ssh_channel_change_pty_size, channel, window_geometry.columns, window_geometry.rows);
 }

--- a/src/sshfs_mount/CMakeLists.txt
+++ b/src/sshfs_mount/CMakeLists.txt
@@ -24,6 +24,7 @@ function(add_sshfs_mount_target TARGET_NAME)
   target_link_libraries(${TARGET_NAME}
     fmt
     logger
+    platform
     ssh
     utils
     Qt5::Core)

--- a/tests/stub_console.h
+++ b/tests/stub_console.h
@@ -26,8 +26,6 @@ namespace test
 {
 struct StubConsole final : public multipass::Console
 {
-    void setup_console() override{};
-
     int read_console(std::array<char, 512>& buffer) override
     {
         return 0;
@@ -36,23 +34,6 @@ struct StubConsole final : public multipass::Console
     void write_console(const char* buffer, int bytes) override{};
 
     void signal_console() override{};
-
-    bool is_window_size_changed() override
-    {
-        return false;
-    };
-
-    bool is_interactive() override
-    {
-        return true;
-    };
-
-    WindowGeometry get_window_geometry() override
-    {
-        return WindowGeometry{-1, -1};
-    };
-
-    void restore_console() override{};
 };
 }
 }

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -18,10 +18,10 @@
  */
 
 #include <src/client/client.h>
-#include <src/daemon/auto_join_thread.h>
 #include <src/daemon/daemon.h>
 #include <src/daemon/daemon_config.h>
 
+#include <multipass/auto_join_thread.h>
 #include <multipass/name_generator.h>
 #include <multipass/version.h>
 #include <multipass/virtual_machine_factory.h>

--- a/tests/test_ssh_client.cpp
+++ b/tests/test_ssh_client.cpp
@@ -51,27 +51,9 @@ struct SSHClient : public testing::Test
 
 TEST_F(SSHClient, throws_when_unable_to_open_session)
 {
-    auto client = make_ssh_client();
     REPLACE(ssh_channel_open_session, [](auto...) { return SSH_ERROR; });
 
-    EXPECT_THROW(client.connect(), std::runtime_error);
-}
-
-TEST_F(SSHClient, throws_when_request_pty_fails)
-{
-    auto client = make_ssh_client();
-    REPLACE(ssh_channel_request_pty, [](auto...) { return SSH_ERROR; });
-
-    EXPECT_THROW(client.connect(), std::runtime_error);
-}
-
-TEST_F(SSHClient, throws_when_change_pty_size_fails)
-{
-    auto client = make_ssh_client();
-    REPLACE(ssh_channel_request_pty, [](auto...) { return SSH_OK; });
-    REPLACE(ssh_channel_change_pty_size, [](auto...) { return SSH_ERROR; });
-
-    EXPECT_THROW(client.connect(), std::runtime_error);
+    EXPECT_THROW(make_ssh_client(), std::runtime_error);
 }
 
 TEST_F(SSHClient, throw_when_request_shell_fails)


### PR DESCRIPTION
This avoids a delay in resizing the output when changing the size of
an interactive terminal.