### PR TITLE
image_vault: Support using `core` alias for launching Ubuntu Core images

### DIFF
--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -446,6 +446,11 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type, co
             source_image = fetch_kernel_and_initrd(info, source_image, image_dir, monitor);
         }
 
+        if (source_image.image_path.endsWith(".xz"))
+        {
+            source_image = extract_downloaded_image(source_image, monitor);
+        }
+
         auto prepared_image = prepare(source_image);
         prepared_image_records[id] = {prepared_image, query, std::chrono::system_clock::now()};
         remove_source_images(source_image, prepared_image);

--- a/tests/test_ubuntu_image_host.cpp
+++ b/tests/test_ubuntu_image_host.cpp
@@ -81,7 +81,8 @@ TEST_F(UbuntuImageHost, iterates_over_all_entries)
     auto action = [&ids](const std::string& remote, const mp::VMImageInfo& info) { ids.insert(info.id.toStdString()); };
     host.for_each_entry_do(action);
 
-    const size_t expected_entries{4};
+    // Account for the hardcoded core image info
+    const size_t expected_entries{5};
     EXPECT_THAT(ids.size(), Eq(expected_entries));
 
     EXPECT_THAT(ids.count("1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac"), Eq(1u));


### PR DESCRIPTION
This is a temporary measure for enabling launching via the `core` alias and will be replaced
by a more robust configuration.