### PR TITLE
Support libvirt backend

### DIFF
--- a/include/multipass/backend_utils.h
+++ b/include/multipass/backend_utils.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_BACKEND_UTILS_H
+#define MULTIPASS_BACKEND_UTILS_H
+
+#include <multipass/path.h>
+
+#include <string>
+
+namespace multipass
+{
+namespace backend
+{
+std::string generate_mac_address();
+std::string generate_random_subnet();
+void check_hypervisor_support();
+void resize_instance_image(const std::string& disk_space, const multipass::Path& image_path);
+}
+}
+#endif // MULTIPASS_BACKEND_UTILS_H

--- a/include/multipass/backend_utils.h
+++ b/include/multipass/backend_utils.h
@@ -28,6 +28,7 @@ namespace backend
 {
 std::string generate_mac_address();
 std::string generate_random_subnet();
+std::string generate_virtual_bridge_name();
 void check_hypervisor_support();
 void resize_instance_image(const std::string& disk_space, const multipass::Path& image_path);
 }

--- a/snap/bin/launch-libvirtd
+++ b/snap/bin/launch-libvirtd
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+
+vm_backend="$(snapctl get vm-backend)"
+
+if [ "$vm_backend" = "LIBVIRT" ]; then
+    exec $SNAP/sbin/libvirtd
+fi

--- a/snap/bin/launch-multipassd
+++ b/snap/bin/launch-multipassd
@@ -2,5 +2,6 @@
 
 export http_proxy="$(snapctl get proxy.http)"
 export https_proxy="$(snapctl get proxy.https)"
+export MULTIPASS_VM_BACKEND="$(snapctl get vm-backend)"
 
 exec $SNAP/bin/multipassd

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,4 +1,19 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
-# Just a placeholder, however validation of the proxy.{http,https}
-# configuration could be made here
+vm_backend="$(snapctl get vm-backend)"
+
+if [[ -n $vm_backend && ! $vm_backend =~ (LIBVIRT|QEMU) ]]; then
+    echo "\"$vm_backend\" is not a supported VM backend"
+    exit 1
+fi
+
+vm_backend_saved="$(snapctl get vm-backend-saved)"
+
+if [[ $vm_backend == "QEMU" && -z $vm_backend_saved ]]; then
+    exit 0
+fi
+
+if [[ $vm_backend != $vm_backend_saved ]]; then
+    snapctl set vm-backend-saved="$vm_backend"
+    snapctl restart $SNAP_NAME
+fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+install -D $SNAP/var/snap/multipass/common/libvirt/libvirtd.conf $SNAP_COMMON/libvirt/libvirtd.conf
+sed -i 's/unix_sock_group = "libvirtd"/unix_sock_group = "sudo"/' $SNAP_COMMON/libvirt/libvirtd.conf

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: multipass
-version: '2017.0.0'
+version: 'git'
 version-script: |
   git describe
 summary: Ubuntu at your fingertips
@@ -15,7 +15,7 @@ apps:
   multipassd:
     command: bin/launch-multipassd
     environment:
-      LD_LIBRARY_PATH: $SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu::$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu
+      LD_LIBRARY_PATH: $SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu:$SNAP/lib:$SNAP/usr/lib
       PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
       QT_PLUGIN_PATH: $SNAP/usr/lib/x86_64-linux-gnu/qt5/plugins
       XDG_DATA_HOME: $SNAP_COMMON/data
@@ -23,11 +23,23 @@ apps:
     daemon: simple
   multipass:
     environment:
-      LD_LIBRARY_PATH: $SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu::$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu
+      LD_LIBRARY_PATH: $SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu:$SNAP/lib:$SNAP/usr/lib
       PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
       QT_PLUGIN_PATH: $SNAP/usr/lib/x86_64-linux-gnu/qt5/plugins
     command: bin/multipass
     completer: etc/bash_completion.d/snap.multipass
+  libvirt-bin:
+    command: bin/launch-libvirtd
+    environment:
+      LD_LIBRARY_PATH: $SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu:$SNAP/lib:$SNAP/usr/lib
+      PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
+      LC_ALL: C
+    daemon: simple
+  virsh:
+    command: bin/virsh
+    environment:
+      PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
+      LC_ALL: C
 
 parts:
   qtbase5-dev:
@@ -102,13 +114,14 @@ parts:
     - cmake-extras
     - golang
     - libsystemd-dev
+    - libvirt-dev
     source: .
     configflags:
     - -DCMAKE_BUILD_TYPE=RelWithDebInfo
     - -DCMAKE_INSTALL_PREFIX=/
     - -DMULTIPASS_ENABLE_TESTS=off
     install: |-
-      set -ex
+      set -e
       mkdir -p ${SNAPCRAFT_PART_INSTALL}/etc/bash_completion.d/
       echo 'export PATH="${PATH}:/snap/bin:/var/lib/snapd/snap/bin"' > ${SNAPCRAFT_PART_INSTALL}/etc/bash_completion.d/snap.multipass
       cat ../src/completions/bash/multipass >> ${SNAPCRAFT_PART_INSTALL}/etc/bash_completion.d/snap.multipass
@@ -126,21 +139,83 @@ parts:
       usr/share/seabios/kvmvapic.bin: qemu/kvmvapic.bin
       usr/lib/ipxe/qemu/efi-virtio.rom: qemu/efi-virtio.rom
 
-  dnsmasq:
-    plugin: nil
-    stage-packages:
-    - dnsmasq
-
   kvm-support:
     plugin: nil
     stage-packages:
     - msr-tools
+
+  libvirt:
+    source: .
+    source-subdir: libvirt-1.3.1
+    plugin: autotools
+    build-packages:
+    - libxml2-dev
+    - libxml-libxml-perl
+    - libcurl4-gnutls-dev
+    - libncurses5-dev
+    - libreadline-dev
+    - zlib1g-dev
+    - libgcrypt20-dev
+    - libgnutls28-dev
+    - libyajl-dev
+    - libpcap0.8-dev
+    - libaudit-dev
+    - libdevmapper-dev
+    - libpciaccess-dev
+    - libnl-3-dev
+    - libnl-route-3-dev
+    - uuid-dev
+    - libnuma-dev
+    - python-all
+    - python-six
+    stage-packages:
+    - dmidecode
+    - dnsmasq
+    - libxml2
+    - libyajl2
+    - libnuma1
+    - libcurl3-gnutls
+    - libpciaccess0
+    configflags:
+    - --with-qemu
+    - --without-bhyve
+    - --without-xen
+    - --without-openvz
+    - --without-vmware
+    - --without-xenapi
+    - --without-esx
+    - --without-hyperv
+    - --without-lxc
+    - --without-vz
+    - --without-vbox
+    - --without-uml
+    - --without-sasl
+    - --without-storage-iscsi
+    - --without-storage-sheepdog
+    - --without-storage-rbd
+    - --without-storage-lvm
+    - --without-selinux
+    - --prefix=/snap/$SNAPCRAFT_PROJECT_NAME/current
+    - --localstatedir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
+    - --sysconfdir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
+    - DNSMASQ=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/sbin/dnsmasq
+    - DMIDECODE=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/sbin/dmidecode
+    prepare: |
+      apt update
+      apt source libvirt
+    organize:
+      # Hack to shift installed libvirt back to root of snap
+      # required to ensure that pathing to files etc works at
+      # runtime
+      # * is not used to avoid directory merge conflicts
+      snap/multipass/current/: ./
 
   network-utils:
     plugin: nil
     stage-packages:
     - iproute2
     - iputils-ping
+    - libatm1
 
   glue:
     plugin: dump

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(platform STATIC
 
 target_link_libraries(platform
   qemu_backend
+  libvirt_backend
   journaldlogger)
 
 add_subdirectory(backends)

--- a/src/platform/backends/CMakeLists.txt
+++ b/src/platform/backends/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017 Canonical Ltd.
+# Copyright © 2017-2018 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,4 +14,6 @@
 #
 # Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
 
+add_subdirectory(backend_utils)
+add_subdirectory(libvirt)
 add_subdirectory(qemu)

--- a/src/platform/backends/backend_utils/CMakeLists.txt
+++ b/src/platform/backends/backend_utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2018 Canonical Ltd.
+# Copyright © 2018 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -11,23 +11,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-# Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
 
-add_library(qemu_backend STATIC
-  dnsmasq_server.cpp
-  qemu_virtual_machine_factory.cpp
-  qemu_virtual_machine.cpp)
+add_library(backend_utils STATIC
+  backend_utils.cpp)
 
-target_link_libraries(qemu_backend
-  backend_utils
+target_link_libraries(backend_utils
   fmt
-  logger
-  Qt5::Core
-  Qt5::Network
-  ip_address_pool
-  ssh
-  yaml)
-
-install(PROGRAMS check_kvm_support
-  DESTINATION bin)
+  utils
+  Qt5::Core)

--- a/src/platform/backends/backend_utils/backend_utils.cpp
+++ b/src/platform/backends/backend_utils/backend_utils.cpp
@@ -74,6 +74,21 @@ std::string mp::backend::generate_random_subnet()
     throw std::runtime_error("Could not determine a subnet for networking.");
 }
 
+std::string mp::backend::generate_virtual_bridge_name()
+{
+    std::string bridge_name;
+
+    for (auto i = 0; i < 100; ++i)
+    {
+        bridge_name = fmt::format("mpbr{}", i);
+
+        if (!mp::utils::run_cmd_for_status("ip", {"addr", "show", QString::fromStdString(bridge_name)}))
+            return bridge_name;
+    }
+
+    return "";
+}
+
 void mp::backend::check_hypervisor_support()
 {
     QProcess check_kvm;

--- a/src/platform/backends/backend_utils/backend_utils.cpp
+++ b/src/platform/backends/backend_utils/backend_utils.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <multipass/backend_utils.h>
+#include <multipass/utils.h>
+
+#include <fmt/format.h>
+
+#include <QProcess>
+#include <QString>
+
+#include <chrono>
+#include <exception>
+#include <random>
+
+namespace mp = multipass;
+
+namespace
+{
+std::default_random_engine gen;
+std::uniform_int_distribution<int> dist{0, 255};
+
+bool subnet_used_locally(const std::string& subnet)
+{
+    const auto ip_cmd = fmt::format("ip -4 route show | grep -q {}", subnet);
+    return mp::utils::run_cmd_for_status("bash", {"-c", ip_cmd.c_str()});
+}
+
+bool can_reach_gateway(const std::string& ip)
+{
+    return mp::utils::run_cmd_for_status("ping", {"-n", "-q", ip.c_str(), "-c", "-1", "-W", "1"});
+}
+}
+
+std::string mp::backend::generate_mac_address()
+{
+    gen.seed(std::chrono::system_clock::now().time_since_epoch().count());
+    std::array<int, 3> octets{dist(gen), dist(gen), dist(gen)};
+    return fmt::format("52:54:00:{:02x}:{:02x}:{:02x}", octets[0], octets[1], octets[2]);
+}
+
+std::string mp::backend::generate_random_subnet()
+{
+    gen.seed(std::chrono::system_clock::now().time_since_epoch().count());
+    for (auto i = 0; i < 100; ++i)
+    {
+        auto subnet = fmt::format("10.{}.{}", dist(gen), dist(gen));
+        if (subnet_used_locally(subnet))
+            continue;
+
+        if (can_reach_gateway(fmt::format("{}.1", subnet)))
+            continue;
+
+        if (can_reach_gateway(fmt::format("{}.254", subnet)))
+            continue;
+
+        return subnet;
+    }
+
+    throw std::runtime_error("Could not determine a subnet for networking.");
+}
+
+void mp::backend::check_hypervisor_support()
+{
+    QProcess check_kvm;
+    check_kvm.start("check_kvm_support");
+    check_kvm.waitForFinished();
+
+    if (check_kvm.exitCode() == 1)
+    {
+        throw std::runtime_error(check_kvm.readAll().trimmed().toStdString());
+    }
+}
+
+void mp::backend::resize_instance_image(const std::string& disk_space, const mp::Path& image_path)
+{
+    auto disk_size = QString::fromStdString(disk_space);
+
+    if (disk_size.endsWith("B"))
+        disk_size.chop(1);
+
+    mp::utils::run_cmd_for_status("qemu-img", {QStringLiteral("resize"), image_path, disk_size});
+}

--- a/src/platform/backends/libvirt/CMakeLists.txt
+++ b/src/platform/backends/libvirt/CMakeLists.txt
@@ -1,0 +1,30 @@
+#Copyright © 2018 Canonical Ltd.
+#
+#This program is free software : you can redistribute it and / or modify
+#it under the terms of the GNU General Public License version 3 as
+#published by the Free Software Foundation.
+#
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.If not, see < http: // www.gnu.org/licenses/>.
+#
+
+find_package(PkgConfig)
+pkg_check_modules(LIBVIRT libvirt REQUIRED)
+
+add_library(libvirt_backend STATIC
+  libvirt_virtual_machine_factory.cpp
+  libvirt_virtual_machine.cpp)
+
+target_include_directories(libvirt_backend PRIVATE ${LIBVIRT_INCLUDE_DIRS})
+target_link_libraries(libvirt_backend
+  backend_utils
+  fmt
+  ip_address_pool
+  Qt5::Core
+  ssh
+  ${LIBVIRT_LIBRARIES})

--- a/src/platform/backends/libvirt/libvirt_virtual_machine.cpp
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine.cpp
@@ -1,0 +1,325 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "libvirt_virtual_machine.h"
+
+#include <multipass/backend_utils.h>
+#include <multipass/logging/log.h>
+#include <multipass/ssh/ssh_session.h>
+#include <multipass/utils.h>
+#include <multipass/virtual_machine_description.h>
+#include <multipass/vm_status_monitor.h>
+
+#include <QXmlStreamReader>
+
+#include <fmt/format.h>
+
+#include <libvirt/virterror.h>
+
+namespace mp = multipass;
+namespace mpl = multipass::logging;
+
+namespace
+{
+virErrorPtr libvirt_error;
+
+static void libvirt_error_handler(void* opaque, virErrorPtr error)
+{
+    virFreeError(libvirt_error);
+    libvirt_error = virSaveLastError();
+}
+
+auto get_instance_mac_addr(virDomainPtr domain)
+{
+    std::string mac_addr;
+    std::unique_ptr<char, decltype(free)*> desc{virDomainGetXMLDesc(domain, 0), free};
+
+    QXmlStreamReader reader(desc.get());
+
+    while (!reader.atEnd())
+    {
+        reader.readNext();
+
+        if (reader.name() == "mac")
+        {
+            mac_addr = reader.attributes().value("address").toString().toStdString();
+            break;
+        }
+    }
+
+    return mac_addr;
+}
+
+auto get_instance_ip(virConnectPtr connection, const std::string& mac_addr)
+{
+    mp::optional<mp::IPAddress> ip_address;
+
+    mp::LibVirtVirtualMachine::NetworkUPtr network{virNetworkLookupByName(connection, "default"), virNetworkFree};
+
+    virNetworkDHCPLeasePtr* leases = nullptr;
+    auto nleases = virNetworkGetDHCPLeases(network.get(), mac_addr.c_str(), &leases, 0);
+
+    auto leases_deleter = [&nleases](virNetworkDHCPLeasePtr* leases) {
+        for (auto i = 0; i < nleases; ++i)
+        {
+            virNetworkDHCPLeaseFree(leases[i]);
+        }
+        free(leases);
+    };
+
+    std::unique_ptr<virNetworkDHCPLeasePtr, decltype(leases_deleter)> leases_ptr{leases, leases_deleter};
+    if (nleases > 0)
+    {
+        ip_address.emplace(leases[0]->ipaddr);
+    }
+
+    return ip_address;
+}
+
+void get_parsed_memory_values(const std::string& mem_size, std::string& memory, std::string& mem_unit)
+{
+    auto mem{QString::fromStdString(mem_size)};
+    QString unit;
+
+    for (auto i = 0; i < mem.size(); ++i)
+    {
+        if (mem[i].isDigit())
+            memory.append(1, mem[i].toLatin1());
+        else if (mem[i].isLetter())
+            unit.append(mem[i]);
+    }
+
+    if (unit.isEmpty())
+        mem_unit = "b";
+    else if (unit.startsWith("K"))
+        mem_unit = "KiB";
+    else if (unit.startsWith("M"))
+        mem_unit = "MiB";
+    else if (unit.startsWith("G"))
+        mem_unit = "GiB";
+}
+
+auto generate_xml_config_for(const mp::VirtualMachineDescription& desc)
+{
+    std::string memory, mem_unit;
+
+    get_parsed_memory_values(desc.mem_size, memory, mem_unit);
+
+    return fmt::format(
+        "<domain type=\'kvm\'>\n"
+        "  <name>{}</name>\n"
+        "  <memory unit=\'{}\'>{}</memory>\n"
+        "  <currentMemory unit=\'{}\'>{}</currentMemory>\n"
+        "  <vcpu placement=\'static\'>{}</vcpu>\n"
+        "  <resource>\n"
+        "    <partition>/machine</partition>\n"
+        "  </resource>\n"
+        "  <os>\n"
+        "    <type arch=\'x86_64\'>hvm</type>\n"
+        "    <boot dev=\'hd\'/>\n"
+        "  </os>\n"
+        "  <features>\n"
+        "    <acpi/>\n"
+        "    <apic/>\n"
+        "    <vmport state=\'off\'/>\n"
+        "  </features>\n"
+        "  <devices>\n"
+        "    <emulator>/usr/bin/qemu-system-x86_64</emulator>\n"
+        "    <disk type=\'file\' device=\'disk\'>\n"
+        "      <driver name=\'qemu\' type=\'qcow2\'/>\n"
+        "      <source file=\'{}\'/>\n"
+        "      <backingStore/>\n"
+        "      <target dev=\'vda\' bus=\'virtio\'/>\n"
+        "      <alias name=\'virtio-disk0\'/>\n"
+        "    </disk>\n"
+        "    <disk type=\'file\' device=\'disk\'>\n"
+        "      <driver name=\'qemu\' type=\'raw\'/>\n"
+        "      <source file=\'{}\'/>\n"
+        "      <backingStore/>\n"
+        "      <target dev=\'vdb\' bus=\'virtio\'/>\n"
+        "      <alias name=\'virtio-disk1\'/>\n"
+        "    </disk>\n"
+        "    <interface type=\'bridge\'>\n"
+        "      <mac address=\'{}\'/>\n"
+        "      <source bridge=\'virbr0\'/>\n"
+        "      <target dev=\'vnet0\'/>\n"
+        "      <model type=\'virtio\'/>\n"
+        "      <alias name=\'net0\'/>\n"
+        "    </interface>\n"
+        "    <serial type=\'null\'>\n"
+        "      <target port=\"1\"/>\n"
+        "    </serial>\n"
+        "    <video>\n"
+        "      <model type=\'qxl\' ram=\'65536\' vram=\'65536\' vgamem=\'16384\' heads=\'1\' primary=\'yes\'/>\n"
+        "      <alias name=\'video0\'/>\n"
+        "    </video>\n"
+        "  </devices>\n"
+        "  <seclabel type=\'dynamic\' model=\'apparmor\' relabel=\'yes\'>\n"
+        "  </seclabel>\n"
+        "</domain>",
+        desc.vm_name, mem_unit, memory, mem_unit, memory, desc.num_cores, desc.image.image_path.toStdString(),
+        desc.cloud_init_iso.toStdString(), mp::backend::generate_mac_address());
+}
+
+auto get_domain_definition(virConnectPtr connection, const mp::VirtualMachineDescription& desc)
+{
+    virSetErrorFunc(NULL, libvirt_error_handler);
+
+    mp::LibVirtVirtualMachine::DomainUPtr domain{virDomainLookupByName(connection, desc.vm_name.c_str()),
+                                                 virDomainFree};
+
+    virFreeError(libvirt_error);
+    libvirt_error = nullptr;
+
+    if (domain == nullptr)
+        domain = mp::LibVirtVirtualMachine::DomainUPtr{
+            virDomainDefineXML(connection, generate_xml_config_for(desc).c_str()), virDomainFree};
+
+    if (domain == nullptr)
+        throw std::runtime_error("Error getting domain definition");
+
+    return domain;
+}
+
+auto get_domain_state(virDomainPtr domain)
+{
+    auto state{0};
+
+    virDomainGetState(domain, &state, nullptr, 0);
+
+    return (state == VIR_DOMAIN_RUNNING) ? mp::VirtualMachine::State::running : mp::VirtualMachine::State::off;
+}
+}
+
+mp::LibVirtVirtualMachine::LibVirtVirtualMachine(const mp::VirtualMachineDescription& desc, virConnectPtr connection,
+                                                 mp::VMStatusMonitor& monitor)
+    : vm_name{desc.vm_name},
+      connection{connection},
+      domain{get_domain_definition(connection, desc)},
+      state{get_domain_state(domain.get())},
+      mac_addr{get_instance_mac_addr(domain.get())},
+      ip{get_instance_ip(connection, mac_addr)},
+      key_provider{desc.key_provider},
+      monitor{&monitor}
+{
+}
+
+mp::LibVirtVirtualMachine::~LibVirtVirtualMachine()
+{
+}
+
+void mp::LibVirtVirtualMachine::start()
+{
+    if (state == State::running)
+        return;
+
+    virDomainCreate(domain.get());
+
+    state = State::starting;
+    monitor->on_resume();
+}
+
+void mp::LibVirtVirtualMachine::stop()
+{
+    shutdown();
+}
+
+void mp::LibVirtVirtualMachine::shutdown()
+{
+    virDomainShutdown(domain.get());
+    state = State::off;
+    monitor->on_shutdown();
+}
+
+mp::VirtualMachine::State mp::LibVirtVirtualMachine::current_state()
+{
+    return state;
+}
+
+int mp::LibVirtVirtualMachine::ssh_port()
+{
+    return 22;
+}
+
+std::string mp::LibVirtVirtualMachine::ssh_hostname()
+{
+    auto action = [this] {
+        auto result = get_instance_ip(connection, mac_addr);
+        if (result)
+        {
+            ip.emplace(result.value());
+            return mp::utils::TimeoutAction::done;
+        }
+        else
+        {
+            return mp::utils::TimeoutAction::retry;
+        }
+    };
+    auto on_timeout = [] { return std::runtime_error("failed to determine IP address"); };
+    mp::utils::try_action_for(on_timeout, std::chrono::minutes(2), action);
+
+    return ip.value().as_string();
+}
+
+std::string mp::LibVirtVirtualMachine::ipv4()
+{
+    if (!ip)
+    {
+        auto result = get_instance_ip(connection, mac_addr);
+        if (result)
+            ip.emplace(result.value());
+        else
+            return "UNKNOWN";
+    }
+
+    return ip.value().as_string();
+}
+
+std::string mp::LibVirtVirtualMachine::ipv6()
+{
+    return {};
+}
+
+void mp::LibVirtVirtualMachine::wait_until_ssh_up(std::chrono::milliseconds timeout)
+{
+    auto action = [this] {
+        try
+        {
+            mp::SSHSession session{ssh_hostname(), ssh_port()};
+            state = State::running;
+            return mp::utils::TimeoutAction::done;
+        }
+        catch (const std::exception&)
+        {
+            state = State::unknown;
+            return mp::utils::TimeoutAction::retry;
+        }
+    };
+    auto on_timeout = [] { return std::runtime_error("timed out waiting for ssh service to start"); };
+    mp::utils::try_action_for(on_timeout, timeout, action);
+}
+
+void mp::LibVirtVirtualMachine::wait_for_cloud_init(std::chrono::milliseconds timeout)
+{
+    auto action = [this] {
+        mp::SSHSession session{ssh_hostname(), ssh_port(), key_provider};
+        auto ssh_process = session.exec({"[ -e /var/lib/cloud/instance/boot-finished ]"});
+        return ssh_process.exit_code() == 0 ? mp::utils::TimeoutAction::done : mp::utils::TimeoutAction::retry;
+    };
+    auto on_timeout = [] { return std::runtime_error("timed out waiting for cloud-init to complete"); };
+    mp::utils::try_action_for(on_timeout, timeout, action);
+}

--- a/src/platform/backends/libvirt/libvirt_virtual_machine.h
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine.h
@@ -36,7 +36,8 @@ public:
     using DomainUPtr = std::unique_ptr<virDomain, decltype(virDomainFree)*>;
     using NetworkUPtr = std::unique_ptr<virNetwork, decltype(virNetworkFree)*>;
 
-    LibVirtVirtualMachine(const VirtualMachineDescription& desc, virConnectPtr connection, VMStatusMonitor& monitor);
+    LibVirtVirtualMachine(const VirtualMachineDescription& desc, virConnectPtr connection,
+                          const std::string& bridge_name, VMStatusMonitor& monitor);
     ~LibVirtVirtualMachine();
 
     void start() override;

--- a/src/platform/backends/libvirt/libvirt_virtual_machine.h
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_LIBVIRT_VIRTUAL_MACHINE_H
+#define MULTIPASS_LIBVIRT_VIRTUAL_MACHINE_H
+
+#include <multipass/ip_address.h>
+#include <multipass/optional.h>
+#include <multipass/virtual_machine.h>
+
+#include <libvirt/libvirt.h>
+
+namespace multipass
+{
+class SSHKeyProvider;
+class VMStatusMonitor;
+class VirtualMachineDescription;
+
+class LibVirtVirtualMachine final : public VirtualMachine
+{
+public:
+    using DomainUPtr = std::unique_ptr<virDomain, decltype(virDomainFree)*>;
+    using NetworkUPtr = std::unique_ptr<virNetwork, decltype(virNetworkFree)*>;
+
+    LibVirtVirtualMachine(const VirtualMachineDescription& desc, virConnectPtr connection, VMStatusMonitor& monitor);
+    ~LibVirtVirtualMachine();
+
+    void start() override;
+    void stop() override;
+    void shutdown() override;
+    State current_state() override;
+    int ssh_port() override;
+    std::string ssh_hostname() override;
+    std::string ipv4() override;
+    std::string ipv6() override;
+    void wait_until_ssh_up(std::chrono::milliseconds timeout) override;
+    void wait_for_cloud_init(std::chrono::milliseconds timeout) override;
+
+private:
+    const std::string vm_name;
+    virConnectPtr connection;
+    DomainUPtr domain;
+    VirtualMachine::State state;
+    const std::string mac_addr;
+    optional<IPAddress> ip;
+    const SSHKeyProvider& key_provider;
+    VMStatusMonitor* monitor;
+};
+}
+
+#endif // MULTIPASS_LIBVIRT_VIRTUAL_MACHINE_H

--- a/src/platform/backends/libvirt/libvirt_virtual_machine_factory.cpp
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine_factory.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "libvirt_virtual_machine_factory.h"
+#include "libvirt_virtual_machine.h"
+
+#include <multipass/backend_utils.h>
+#include <multipass/virtual_machine_description.h>
+
+#include <fmt/format.h>
+
+namespace mp = multipass;
+
+namespace
+{
+auto connect_to_libvirt_daemon()
+{
+    mp::LibVirtVirtualMachineFactory::ConnectionUPtr conn{virConnectOpen("qemu:///system"), virConnectClose};
+
+    if (conn == nullptr)
+        throw std::runtime_error("Cannot connect to libvirtd");
+
+    return conn;
+}
+
+auto generate_libvirt_bridge_xml_config()
+{
+    auto subnet = mp::backend::generate_random_subnet();
+
+    return fmt::format("<network>\n"
+                       "  <name>default</name>\n"
+                       "  <bridge name=\"mpbr0\"/>\n"
+                       "  <forward/>\n"
+                       "  <ip address=\"{}.1\" netmask=\"255.255.255.0\">\n"
+                       "    <dhcp>\n"
+                       "      <range start=\"{}.2\" end=\"{}.254\"/>\n"
+                       "    </dhcp>\n"
+                       "  </ip>\n"
+                       "</network>",
+                       subnet, subnet, subnet);
+}
+
+void enable_libvirt_network(virConnectPtr connection)
+{
+    mp::LibVirtVirtualMachine::NetworkUPtr network{virNetworkLookupByName(connection, "default"), virNetworkFree};
+
+    if (network == nullptr)
+    {
+        network = mp::LibVirtVirtualMachine::NetworkUPtr{
+            virNetworkCreateXML(connection, generate_libvirt_bridge_xml_config().c_str()), virNetworkFree};
+    }
+    else
+    {
+        if (virNetworkIsActive(network.get()) == 0)
+        {
+            virNetworkCreate(network.get());
+        }
+    }
+}
+}
+
+mp::LibVirtVirtualMachineFactory::LibVirtVirtualMachineFactory(const mp::Path& data_dir)
+    : connection{connect_to_libvirt_daemon()}
+{
+    enable_libvirt_network(connection.get());
+}
+
+mp::LibVirtVirtualMachineFactory::~LibVirtVirtualMachineFactory()
+{
+}
+
+mp::VirtualMachine::UPtr mp::LibVirtVirtualMachineFactory::create_virtual_machine(const VirtualMachineDescription& desc,
+                                                                                  VMStatusMonitor& monitor)
+{
+    return std::make_unique<mp::LibVirtVirtualMachine>(desc, connection.get(), monitor);
+}
+
+void mp::LibVirtVirtualMachineFactory::remove_resources_for(const std::string& name)
+{
+    virDomainUndefine(virDomainLookupByName(connection.get(), name.c_str()));
+}
+
+mp::FetchType mp::LibVirtVirtualMachineFactory::fetch_type()
+{
+    return mp::FetchType::ImageOnly;
+}
+
+mp::VMImage mp::LibVirtVirtualMachineFactory::prepare_source_image(const VMImage& source_image)
+{
+    return source_image;
+}
+
+void mp::LibVirtVirtualMachineFactory::prepare_instance_image(const VMImage& instance_image,
+                                                              const VirtualMachineDescription& desc)
+{
+    mp::backend::resize_instance_image(desc.disk_space, instance_image.image_path);
+}
+
+void mp::LibVirtVirtualMachineFactory::configure(const std::string& name, YAML::Node& meta_config,
+                                                 YAML::Node& user_config)
+{
+}
+
+void mp::LibVirtVirtualMachineFactory::check_hypervisor_support()
+{
+    mp::backend::check_hypervisor_support();
+}

--- a/src/platform/backends/libvirt/libvirt_virtual_machine_factory.h
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine_factory.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#ifndef MULTIPASS_LIBVIRT_VIRTUAL_MACHINE_FACTORY_H
+#define MULTIPASS_LIBVIRT_VIRTUAL_MACHINE_FACTORY_H
+
+#include <multipass/virtual_machine_factory.h>
+
+#include <memory>
+
+#include <libvirt/libvirt.h>
+
+namespace multipass
+{
+class LibVirtVirtualMachineFactory final : public VirtualMachineFactory
+{
+public:
+    using ConnectionUPtr = std::unique_ptr<virConnect, decltype(virConnectClose)*>;
+
+    explicit LibVirtVirtualMachineFactory(const Path& data_dir);
+    ~LibVirtVirtualMachineFactory();
+
+    VirtualMachine::UPtr create_virtual_machine(const VirtualMachineDescription& desc,
+                                                VMStatusMonitor& monitor) override;
+    void remove_resources_for(const std::string& name) override;
+    FetchType fetch_type() override;
+    VMImage prepare_source_image(const VMImage& source_image) override;
+    void prepare_instance_image(const VMImage& instance_image, const VirtualMachineDescription& desc) override;
+    void configure(const std::string& name, YAML::Node& meta_config, YAML::Node& user_config) override;
+    void check_hypervisor_support() override;
+
+private:
+    ConnectionUPtr connection;
+};
+}
+
+#endif // MULTIPASS_LIBVIRT_VIRTUAL_MACHINE_FACTORY_H

--- a/src/platform/backends/libvirt/libvirt_virtual_machine_factory.h
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine_factory.h
@@ -44,6 +44,7 @@ public:
 
 private:
     ConnectionUPtr connection;
+    const std::string bridge_name;
 };
 }
 

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.h
@@ -43,6 +43,7 @@ public:
 
 private:
     IPAddressPool legacy_ip_pool;
+    const QString bridge_name;
     DNSMasqServer dnsmasq_server;
 };
 }

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -21,6 +21,7 @@
 
 #include <multipass/virtual_machine_factory.h>
 
+#include "backends/libvirt/libvirt_virtual_machine_factory.h"
 #include "backends/qemu/qemu_virtual_machine_factory.h"
 #include "logger/journald_logger.h"
 
@@ -33,7 +34,14 @@ std::string mp::platform::default_server_address()
 
 mp::VirtualMachineFactory::UPtr mp::platform::vm_backend(const mp::Path& data_dir)
 {
-    return std::make_unique<QemuVirtualMachineFactory>(data_dir);
+    auto backend = qgetenv("MULTIPASS_VM_BACKEND");
+
+    if (backend.isEmpty() || backend == "QEMU")
+        return std::make_unique<QemuVirtualMachineFactory>(data_dir);
+    else if (backend == "LIBVIRT")
+        return std::make_unique<LibVirtVirtualMachineFactory>(data_dir);
+
+    throw std::runtime_error("Invalid VM backend set in the environment");
 }
 
 mp::logging::Logger::UPtr mp::platform::make_logger(mp::logging::Level level)

--- a/tests/travis-Coverage.patch
+++ b/tests/travis-Coverage.patch
@@ -1,9 +1,9 @@
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
-@@ -102,11 +102,11 @@ parts:
-     - cmake-extras
+@@ -113,11 +113,11 @@ parts:
      - golang
      - libsystemd-dev
+     - libvirt-dev
 +    - lcov
      source: .
      configflags:
@@ -12,5 +12,5 @@
      - -DCMAKE_INSTALL_PREFIX=/
 -    - -DMULTIPASS_ENABLE_TESTS=off
      install: |-
-       set -ex
+       set -e
        mkdir -p ${SNAPCRAFT_PART_INSTALL}/etc/bash_completion.d/


### PR DESCRIPTION
To test with a local build:
`$ MULTIPASS_VM_BACKEND=LIBVIRT ./multipassd`

For a snap, after installing it, do:
`$ sudo snap set multipass vm-backend=LIBVIRT`

Also, when installed as a snap, `multipass.virsh` also works for administering the VM via virsh.