### PR TITLE
snap: Remove using `apt-get source` for fetching libvirt package sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
       - sg lxd -c
           '/snap/bin/lxc exec snapcraft-multipass --
              env CTEST_OUTPUT_ON_FAILURE=1
-                 LD_LIBRARY_PATH=/root/build_multipass/stage/usr/lib/x86_64-linux-gnu/
+                 LD_LIBRARY_PATH=/root/build_multipass/stage/usr/lib/x86_64-linux-gnu/:/root/build_multipass/stage/lib/
                  /root/build_multipass/parts/multipass/build/bin/multipass_tests'
 
     - env: BUILD_TYPE=Coverage
@@ -48,7 +48,7 @@ jobs:
       - sg lxd -c
           '/snap/bin/lxc exec snapcraft-multipass --
              env CTEST_OUTPUT_ON_FAILURE=1
-                 LD_LIBRARY_PATH=/root/build_multipass/stage/usr/lib/x86_64-linux-gnu/
+                 LD_LIBRARY_PATH=/root/build_multipass/stage/usr/lib/x86_64-linux-gnu/:/root/build_multipass/stage/lib/
                  cmake --build /root/build_multipass/parts/multipass/build --target covreport'
       after_success:
       - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -120,7 +120,8 @@ parts:
     - -DCMAKE_BUILD_TYPE=RelWithDebInfo
     - -DCMAKE_INSTALL_PREFIX=/
     - -DMULTIPASS_ENABLE_TESTS=off
-    install: |-
+    override-build: |
+      snapcraftctl build
       set -e
       mkdir -p ${SNAPCRAFT_PART_INSTALL}/etc/bash_completion.d/
       echo 'export PATH="${PATH}:/snap/bin:/var/lib/snapd/snap/bin"' > ${SNAPCRAFT_PART_INSTALL}/etc/bash_completion.d/snap.multipass
@@ -200,11 +201,12 @@ parts:
     - --sysconfdir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
     - DNSMASQ=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/sbin/dnsmasq
     - DMIDECODE=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/sbin/dmidecode
-    prepare: |
+    override-build: |
       wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1.orig.tar.gz
       wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.21.debian.tar.xz
       wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.21.dsc
       dpkg-source -x libvirt_1.3.1-1ubuntu10.21.dsc
+      snapcraftctl build
     organize:
       # Hack to shift installed libvirt back to root of snap
       # required to ensure that pathing to files etc works at

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -108,13 +108,13 @@ parts:
     - qtbase5-dev-tools
     - libqt5core5a
     - libqt5network5
+    - libvirt
     plugin: cmake
     build-packages:
     - build-essential
     - cmake-extras
     - golang
     - libsystemd-dev
-    - libvirt-dev
     source: .
     configflags:
     - -DCMAKE_BUILD_TYPE=RelWithDebInfo
@@ -201,8 +201,10 @@ parts:
     - DNSMASQ=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/sbin/dnsmasq
     - DMIDECODE=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/sbin/dmidecode
     prepare: |
-      apt update
-      apt source libvirt
+      wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1.orig.tar.gz
+      wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.21.debian.tar.xz
+      wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.21.dsc
+      dpkg-source -x libvirt_1.3.1-1ubuntu10.21.dsc
     organize:
       # Hack to shift installed libvirt back to root of snap
       # required to ensure that pathing to files etc works at

--- a/tests/travis-Coverage.patch
+++ b/tests/travis-Coverage.patch
@@ -1,9 +1,9 @@
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
-@@ -113,11 +113,11 @@ parts:
+@@ -115,11 +115,11 @@ parts:
+     - cmake-extras
      - golang
      - libsystemd-dev
-     - libvirt-dev
 +    - lcov
      source: .
      configflags:
@@ -11,6 +11,6 @@
 +    - -DCMAKE_BUILD_TYPE=Coverage
      - -DCMAKE_INSTALL_PREFIX=/
 -    - -DMULTIPASS_ENABLE_TESTS=off
-     install: |-
+     override-build: |
+       snapcraftctl build
        set -e
-       mkdir -p ${SNAPCRAFT_PART_INSTALL}/etc/bash_completion.d/

--- a/tests/travis-Debug.patch
+++ b/tests/travis-Debug.patch
@@ -1,13 +1,13 @@
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
-@@ -94,9 +94,8 @@ parts:
-     - golang
+@@ -117,9 +117,8 @@ parts:
+     - libsystemd-dev
      source: .
      configflags:
 -    - -DCMAKE_BUILD_TYPE=RelWithDebInfo
 +    - -DCMAKE_BUILD_TYPE=Debug
      - -DCMAKE_INSTALL_PREFIX=/
 -    - -DMULTIPASS_ENABLE_TESTS=off
-     install: |-
-       set -ex
-       mkdir -p ${SNAPCRAFT_PART_INSTALL}/etc/bash_completion.d/
+     override-build: |
+       snapcraftctl build
+       set -e


### PR DESCRIPTION
Instead, use `wget` and `dkpg-source` for retrieving and unpacking the package source.
Also, build multipass against our built libvirt instead of libvirt-dev from the archive.