### PR TITLE
image_vault: Remove expunge_invalid_image_records()

### DIFF
--- a/src/daemon/default_vm_image_vault.h
+++ b/src/daemon/default_vm_image_vault.h
@@ -57,7 +57,6 @@ private:
     VMImage image_instance_from(const std::string& name, const VMImage& prepared_image);
     void persist_image_records();
     void persist_instance_records();
-    void expunge_invalid_image_records();
 
     VMImageHost* const image_host;
     URLDownloader* const url_downloader;


### PR DESCRIPTION
This is not needed since the background image maintenance task will take care of
removing cached images and records when they are not needed.

Fixes #200