### PR TITLE
qemu/libvirt: Commonize the functions to detect when the instance is …

### DIFF
--- a/include/multipass/ssh/ssh_process.h
+++ b/include/multipass/ssh/ssh_process.h
@@ -50,6 +50,7 @@ private:
     ssh_channel release_channel();
 
     ssh_session session;
+    const std::string cmd;
     ChannelUPtr channel;
     optional<int> exit_status;
 

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -19,16 +19,20 @@
 #define MULTIPASS_UTILS_H
 
 #include <chrono>
+#include <functional>
 #include <string>
 #include <thread>
 #include <vector>
 
+#include <QCoreApplication>
 #include <QDir>
 #include <QString>
 #include <QStringList>
 
 namespace multipass
 {
+class VirtualMachine;
+
 namespace utils
 {
 enum class QuoteType
@@ -48,6 +52,10 @@ std::string& trim_end(std::string& s);
 std::string escape_char(const std::string& s, char c);
 std::vector<std::string> split(const std::string& string, const std::string& delimiter);
 std::string generate_mac_address();
+void wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
+                       std::function<void()> const& process_vm_events = []() { QCoreApplication::processEvents(); });
+void wait_for_cloud_init(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
+                         std::function<void()> const& process_vm_events = []() { QCoreApplication::processEvents(); });
 
 enum class TimeoutAction
 {

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -26,6 +26,8 @@
 
 namespace multipass
 {
+class SSHKeyProvider;
+
 class VirtualMachine
 {
 public:
@@ -53,8 +55,13 @@ public:
     virtual void wait_until_ssh_up(std::chrono::milliseconds timeout) = 0;
     virtual void wait_for_cloud_init(std::chrono::milliseconds timeout) = 0;
 
+    VirtualMachine::State state;
+    const SSHKeyProvider& key_provider;
+    const std::string vm_name;
+
 protected:
-    VirtualMachine() = default;
+    VirtualMachine(const SSHKeyProvider& key_provider, const std::string& vm_name)
+        : state{State::off}, key_provider{key_provider}, vm_name{vm_name} {};
     VirtualMachine(const VirtualMachine&) = delete;
     VirtualMachine& operator=(const VirtualMachine&) = delete;
 };

--- a/src/platform/backends/libvirt/libvirt_virtual_machine.h
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine.h
@@ -26,7 +26,6 @@
 
 namespace multipass
 {
-class SSHKeyProvider;
 class VMStatusMonitor;
 class VirtualMachineDescription;
 
@@ -52,13 +51,10 @@ public:
     void wait_for_cloud_init(std::chrono::milliseconds timeout) override;
 
 private:
-    const std::string vm_name;
     virConnectPtr connection;
     DomainUPtr domain;
-    VirtualMachine::State state;
     const std::string mac_addr;
     optional<IPAddress> ip;
-    const SSHKeyProvider& key_provider;
     VMStatusMonitor* monitor;
 };
 }

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -31,7 +31,6 @@ class QString;
 namespace multipass
 {
 class DNSMasqServer;
-class SSHKeyProvider;
 class VMStatusMonitor;
 class VirtualMachineDescription;
 
@@ -59,14 +58,11 @@ private:
     void on_shutdown();
     void on_restart();
     void ensure_vm_is_running();
-    VirtualMachine::State state;
     optional<IPAddress> ip;
     bool is_legacy_ip;
     const std::string tap_device_name;
     const std::string mac_addr;
-    const std::string vm_name;
     DNSMasqServer* dnsmasq_server;
-    const SSHKeyProvider& key_provider;
     VMStatusMonitor* monitor;
     std::unique_ptr<QProcess> vm_process;
     std::string saved_error_msg;

--- a/src/ssh/CMakeLists.txt
+++ b/src/ssh/CMakeLists.txt
@@ -22,6 +22,7 @@ function(add_ssh_target TARGET_NAME)
     ssh_session.cpp)
 
   target_link_libraries(${TARGET_NAME}
+    fmt
     libssh
     Qt5::Core)
 endfunction()

--- a/src/ssh/ssh_process.cpp
+++ b/src/ssh/ssh_process.cpp
@@ -19,6 +19,7 @@
 #include <multipass/ssh/ssh_session.h>
 #include <multipass/ssh/throw_on_error.h>
 
+#include <fmt/format.h>
 #include <libssh/callbacks.h>
 
 #include <array>
@@ -66,7 +67,7 @@ auto make_channel(ssh_session ssh_session, const std::string& cmd)
 }
 
 mp::SSHProcess::SSHProcess(ssh_session session, const std::string& cmd)
-    : session{session}, channel{make_channel(session, cmd)}
+    : session{session}, cmd{cmd}, channel{make_channel(session, cmd)}
 {
 }
 
@@ -86,7 +87,7 @@ int mp::SSHProcess::exit_code(std::chrono::milliseconds timeout)
     }
 
     if (!exit_status)
-        throw std::runtime_error("failed to obtain exit status for remote process");
+        throw std::runtime_error(fmt::format("failed to obtain exit status for remote process: \'{}\'", cmd));
 
     return *exit_status;
 }

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -17,4 +17,5 @@ add_library(utils STATIC
 
 target_link_libraries(utils
   fmt
+  ssh
   Qt5::Core)

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -15,7 +15,10 @@
  *
  */
 
+#include <multipass/logging/log.h>
+#include <multipass/ssh/ssh_session.h>
 #include <multipass/utils.h>
+#include <multipass/virtual_machine.h>
 
 #include <fmt/format.h>
 
@@ -28,6 +31,7 @@
 #include <regex>
 
 namespace mp = multipass;
+namespace mpl = multipass::logging;
 
 namespace
 {
@@ -131,4 +135,47 @@ std::string mp::utils::generate_mac_address()
     gen.seed(std::chrono::system_clock::now().time_since_epoch().count());
     std::array<int, 3> octets{{dist(gen), dist(gen), dist(gen)}};
     return fmt::format("52:54:00:{:02x}:{:02x}:{:02x}", octets[0], octets[1], octets[2]);
+}
+
+void mp::utils::wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
+                                  std::function<void()> const& process_vm_events)
+{
+    auto action = [virtual_machine, &process_vm_events] {
+        process_vm_events();
+        try
+        {
+            mp::SSHSession session{virtual_machine->ssh_hostname(), virtual_machine->ssh_port()};
+            virtual_machine->state = VirtualMachine::State::running;
+            return mp::utils::TimeoutAction::done;
+        }
+        catch (const std::exception&)
+        {
+            virtual_machine->state = VirtualMachine::State::unknown;
+            return mp::utils::TimeoutAction::retry;
+        }
+    };
+    auto on_timeout = [] { return std::runtime_error("timed out waiting for ssh service to start"); };
+    mp::utils::try_action_for(on_timeout, timeout, action);
+}
+
+void mp::utils::wait_for_cloud_init(mp::VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
+                                    std::function<void()> const& process_vm_events)
+{
+    auto action = [virtual_machine, &process_vm_events] {
+        process_vm_events();
+        mp::SSHSession session{virtual_machine->ssh_hostname(), virtual_machine->ssh_port(),
+                               virtual_machine->key_provider};
+        auto ssh_process = session.exec({"[ -e /var/lib/cloud/instance/boot-finished ]"});
+        try
+        {
+            return ssh_process.exit_code() == 0 ? mp::utils::TimeoutAction::done : mp::utils::TimeoutAction::retry;
+        }
+        catch (const std::exception& e)
+        {
+            mpl::log(mpl::Level::warning, virtual_machine->vm_name, e.what());
+            return mp::utils::TimeoutAction::retry;
+        }
+    };
+    auto on_timeout = [] { return std::runtime_error("timed out waiting for cloud-init to complete"); };
+    mp::utils::try_action_for(on_timeout, timeout, action);
 }

--- a/tests/stub_virtual_machine.h
+++ b/tests/stub_virtual_machine.h
@@ -22,12 +22,18 @@
 
 #include <multipass/virtual_machine.h>
 
+#include "stub_ssh_key_provider.h"
+
 namespace multipass
 {
 namespace test
 {
 struct StubVirtualMachine final : public multipass::VirtualMachine
 {
+    StubVirtualMachine() : VirtualMachine{StubSSHKeyProvider(), ""}
+    {
+    }
+
     void start() override
     {
     }


### PR DESCRIPTION
…ready

Also, catch an exception thrown when the SSHProcess exit_code cannot be retrieved.

Fixes #232