### PR TITLE
Release 2018.6.1

### DIFF
--- a/3rd-party/CMakeLists.txt
+++ b/3rd-party/CMakeLists.txt
@@ -80,7 +80,7 @@ target_link_libraries(yaml INTERFACE
   yaml-cpp)
 
 # libssh config
-add_subdirectory(libssh EXCLUDE_FROM_ALL)
+add_subdirectory(libssh)
 
 # fmt header only library
 add_library(fmt INTERFACE)

--- a/3rd-party/libssh/CMakeLists.txt
+++ b/3rd-party/libssh/CMakeLists.txt
@@ -45,35 +45,26 @@ configure_file(libssh/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/libssh/config.h
 # but will be included in the final libssh shared library
 set(OPENSSL_CRYPTO_LIBRARY crypto decrepit ssh-boringssl-compat)
 
+message(STATUS "Checking for 'libssh' version")
+
 # Since the main CMake file is bypassed, we have to search that CMake file to determine the proper
 # shared library versions
-file(STRINGS libssh/CMakeLists.txt libssh_version_line REGEX ".*LIBRARY_VERSION.*")
-file(STRINGS libssh/CMakeLists.txt libssh_soversion_line REGEX ".*LIBRARY_SOVERSION.*")
+file(STRINGS libssh/CMakeLists.txt LIBRARY_VERSION REGEX "^set\\(LIBRARY_VERSION")
+file(STRINGS libssh/CMakeLists.txt LIBRARY_SOVERSION REGEX "^set\\(LIBRARY_SOVERSION")
 
-if (NOT libssh_version_line)
-    message(FATAL_ERROR "no library version specified in libssh project")
-endif()
-
-if (NOT libssh_soversion_line)
-    message(FATAL_ERROR "no library soversion specified in libssh project")
-endif()
-
-string(REPLACE "\"" "" libssh_version_line ${libssh_version_line})
-string(REPLACE "\"" "" libssh_soversion_line ${libssh_soversion_line})
-
-unset(CMAKE_MATCH_1)
-string(REGEX MATCH ".*LIBRARY_VERSION (.*)\\)" _ ${libssh_version_line})
-if (NOT CMAKE_MATCH_1)
+string(REGEX REPLACE "^set\\(LIBRARY_VERSION \"(.*)\"\\)$" "\\1"
+       LIBRARY_VERSION "${LIBRARY_VERSION}")
+if (NOT LIBRARY_VERSION)
     message(FATAL_ERROR "unable to find libssh library version")
 endif()
-set(LIBRARY_VERSION ${CMAKE_MATCH_1})
 
-unset(CMAKE_MATCH_1)
-string(REGEX MATCH ".*LIBRARY_SOVERSION (.*)\\)" _ ${libssh_soversion_line})
-if (NOT CMAKE_MATCH_1)
+string(REGEX REPLACE "^set\\(LIBRARY_SOVERSION \"(.*)\"\\)$" "\\1"
+       LIBRARY_SOVERSION "${LIBRARY_SOVERSION}")
+if (NOT LIBRARY_SOVERSION)
     message(FATAL_ERROR "unable to find libssh library soversion")
 endif()
-set(LIBRARY_SOVERSION ${CMAKE_MATCH_1})
+
+message(STATUS "  Found ${LIBRARY_VERSION}, ${LIBRARY_SOVERSION}")
 
 # We bypass the main CMake file to avoid various package checks which are satisfied manually
 # through the configuration above.

--- a/3rd-party/libssh/CMakeLists.txt
+++ b/3rd-party/libssh/CMakeLists.txt
@@ -15,7 +15,6 @@
 # Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
 
 set(WITH_ZLIB FALSE)
-set(WITH_STATIC_LIB TRUE)
 set(WITH_EXAMPLES FALSE)
 set(WITH_SERVER TRUE)
 set(WITH_SFTP TRUE)
@@ -31,7 +30,8 @@ set(OPENSSL_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../grpc/third_party/boringss
 set(LIBSSH_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libssh/include)
 
 # Needed only because of libssh install target
-set(LIB_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR})
+set(LIB_INSTALL_DIR lib)
+set(BIN_INSTALL_DIR bin)
 
 include_directories(${LIBSSH_INCLUDE_DIR})
 include_directories(${OPENSSL_INCLUDE_DIR})
@@ -41,8 +41,43 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/libssh)
 include(libssh/ConfigureChecks.cmake)
 configure_file(libssh/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/libssh/config.h)
 
-# We bypass the main CMake file to avoid various unneded checks
-add_subdirectory(libssh/src EXCLUDE_FROM_ALL)
+# Must be set after configure checks as crypto has not been built yet
+# but will be included in the final libssh shared library
+set(OPENSSL_CRYPTO_LIBRARY crypto decrepit ssh-boringssl-compat)
+
+# Since the main CMake file is bypassed, we have to search that CMake file to determine the proper
+# shared library versions
+file(STRINGS libssh/CMakeLists.txt libssh_version_line REGEX ".*LIBRARY_VERSION.*")
+file(STRINGS libssh/CMakeLists.txt libssh_soversion_line REGEX ".*LIBRARY_SOVERSION.*")
+
+if (NOT libssh_version_line)
+    message(FATAL_ERROR "no library version specified in libssh project")
+endif()
+
+if (NOT libssh_soversion_line)
+    message(FATAL_ERROR "no library soversion specified in libssh project")
+endif()
+
+string(REPLACE "\"" "" libssh_version_line ${libssh_version_line})
+string(REPLACE "\"" "" libssh_soversion_line ${libssh_soversion_line})
+
+unset(CMAKE_MATCH_1)
+string(REGEX MATCH ".*LIBRARY_VERSION (.*)\\)" _ ${libssh_version_line})
+if (NOT CMAKE_MATCH_1)
+    message(FATAL_ERROR "unable to find libssh library version")
+endif()
+set(LIBRARY_VERSION ${CMAKE_MATCH_1})
+
+unset(CMAKE_MATCH_1)
+string(REGEX MATCH ".*LIBRARY_SOVERSION (.*)\\)" _ ${libssh_soversion_line})
+if (NOT CMAKE_MATCH_1)
+    message(FATAL_ERROR "unable to find libssh library soversion")
+endif()
+set(LIBRARY_SOVERSION ${CMAKE_MATCH_1})
+
+# We bypass the main CMake file to avoid various package checks which are satisfied manually
+# through the configuration above.
+add_subdirectory(libssh/src)
 
 add_library(ssh-boringssl-compat STATIC
   ssh-boringssl-compat.c)
@@ -53,7 +88,4 @@ target_include_directories(libssh INTERFACE
   ${LIBSSH_INCLUDE_DIR})
 
 target_link_libraries(libssh INTERFACE
-  ssh_static
-  crypto
-  decrepit
-  ssh-boringssl-compat)
+  ssh_shared)

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -40,11 +40,12 @@ _multipass_complete()
         done
     }
 
-    local cur cmd opts prev
+    local cur cmd opts prev prev_opts
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     cmd="${COMP_WORDS[1]}"
+    prev_opts=false
     multipass_cmds="copy-files delete exec find help info launch list mount purge \
                     recover shell start stop umount version"
 
@@ -74,13 +75,16 @@ _multipass_complete()
         case "${prev}" in
             "--format"|"-f")
                 opts="table json csv yaml"
+                prev_opts=true
             ;;
             "--cloud-init")
                 _filedir
                 return
             ;;
         esac
-    else
+    fi
+
+    if [[ "$prev_opts" = false ]]; then
         case "${cmd}" in
             "connect"|"sh"|"shell"|"exec"|"stop")
                 _multipass_instances "RUNNING"

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -75,7 +75,7 @@ _multipass_complete()
             "--format"|"-f")
                 opts="table json csv yaml"
             ;;
-            "--cloud-init"|"--image")
+            "--cloud-init")
                 _filedir
                 return
             ;;


### PR DESCRIPTION
Highlights:
- support custom VM images (#24)
- support "core" as an alias (#87)
- switched to a dedicated "multipass" user inside the instance
  - avoid hardcoding "/home/ubuntu" in your commands

Significant improvements:
- multiple bash completion fixes (#206, #207, #220, #239)
- fixed image caching if removed from streams (#200)
- caching info data to display when instance is stopped (#199)
- support for custom SSH keys (#52)
- (re)storing instance state (#130)
- verify downloaded images (#275)