### PR TITLE
image_vault: Cache the image release version

### DIFF
--- a/include/multipass/vm_image.h
+++ b/include/multipass/vm_image.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,6 +33,8 @@ public:
     Path kernel_path;
     Path initrd_path;
     std::string id;
+    std::string original_release;
+    std::string current_release;
     std::vector<std::string> aliases;
 };
 }

--- a/src/client/formatter/table_formatter.cpp
+++ b/src/client/formatter/table_formatter.cpp
@@ -70,7 +70,8 @@ std::string mp::TableFormatter::format(const InfoReply& reply) const
         if (info.id().empty())
             out.write("{}\n", "Not Available");
         else
-            out.write("{} (Ubuntu {})\n", info.id().substr(0, 12), info.image_release());
+            out.write("{}{}\n", info.id().substr(0, 12),
+                      !info.image_release().empty() ? fmt::format(" (Ubuntu {})", info.image_release()) : "");
         out.write("{:<16}{}\n", "Load:", info.load().empty() ? "--" : info.load());
         out.write("{:<16}{}\n", "Disk usage:", to_usage(info.disk_usage(), info.disk_total()));
         out.write("{:<16}{}\n", "Memory usage:", to_usage(info.memory_usage(), info.memory_total()));
@@ -107,7 +108,8 @@ std::string mp::TableFormatter::format(const ListReply& reply) const
         out.write("{:<24}{:<12}{:<17}{:<}\n", instance.name(),
                   mp::format::status_string_for(instance.instance_status()),
                   instance.ipv4().empty() ? "--" : instance.ipv4(),
-                  instance.current_release().empty() ? "Not Available" : instance.current_release());
+                  instance.current_release().empty() ? "Not Available"
+                                                     : fmt::format("Ubuntu {}", instance.current_release()));
     }
 
     return out.str();

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -23,6 +23,7 @@
 #include <multipass/simple_streams_index.h>
 #include <multipass/url_downloader.h>
 
+#include <QTimer>
 #include <QUrl>
 
 #include <algorithm>
@@ -70,6 +71,7 @@ mp::UbuntuVMImageHost::UbuntuVMImageHost(std::unordered_map<std::string, std::st
                                          URLDownloader* downloader, std::chrono::seconds manifest_time_to_live)
     : manifest_time_to_live{manifest_time_to_live}, url_downloader{downloader}, remotes{remotes}
 {
+    QTimer::singleShot(0, [this]() { update_manifest(); });
 }
 
 mp::VMImageInfo mp::UbuntuVMImageHost::info_for(const Query& query)

--- a/tests/stub_vm_image_vault.h
+++ b/tests/stub_vm_image_vault.h
@@ -32,7 +32,7 @@ struct StubVMImageVault final : public multipass::VMImageVault
     multipass::VMImage fetch_image(const multipass::FetchType&, const multipass::Query&, const PrepareAction& prepare,
                                    const multipass::ProgressMonitor&) override
     {
-        return prepare({dummy_image.name(), dummy_image.name(), dummy_image.name(), {}, {}});
+        return prepare({dummy_image.name(), dummy_image.name(), dummy_image.name(), {}, {}, {}, {}});
     };
 
     void remove(const std::string&) override{};

--- a/tests/test_image_vault.cpp
+++ b/tests/test_image_vault.cpp
@@ -273,7 +273,7 @@ TEST_F(ImageVault, uses_image_from_prepare)
     }
 
     auto prepare = [&file_name](const mp::VMImage& source_image) -> mp::VMImage {
-        return {file_name, "", "", source_image.id, {}};
+        return {file_name, "", "", source_image.id, "", "", {}};
     };
 
     mp::DefaultVMImageVault vault{&host, &url_downloader, cache_dir.path(), data_dir.path(), mp::days{0}};
@@ -300,7 +300,7 @@ TEST_F(ImageVault, image_purged_expired)
             file.write("");
             file.flush();
         }
-        return {file_name, "", "", source_image.id, {}};
+        return {file_name, "", "", source_image.id, "", "", {}};
     };
     auto vm_image = vault.fetch_image(mp::FetchType::ImageOnly, default_query, prepare, stub_monitor);
 
@@ -327,7 +327,7 @@ TEST_F(ImageVault, image_exists_not_expired)
             file.write("");
             file.flush();
         }
-        return {file_name, "", "", source_image.id, {}};
+        return {file_name, "", "", source_image.id, "", "", {}};
     };
     auto vm_image = vault.fetch_image(mp::FetchType::ImageOnly, default_query, prepare, stub_monitor);
 

--- a/tests/test_output_formatter.cpp
+++ b/tests/test_output_formatter.cpp
@@ -37,7 +37,7 @@ auto construct_single_instance_list_reply()
     auto list_entry = list_reply.add_instances();
     list_entry->set_name("foo");
     list_entry->mutable_instance_status()->set_status(mp::InstanceStatus::RUNNING);
-    list_entry->set_current_release("Ubuntu 16.04 LTS");
+    list_entry->set_current_release("16.04 LTS");
     list_entry->set_ipv4("10.168.32.2");
 
     return list_reply;
@@ -50,13 +50,13 @@ auto construct_multiple_instances_list_reply()
     auto list_entry = list_reply.add_instances();
     list_entry->set_name("bogus-instance");
     list_entry->mutable_instance_status()->set_status(mp::InstanceStatus::RUNNING);
-    list_entry->set_current_release("Ubuntu 16.04 LTS");
+    list_entry->set_current_release("16.04 LTS");
     list_entry->set_ipv4("10.21.124.56");
 
     list_entry = list_reply.add_instances();
     list_entry->set_name("bombastic");
     list_entry->mutable_instance_status()->set_status(mp::InstanceStatus::STOPPED);
-    list_entry->set_current_release("Ubuntu 18.04 LTS");
+    list_entry->set_current_release("18.04 LTS");
 
     return list_reply;
 }
@@ -273,7 +273,7 @@ TEST_F(JsonFormatter, single_instance_list_output)
                                 "                \"10.168.32.2\"\n"
                                 "            ],\n"
                                 "            \"name\": \"foo\",\n"
-                                "            \"release\": \"Ubuntu 16.04 LTS\",\n"
+                                "            \"release\": \"16.04 LTS\",\n"
                                 "            \"state\": \"RUNNING\"\n"
                                 "        }\n"
                                 "    ]\n"
@@ -296,14 +296,14 @@ TEST_F(JsonFormatter, multiple_instances_list_output)
                                 "                \"10.21.124.56\"\n"
                                 "            ],\n"
                                 "            \"name\": \"bogus-instance\",\n"
-                                "            \"release\": \"Ubuntu 16.04 LTS\",\n"
+                                "            \"release\": \"16.04 LTS\",\n"
                                 "            \"state\": \"RUNNING\"\n"
                                 "        },\n"
                                 "        {\n"
                                 "            \"ipv4\": [\n"
                                 "            ],\n"
                                 "            \"name\": \"bombastic\",\n"
-                                "            \"release\": \"Ubuntu 18.04 LTS\",\n"
+                                "            \"release\": \"18.04 LTS\",\n"
                                 "            \"state\": \"STOPPED\"\n"
                                 "        }\n"
                                 "    ]\n"
@@ -479,7 +479,7 @@ TEST_F(CSVFormatter, single_instance_list_output)
     auto list_reply = construct_single_instance_list_reply();
 
     auto expected_output = "Name,State,IPv4,IPv6,Release\n"
-                           "foo,RUNNING,10.168.32.2,,Ubuntu 16.04 LTS\n";
+                           "foo,RUNNING,10.168.32.2,,16.04 LTS\n";
 
     mp::CSVFormatter csv_formatter;
     auto output = csv_formatter.format(list_reply);
@@ -492,8 +492,8 @@ TEST_F(CSVFormatter, multiple_instance_list_output)
     auto list_reply = construct_multiple_instances_list_reply();
 
     auto expected_output = "Name,State,IPv4,IPv6,Release\n"
-                           "bogus-instance,RUNNING,10.21.124.56,,Ubuntu 16.04 LTS\n"
-                           "bombastic,STOPPED,,,Ubuntu 18.04 LTS\n";
+                           "bogus-instance,RUNNING,10.21.124.56,,16.04 LTS\n"
+                           "bombastic,STOPPED,,,18.04 LTS\n";
 
     mp::CSVFormatter csv_formatter;
     auto output = csv_formatter.format(list_reply);
@@ -567,7 +567,7 @@ TEST_F(YamlFormatter, single_instance_list_output)
                            "  - state: RUNNING\n"
                            "    ipv4:\n"
                            "      - 10.168.32.2\n"
-                           "    release: Ubuntu 16.04 LTS\n";
+                           "    release: 16.04 LTS\n";
 
     mp::YamlFormatter formatter;
     auto output = formatter.format(list_reply);
@@ -583,12 +583,12 @@ TEST_F(YamlFormatter, multiple_instance_list_output)
                            "  - state: RUNNING\n"
                            "    ipv4:\n"
                            "      - 10.21.124.56\n"
-                           "    release: Ubuntu 16.04 LTS\n"
+                           "    release: 16.04 LTS\n"
                            "bombastic:\n"
                            "  - state: STOPPED\n"
                            "    ipv4:\n"
                            "      - \"\"\n"
-                           "    release: Ubuntu 18.04 LTS\n";
+                           "    release: 18.04 LTS\n";
 
     mp::YamlFormatter formatter;
     auto output = formatter.format(list_reply);

--- a/tests/test_qemu_backend.cpp
+++ b/tests/test_qemu_backend.cpp
@@ -77,7 +77,7 @@ struct QemuBackend : public testing::Test
                                                       "",
                                                       "pied-piper-valley",
                                                       "",
-                                                      {dummy_image.name(), "", "", "", {}},
+                                                      {dummy_image.name(), "", "", "", "", "", {}},
                                                       dummy_cloud_init_iso.name(),
                                                       key_provider};
     QTemporaryDir data_dir;


### PR DESCRIPTION
In case the image is removed from the image server, cache the image's original release version so it can be displayed in info & list.

This only applies to any images downloaded after this is applied.  Retrieving information for images already downloaded will still query SimpleStreams.