### PR TITLE
daemon: Restore instance state when starting

### DIFF
--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -55,6 +55,7 @@ public:
     virtual std::string ipv6() = 0;
     virtual void wait_until_ssh_up(std::chrono::milliseconds timeout) = 0;
     virtual void wait_for_cloud_init(std::chrono::milliseconds timeout) = 0;
+    virtual void update_state() = 0;
 
     VirtualMachine::State state;
     const SSHKeyProvider& key_provider;

--- a/include/multipass/vm_status_monitor.h
+++ b/include/multipass/vm_status_monitor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,6 +32,7 @@ public:
     virtual void on_stop() = 0;
     virtual void on_shutdown() = 0;
     virtual void on_restart(const std::string& name) = 0;
+    virtual void persist_state_for(const std::string& name) = 0;
 
 protected:
     VMStatusMonitor() = default;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,6 +47,7 @@ struct VMSpecs
     std::string disk_space;
     std::string mac_addr;
     std::string ssh_username;
+    VirtualMachine::State state;
     std::unordered_map<std::string, VMMount> mounts;
 };
 
@@ -62,6 +63,7 @@ protected:
     void on_stop() override;
     void on_shutdown() override;
     void on_restart(const std::string& name) override;
+    void persist_state_for(const std::string& name) override;
 
 public slots:
     grpc::Status launch(grpc::ServerContext* context, const LaunchRequest* request,

--- a/src/platform/backends/libvirt/libvirt_virtual_machine.cpp
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine.cpp
@@ -261,6 +261,7 @@ void mp::LibVirtVirtualMachine::start()
         throw std::runtime_error(virGetLastErrorMessage());
 
     state = State::starting;
+    update_state();
     monitor->on_resume();
 }
 
@@ -273,6 +274,7 @@ void mp::LibVirtVirtualMachine::shutdown()
 {
     virDomainShutdown(domain.get());
     state = State::off;
+    update_state();
     monitor->on_shutdown();
 }
 
@@ -338,4 +340,9 @@ void mp::LibVirtVirtualMachine::wait_until_ssh_up(std::chrono::milliseconds time
 void mp::LibVirtVirtualMachine::wait_for_cloud_init(std::chrono::milliseconds timeout)
 {
     mp::utils::wait_for_cloud_init(this, timeout);
+}
+
+void mp::LibVirtVirtualMachine::update_state()
+{
+    monitor->persist_state_for(vm_name);
 }

--- a/src/platform/backends/libvirt/libvirt_virtual_machine.h
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine.h
@@ -50,6 +50,7 @@ public:
     std::string ipv6() override;
     void wait_until_ssh_up(std::chrono::milliseconds timeout) override;
     void wait_for_cloud_init(std::chrono::milliseconds timeout) override;
+    void update_state() override;
 
 private:
     virConnectPtr connection;

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -52,6 +52,7 @@ public:
     std::string ipv6() override;
     void wait_until_ssh_up(std::chrono::milliseconds timeout) override;
     void wait_for_cloud_init(std::chrono::milliseconds timeout) override;
+    void update_state() override;
 
 private:
     void on_started();
@@ -68,6 +69,7 @@ private:
     VMStatusMonitor* monitor;
     std::unique_ptr<QProcess> vm_process;
     std::string saved_error_msg;
+    bool update_shutdown_status{true};
 };
 }
 

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -146,15 +146,20 @@ void mp::utils::wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::
         {
             mp::SSHSession session{virtual_machine->ssh_hostname(), virtual_machine->ssh_port()};
             virtual_machine->state = VirtualMachine::State::running;
+            virtual_machine->update_state();
             return mp::utils::TimeoutAction::done;
         }
         catch (const std::exception&)
         {
-            virtual_machine->state = VirtualMachine::State::unknown;
             return mp::utils::TimeoutAction::retry;
         }
     };
-    auto on_timeout = [] { return std::runtime_error("timed out waiting for ssh service to start"); };
+    auto on_timeout = [virtual_machine] {
+        virtual_machine->state = VirtualMachine::State::unknown;
+        virtual_machine->update_state();
+        return std::runtime_error("timed out waiting for ssh service to start");
+    };
+
     mp::utils::try_action_for(on_timeout, timeout, action);
 }
 

--- a/tests/mock_status_monitor.h
+++ b/tests/mock_status_monitor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,6 +33,7 @@ struct MockVMStatusMonitor : public VMStatusMonitor
     MOCK_METHOD0(on_stop, void());
     MOCK_METHOD0(on_shutdown, void());
     MOCK_METHOD1(on_restart, void(const std::string&));
+    MOCK_METHOD1(persist_state_for, void(const std::string&));
 };
 }
 }

--- a/tests/stub_status_monitor.h
+++ b/tests/stub_status_monitor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,6 +32,7 @@ struct StubVMStatusMonitor : public multipass::VMStatusMonitor
     void on_stop() override{};
     void on_shutdown() override{};
     void on_restart(const std::string& name) override{};
+    void persist_state_for(const std::string& name) override{};
 };
 }
 }

--- a/tests/stub_virtual_machine.h
+++ b/tests/stub_virtual_machine.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -81,6 +81,10 @@ struct StubVirtualMachine final : public multipass::VirtualMachine
     }
 
     void wait_for_cloud_init(std::chrono::milliseconds) override
+    {
+    }
+
+    void update_state() override
     {
     }
 };

--- a/tests/test_qemu_backend.cpp
+++ b/tests/test_qemu_backend.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -101,9 +101,11 @@ TEST_F(QemuBackend, machine_sends_monitoring_events)
 
     auto machine = backend.create_virtual_machine(default_description, mock_monitor);
 
+    EXPECT_CALL(mock_monitor, persist_state_for(_));
     EXPECT_CALL(mock_monitor, on_resume());
     machine->start();
 
+    EXPECT_CALL(mock_monitor, persist_state_for(_)).Times(AtLeast(1));
     EXPECT_CALL(mock_monitor, on_shutdown());
     machine->shutdown();
 }


### PR DESCRIPTION
Persist the instance state in the DB and read this when the daemon starts. If instance
was running but is not currently, then start the instance.

Fixes #130