### PR TITLE
snap: Add missing build dependencies for wget and dpkg-source

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -169,6 +169,8 @@ parts:
     - libnuma-dev
     - python-all
     - python-six
+    - wget
+    - dpkg-dev
     stage-packages:
     - dmidecode
     - dnsmasq


### PR DESCRIPTION
I can confirm in a private build on build.s.i, that this fixes the issue.