### PR TITLE
snap: Revert libvirtd 'stop-mode: sigterm' daemon mode

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,7 +35,6 @@ apps:
       PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
       LC_ALL: C
     daemon: simple
-    stop-mode: sigterm
   virsh:
     command: bin/virsh
     environment:


### PR DESCRIPTION
This is causing problems with other processes that are spawned by libvirtd.