### PR TITLE
daemon: Do not set a default remote during `launch`

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -444,8 +444,6 @@ try // clang-format on
     }
 
     auto query = query_from(request, name);
-    if (query.remote_name.empty())
-        query.remote_name = config->image_host->get_default_remote();
 
     if (!mp::platform::is_remote_supported(query.remote_name))
         throw std::runtime_error(fmt::format(


### PR DESCRIPTION
Fixes #299