### PR TITLE
snap: Do not kill libvirt's qemu processes on snap refresh

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,6 +20,8 @@ apps:
       XDG_DATA_HOME: $SNAP_COMMON/data
       XDG_CACHE_HOME: $SNAP_COMMON/cache
     daemon: simple
+    passthrough:
+      after: [libvirt-bin]
   multipass:
     environment:
       LD_LIBRARY_PATH: $SNAP/lib:$SNAP/usr/lib
@@ -33,6 +35,7 @@ apps:
       PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
       LC_ALL: C
     daemon: simple
+    stop-mode: sigterm
   virsh:
     command: bin/virsh
     environment:


### PR DESCRIPTION
Only send sigterm to libvirtd and not any of its spawned qemu processes.
Also, start multipassd after libvirtd has started.

Fixes #55.