### PR TITLE
Base support for remote clients

### DIFF
--- a/include/multipass/cert_store.h
+++ b/include/multipass/cert_store.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_CERT_STORE_H
+#define MULTIPASS_CERT_STORE_H
+
+#include <string>
+
+namespace multipass
+{
+class CertStore
+{
+public:
+    virtual ~CertStore() = default;
+    virtual void add_cert(const std::string& pem_cert) = 0;
+    virtual std::string PEM_cert_chain() const = 0;
+
+protected:
+    CertStore() = default;
+    CertStore(const CertStore&) = delete;
+    CertStore& operator=(const CertStore&) = delete;
+};
+} // namespace multipass
+#endif // MULTIPASS_CERT_STORE_H

--- a/include/multipass/client_cert_store.h
+++ b/include/multipass/client_cert_store.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_CLIENT_CERT_STORE_H
+#define MULTIPASS_CLIENT_CERT_STORE_H
+
+#include <multipass/cert_store.h>
+#include <multipass/path.h>
+
+namespace multipass
+{
+class ClientCertStore : public CertStore
+{
+public:
+    explicit ClientCertStore(const multipass::Path& cert_dir);
+    void add_cert(const std::string& pem_cert) override;
+    std::string PEM_cert_chain() const override;
+
+private:
+    Path cert_dir;
+};
+} // namespace multipass
+#endif // MULTIPASS_CLIENT_CERT_STORE_H

--- a/include/multipass/metrics_provider.h
+++ b/include/multipass/metrics_provider.h
@@ -34,8 +34,6 @@ public:
     bool send_metrics();
     void send_denied();
 
-    static QString generate_unique_id();
-
 private:
     void post_request(const QByteArray& body);
 

--- a/include/multipass/ssl_cert_provider.h
+++ b/include/multipass/ssl_cert_provider.h
@@ -37,6 +37,7 @@ public:
     };
 
     explicit SSLCertProvider(const Path& data_dir);
+    SSLCertProvider(const Path& data_dir, const std::string& server_name);
     std::string PEM_certificate() const override;
     std::string PEM_signing_key() const override;
 

--- a/include/multipass/ssl_cert_provider.h
+++ b/include/multipass/ssl_cert_provider.h
@@ -21,8 +21,6 @@
 #include <multipass/cert_provider.h>
 #include <multipass/path.h>
 
-#include <QDir>
-
 #include <string>
 
 namespace multipass
@@ -42,7 +40,6 @@ public:
     std::string PEM_signing_key() const override;
 
 private:
-    QDir cert_dir;
     KeyCertificatePair key_cert_pair;
 };
 } // namespace multipass

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -45,6 +45,7 @@ enum class QuoteType
 
 QDir base_dir(const QString& path);
 multipass::Path make_dir(const QDir& a_dir, const QString& name);
+QString make_uuid();
 bool valid_memory_value(const QString& mem_string);
 bool valid_hostname(const QString& name_string);
 bool invalid_target_path(const QString& target_path);

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -47,6 +47,7 @@ QDir base_dir(const QString& path);
 multipass::Path make_dir(const QDir& a_dir, const QString& name);
 QString make_uuid();
 std::string contents_of(const multipass::Path& file_path);
+bool has_only_digits(const std::string& value);
 bool valid_memory_value(const QString& mem_string);
 bool valid_hostname(const QString& name_string);
 bool invalid_target_path(const QString& target_path);

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -46,6 +46,7 @@ enum class QuoteType
 QDir base_dir(const QString& path);
 multipass::Path make_dir(const QDir& a_dir, const QString& name);
 QString make_uuid();
+std::string contents_of(const multipass::Path& file_path);
 bool valid_memory_value(const QString& mem_string);
 bool valid_hostname(const QString& name_string);
 bool invalid_target_path(const QString& target_path);

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -48,6 +48,7 @@ multipass::Path make_dir(const QDir& a_dir, const QString& name);
 QString make_uuid();
 std::string contents_of(const multipass::Path& file_path);
 bool has_only_digits(const std::string& value);
+void validate_server_address(const std::string& value);
 bool valid_memory_value(const QString& mem_string);
 bool valid_hostname(const QString& name_string);
 bool invalid_target_path(const QString& target_path);

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -18,6 +18,8 @@
 #ifndef MULTIPASS_UTILS_H
 #define MULTIPASS_UTILS_H
 
+#include <multipass/path.h>
+
 #include <chrono>
 #include <functional>
 #include <string>
@@ -42,7 +44,7 @@ enum class QuoteType
 };
 
 QDir base_dir(const QString& path);
-QDir make_dir(const QDir& a_dir, const QString& name);
+multipass::Path make_dir(const QDir& a_dir, const QString& name);
 bool valid_memory_value(const QString& mem_string);
 bool valid_hostname(const QString& name_string);
 bool invalid_target_path(const QString& target_path);

--- a/src/cert/CMakeLists.txt
+++ b/src/cert/CMakeLists.txt
@@ -14,6 +14,7 @@
 #
 
 add_library(cert
+  client_cert_store.cpp
   ssl_cert_provider.cpp
 )
 

--- a/src/cert/CMakeLists.txt
+++ b/src/cert/CMakeLists.txt
@@ -41,6 +41,7 @@ endif()
 
 if (ssl_ignore_header_warning_flags)
   set_source_files_properties(ssl_cert_provider.cpp PROPERTIES COMPILE_FLAGS ${ssl_ignore_header_warning_flags})
+  set_source_files_properties(client_cert_store.cpp PROPERTIES COMPILE_FLAGS ${ssl_ignore_header_warning_flags})
 endif()
 
 target_link_libraries(cert

--- a/src/cert/CMakeLists.txt
+++ b/src/cert/CMakeLists.txt
@@ -14,6 +14,7 @@
 #
 
 add_library(cert
+  biomem.cpp
   client_cert_store.cpp
   ssl_cert_provider.cpp
 )

--- a/src/cert/biomem.cpp
+++ b/src/cert/biomem.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "biomem.h"
+
+#include <vector>
+
+namespace mp = multipass;
+
+mp::BIOMem::BIOMem() : bio{BIO_new(BIO_s_mem()), BIO_free}
+{
+    if (bio == nullptr)
+        throw std::runtime_error("Failed to create BIO structure");
+}
+
+mp::BIOMem::BIOMem(const std::string& pem_source) : BIOMem()
+{
+    BIO_write(bio.get(), pem_source.data(), pem_source.size());
+}
+
+std::string mp::BIOMem::as_string() const
+{
+    std::vector<char> pem(bio->num_write);
+    BIO_read(bio.get(), pem.data(), pem.size());
+    return {pem.begin(), pem.end()};
+}
+
+BIO* mp::BIOMem::get() const
+{
+    return bio.get();
+}

--- a/src/cert/biomem.h
+++ b/src/cert/biomem.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_BIOMEM_H
+#define MULTIPASS_BIOMEM_H
+
+#include <openssl/bio.h>
+
+#include <string>
+
+namespace multipass
+{
+class BIOMem
+{
+public:
+    BIOMem();
+    BIOMem(const std::string& pem_source);
+    std::string as_string() const;
+    BIO* get() const;
+
+private:
+    const std::unique_ptr<BIO, decltype(BIO_free)*> bio;
+};
+} // namespace multipass
+#endif // MULTIPASS_BIOMEM_H

--- a/src/cert/client_cert_store.cpp
+++ b/src/cert/client_cert_store.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <multipass/client_cert_store.h>
+#include <multipass/utils.h>
+
+#include <QDir>
+#include <QFile>
+
+#include <stdexcept>
+
+namespace mp = multipass;
+
+namespace
+{
+constexpr auto chain_name = "multipass_client_certs.pem";
+}
+
+mp::ClientCertStore::ClientCertStore(const multipass::Path& cert_dir) : cert_dir{cert_dir}
+{
+}
+
+void mp::ClientCertStore::add_cert(const std::string& pem_cert)
+{
+    QDir dir{cert_dir};
+    QFile file{dir.filePath(chain_name)};
+    auto opened = file.open(QIODevice::WriteOnly | QIODevice::Append);
+    if (!opened)
+        throw std::runtime_error("failed to create file to store certificate");
+
+    size_t written = file.write(pem_cert.data(), pem_cert.size());
+    if (written != pem_cert.size())
+        throw std::runtime_error("failed to write certificate");
+}
+
+std::string mp::ClientCertStore::PEM_cert_chain() const
+{
+    QDir dir{cert_dir};
+    auto path = dir.filePath(chain_name);
+    if (QFile::exists(path))
+        return mp::utils::contents_of(path);
+    return {};
+}

--- a/src/cert/ssl_cert_provider.cpp
+++ b/src/cert/ssl_cert_provider.cpp
@@ -233,8 +233,8 @@ mp::SSLCertProvider::KeyCertificatePair make_cert_key_pair(const QDir& cert_dir,
 
 } // namespace
 
-mp::SSLCertProvider::SSLCertProvider(const multipass::Path& data_dir, const std::string& server_name)
-    : cert_dir{mp::utils::make_dir(data_dir, "certificate")}, key_cert_pair{make_cert_key_pair(cert_dir, server_name)}
+mp::SSLCertProvider::SSLCertProvider(const multipass::Path& cert_dir, const std::string& server_name)
+    : key_cert_pair{make_cert_key_pair(cert_dir, server_name)}
 {
 }
 

--- a/src/cert/ssl_cert_provider.cpp
+++ b/src/cert/ssl_cert_provider.cpp
@@ -203,23 +203,6 @@ private:
     std::unique_ptr<X509, decltype(X509_free)*> x509{X509_new(), X509_free};
 };
 
-std::string contents_of(const QString& name)
-{
-    std::ifstream in(name.toStdString(), std::ios::in | std::ios::binary);
-    if (in)
-    {
-        std::string contents;
-        in.seekg(0, std::ios::end);
-        contents.resize(in.tellg());
-        in.seekg(0, std::ios::beg);
-        in.read(&contents[0], contents.size());
-        in.close();
-        return contents;
-    }
-    throw std::runtime_error(
-        fmt::format("failed to open file '{}': {}({})", name.toStdString(), strerror(errno), errno));
-}
-
 mp::SSLCertProvider::KeyCertificatePair make_cert_key_pair(const QDir& cert_dir)
 {
     auto priv_key_path = cert_dir.filePath("multipass_cert_key.pem");
@@ -227,7 +210,7 @@ mp::SSLCertProvider::KeyCertificatePair make_cert_key_pair(const QDir& cert_dir)
 
     if (QFile::exists(priv_key_path) && QFile::exists(cert_path))
     {
-        return {contents_of(cert_path), contents_of(priv_key_path)};
+        return {mp::utils::contents_of(cert_path), mp::utils::contents_of(priv_key_path)};
     }
 
     EVPKey key;

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(client STATIC
   client.cpp)
 
 target_link_libraries(client
+  cert
   commands
   fmt
   formatter

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -34,10 +34,11 @@
 #include "cmd/umount.h"
 #include "cmd/version.h"
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 #include <algorithm>
 
+#include <multipass/cert_provider.h>
 #include <multipass/cli/argparser.h>
 #include <multipass/cli/csv_formatter.h>
 #include <multipass/cli/json_formatter.h>
@@ -64,13 +65,15 @@ auto make_map()
     return map;
 }
 
-auto make_channel(const std::string& server_address, mp::RpcConnectionType conn_type)
+auto make_channel(const std::string& server_address, mp::RpcConnectionType conn_type, mp::CertProvider& cert_provider)
 {
     std::shared_ptr<grpc::ChannelCredentials> creds;
     if (conn_type == mp::RpcConnectionType::ssl)
     {
         auto opts = grpc::SslCredentialsOptions();
         opts.server_certificate_request = GRPC_SSL_REQUEST_SERVER_CERTIFICATE_BUT_DONT_VERIFY;
+        opts.pem_cert_chain = cert_provider.PEM_certificate();
+        opts.pem_private_key = cert_provider.PEM_signing_key();
         creds = grpc::SslCredentials(opts);
     }
     else if (conn_type == mp::RpcConnectionType::insecure)
@@ -85,8 +88,9 @@ auto make_channel(const std::string& server_address, mp::RpcConnectionType conn_
 }
 } // namespace
 
-mp::Client::Client(const ClientConfig& config)
-    : rpc_channel{make_channel(config.server_address, config.conn_type)},
+mp::Client::Client(ClientConfig& config)
+    : cert_provider{std::move(config.cert_provider)},
+      rpc_channel{make_channel(config.server_address, config.conn_type, *cert_provider)},
       stub{mp::Rpc::NewStub(rpc_channel)},
       formatters{make_map()},
       cout{config.cout},

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -18,6 +18,7 @@
 #ifndef MULTIPASS_CLIENT_H
 #define MULTIPASS_CLIENT_H
 
+#include <multipass/cert_provider.h>
 #include <multipass/cli/cli.h>
 #include <multipass/cli/command.h>
 #include <multipass/cli/formatter.h>
@@ -34,6 +35,7 @@ struct ClientConfig
 {
     const std::string server_address;
     const RpcConnectionType conn_type;
+    std::unique_ptr<CertProvider> cert_provider;
     std::ostream& cout;
     std::ostream& cerr;
 };
@@ -41,12 +43,13 @@ struct ClientConfig
 class Client
 {
 public:
-    explicit Client(const ClientConfig& context);
+    explicit Client(ClientConfig& context);
     int run(const QStringList& arguments);
 
 private:
     template <typename T>
     void add_command();
+    const std::unique_ptr<CertProvider> cert_provider;
     std::shared_ptr<grpc::Channel> rpc_channel;
     std::unique_ptr<multipass::Rpc::Stub> stub;
     std::map<std::string, std::unique_ptr<multipass::Formatter>> formatters;

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -22,9 +22,11 @@
 #include <multipass/cli/cli.h>
 #include <multipass/console.h>
 #include <multipass/platform.h>
+#include <multipass/ssl_cert_provider.h>
 #include <multipass/utils.h>
 
 #include <QCoreApplication>
+#include <QStandardPaths>
 #include <QtGlobal>
 
 namespace mp = multipass;
@@ -50,7 +52,12 @@ int main(int argc, char* argv[])
     QCoreApplication::setApplicationName("multipass");
     mp::Console::setup_environment();
 
-    mp::ClientConfig config{get_server_address(), mp::RpcConnectionType::ssl, std::cout, std::cerr};
+    auto data_dir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    auto client_cert_dir = mp::utils::make_dir(data_dir, "client-cert");
+    auto cert_provider = std::make_unique<mp::SSLCertProvider>(client_cert_dir);
+
+    mp::ClientConfig config{get_server_address(), mp::RpcConnectionType::ssl, std::move(cert_provider), std::cout,
+                            std::cerr};
     mp::Client client{config};
 
     return client.run(QCoreApplication::arguments());

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char* argv[])
     mp::Console::setup_environment();
 
     auto data_dir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    auto client_cert_dir = mp::utils::make_dir(data_dir, "client-cert");
+    auto client_cert_dir = mp::utils::make_dir(data_dir, "client-certificate");
     auto cert_provider = std::make_unique<mp::SSLCertProvider>(client_cert_dir);
 
     mp::ClientConfig config{get_server_address(), mp::RpcConnectionType::ssl, std::move(cert_provider), std::cout,

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -22,10 +22,27 @@
 #include <multipass/cli/cli.h>
 #include <multipass/console.h>
 #include <multipass/platform.h>
+#include <multipass/utils.h>
 
 #include <QCoreApplication>
+#include <QtGlobal>
 
 namespace mp = multipass;
+
+namespace
+{
+std::string get_server_address()
+{
+    const auto address = qgetenv("MULTIPASS_SERVER_ADDRESS").toStdString();
+    if (!address.empty())
+    {
+        mp::utils::validate_server_address(address);
+        return address;
+    }
+
+    return mp::platform::default_server_address();
+}
+} // namespace
 
 int main(int argc, char* argv[])
 {
@@ -33,7 +50,7 @@ int main(int argc, char* argv[])
     QCoreApplication::setApplicationName("multipass");
     mp::Console::setup_environment();
 
-    mp::ClientConfig config{mp::platform::default_server_address(), mp::RpcConnectionType::ssl, std::cout, std::cerr};
+    mp::ClientConfig config{get_server_address(), mp::RpcConnectionType::ssl, std::cout, std::cerr};
     mp::Client client{config};
 
     return client.run(QCoreApplication::arguments());

--- a/src/daemon/cli.cpp
+++ b/src/daemon/cli.cpp
@@ -26,9 +26,6 @@
 #include <QCommandLineOption>
 #include <QCommandLineParser>
 
-#include <algorithm>
-#include <cctype>
-
 namespace mp = multipass;
 namespace mpl = multipass::logging;
 
@@ -89,23 +86,7 @@ mp::DaemonConfigBuilder mp::cli::parse(const QCoreApplication& app)
     if (parser.isSet(address_option))
     {
         auto address = parser.value(address_option).toStdString();
-        if (address.empty())
-            throw std::runtime_error("empty server address");
-
-        auto tokens = mp::utils::split(address, ":");
-        const auto server_name = tokens[0];
-        if (tokens.size() == 1u)
-        {
-            if (server_name == "unix")
-                throw std::runtime_error(fmt::format("missing socket file in address '{}'", address));
-            else
-                throw std::runtime_error(fmt::format("missing port number in address '{}'", address));
-        }
-
-        const auto port = tokens[1];
-        if (server_name != "unix" && !mp::utils::has_only_digits(port))
-            throw std::runtime_error(fmt::format("invalid port number in address '{}'", address));
-
+        mp::utils::validate_server_address(address);
         builder.server_address = address;
     }
 

--- a/src/daemon/cli.cpp
+++ b/src/daemon/cli.cpp
@@ -19,9 +19,15 @@
 
 #include <multipass/logging/standard_logger.h>
 #include <multipass/platform.h>
+#include <multipass/utils.h>
+
+#include <fmt/format.h>
 
 #include <QCommandLineOption>
 #include <QCommandLineParser>
+
+#include <algorithm>
+#include <cctype>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;
@@ -39,7 +45,7 @@ multipass::logging::Level to_logging_level(const QString& value)
     if (value == "debug")
         return mpl::Level::debug;
 
-    throw std::runtime_error("Invalid logging verbosity: " + value.toStdString());
+    throw std::runtime_error("invalid logging verbosity: " + value.toStdString());
 }
 } // namespace
 
@@ -53,9 +59,14 @@ mp::DaemonConfigBuilder mp::cli::parse(const QCoreApplication& app)
     QCommandLineOption logger_option{"logger", "specifies which logger to use", "platform|stderr"};
     QCommandLineOption verbosity_option{
         {"V", "verbosity"}, "specifies the logging verbosity level", "error|warning|info|debug"};
+    QCommandLineOption address_option{"address",
+                                      "specifies which address to use for the multipassd service;"
+                                      " a socket can be specified using unix:<socket_file>",
+                                      "server_name:port"};
 
     parser.addOption(logger_option);
     parser.addOption(verbosity_option);
+    parser.addOption(address_option);
 
     parser.process(app);
 
@@ -72,7 +83,30 @@ mp::DaemonConfigBuilder mp::cli::parse(const QCoreApplication& app)
         else if (logger == "stderr")
             builder.logger = std::make_unique<mpl::StandardLogger>(builder.verbosity_level);
         else
-            throw std::runtime_error("Invalid logger option: " + logger.toStdString());
+            throw std::runtime_error(fmt::format("invalid logger option '{}'", logger.toStdString()));
+    }
+
+    if (parser.isSet(address_option))
+    {
+        auto address = parser.value(address_option).toStdString();
+        if (address.empty())
+            throw std::runtime_error("empty server address");
+
+        auto tokens = mp::utils::split(address, ":");
+        const auto server_name = tokens[0];
+        if (tokens.size() == 1u)
+        {
+            if (server_name == "unix")
+                throw std::runtime_error(fmt::format("missing socket file in address '{}'", address));
+            else
+                throw std::runtime_error(fmt::format("missing port number in address '{}'", address));
+        }
+
+        const auto port = tokens[1];
+        if (server_name != "unix" && !mp::utils::has_only_digits(port))
+            throw std::runtime_error(fmt::format("invalid port number in address '{}'", address));
+
+        builder.server_address = address;
     }
 
     return builder;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -316,7 +316,7 @@ auto get_unique_id(const mp::Path& data_path)
 
     if (!id_file.exists())
     {
-        id = mp::MetricsProvider::generate_unique_id();
+        id = mp::utils::make_uuid();
         id_file.open(QIODevice::WriteOnly);
         id_file.write(id.toUtf8());
     }

--- a/src/daemon/daemon_config.cpp
+++ b/src/daemon/daemon_config.cpp
@@ -29,6 +29,7 @@
 #include <multipass/platform.h>
 #include <multipass/ssh/openssh_key_provider.h>
 #include <multipass/ssl_cert_provider.h>
+#include <multipass/utils.h>
 
 #include <QStandardPaths>
 
@@ -37,6 +38,18 @@
 namespace mp = multipass;
 namespace mpl = multipass::logging;
 
+namespace
+{
+std::string server_name_from(const std::string& server_address)
+{
+    auto tokens = mp::utils::split(server_address, ":");
+    const auto server_name = tokens[0];
+
+    if (server_name == "unix")
+        return "localhost";
+    return server_name;
+}
+} // namespace
 std::unique_ptr<const mp::DaemonConfig> mp::DaemonConfigBuilder::build()
 {
     // Install logger as early as possible
@@ -83,7 +96,7 @@ std::unique_ptr<const mp::DaemonConfig> mp::DaemonConfigBuilder::build()
     if (ssh_key_provider == nullptr)
         ssh_key_provider = std::make_unique<OpenSSHKeyProvider>(data_directory, cache_directory);
     if (cert_provider == nullptr)
-        cert_provider = std::make_unique<mp::SSLCertProvider>(data_directory);
+        cert_provider = std::make_unique<mp::SSLCertProvider>(data_directory, server_name_from(server_address));
     if (ssh_username.empty())
         ssh_username = "multipass";
 

--- a/src/daemon/daemon_config.cpp
+++ b/src/daemon/daemon_config.cpp
@@ -96,7 +96,8 @@ std::unique_ptr<const mp::DaemonConfig> mp::DaemonConfigBuilder::build()
     if (ssh_key_provider == nullptr)
         ssh_key_provider = std::make_unique<OpenSSHKeyProvider>(data_directory, cache_directory);
     if (cert_provider == nullptr)
-        cert_provider = std::make_unique<mp::SSLCertProvider>(data_directory, server_name_from(server_address));
+        cert_provider = std::make_unique<mp::SSLCertProvider>(mp::utils::make_dir(data_directory, "certificates"),
+                                                              server_name_from(server_address));
     if (ssh_username.empty())
         ssh_username = "multipass";
 

--- a/src/daemon/daemon_config.cpp
+++ b/src/daemon/daemon_config.cpp
@@ -23,6 +23,7 @@
 #include "custom_image_host.h"
 #include "ubuntu_image_host.h"
 
+#include <multipass/client_cert_store.h>
 #include <multipass/logging/log.h>
 #include <multipass/logging/standard_logger.h>
 #include <multipass/name_generator.h>
@@ -98,11 +99,14 @@ std::unique_ptr<const mp::DaemonConfig> mp::DaemonConfigBuilder::build()
     if (cert_provider == nullptr)
         cert_provider = std::make_unique<mp::SSLCertProvider>(mp::utils::make_dir(data_directory, "certificates"),
                                                               server_name_from(server_address));
+    if (client_cert_store == nullptr)
+        client_cert_store =
+            std::make_unique<mp::ClientCertStore>(mp::utils::make_dir(data_directory, "registered-certs"));
     if (ssh_username.empty())
         ssh_username = "multipass";
 
     return std::unique_ptr<const DaemonConfig>(new DaemonConfig{
         std::move(url_downloader), std::move(factory), std::move(image_hosts), std::move(vault),
-        std::move(name_generator), std::move(ssh_key_provider), std::move(cert_provider), shared_logger,
-        cache_directory, data_directory, server_address, ssh_username, connection_type});
+        std::move(name_generator), std::move(ssh_key_provider), std::move(cert_provider), std::move(client_cert_store),
+        shared_logger, cache_directory, data_directory, server_address, ssh_username, connection_type});
 }

--- a/src/daemon/daemon_config.h
+++ b/src/daemon/daemon_config.h
@@ -24,6 +24,7 @@
 #include <multipass/rpc/multipass.grpc.pb.h>
 
 #include <multipass/cert_provider.h>
+#include <multipass/cert_store.h>
 #include <multipass/logging/logger.h>
 #include <multipass/name_generator.h>
 #include <multipass/rpc_connection_type.h>
@@ -49,6 +50,7 @@ struct DaemonConfig
     const std::unique_ptr<NameGenerator> name_generator;
     const std::unique_ptr<SSHKeyProvider> ssh_key_provider;
     const std::unique_ptr<CertProvider> cert_provider;
+    const std::unique_ptr<CertStore> client_cert_store;
     const std::shared_ptr<logging::Logger> logger;
     const multipass::Path cache_directory;
     const multipass::Path data_directory;
@@ -66,6 +68,7 @@ struct DaemonConfigBuilder
     std::unique_ptr<NameGenerator> name_generator;
     std::unique_ptr<SSHKeyProvider> ssh_key_provider;
     std::unique_ptr<CertProvider> cert_provider;
+    std::unique_ptr<CertStore> client_cert_store;
     std::unique_ptr<logging::Logger> logger;
     multipass::Path cache_directory;
     multipass::Path data_directory;

--- a/src/daemon/daemon_main.cpp
+++ b/src/daemon/daemon_main.cpp
@@ -27,6 +27,7 @@
 #include <multipass/name_generator.h>
 #include <multipass/platform.h>
 #include <multipass/platform_unix.h>
+#include <multipass/utils.h>
 #include <multipass/version.h>
 #include <multipass/virtual_machine_factory.h>
 #include <multipass/vm_image_host.h>
@@ -42,6 +43,7 @@
 #include <sys/stat.h>
 #include <vector>
 
+namespace mp = multipass;
 namespace mpl = multipass::logging;
 namespace mpp = multipass::platform;
 
@@ -49,16 +51,19 @@ namespace
 {
 void set_server_permissions(const std::string& server_address)
 {
-    QString address = QString::fromStdString(server_address);
+    auto tokens = mp::utils::split(server_address, ":");
+    if (tokens.size() != 2u)
+        throw std::runtime_error(fmt::format("invalid server address specified: {}", server_address));
 
-    if (!address.startsWith("unix:"))
+    const auto server_name = tokens[0];
+    if (server_name != "unix")
         return;
 
     auto group = getgrnam("sudo");
     if (!group)
         throw std::runtime_error("Could not determine group id for 'sudo'.");
 
-    auto socket_path = address.section("unix:", 1, 1).toStdString();
+    const auto socket_path = tokens[1];
     if (chown(socket_path.c_str(), 0, group->gr_gid) == -1)
         throw std::runtime_error("Could not set ownership of the multipass socket.");
 
@@ -90,7 +95,7 @@ public:
     }
 
 private:
-    multipass::AutoJoinThread signal_handling_thread;
+    mp::AutoJoinThread signal_handling_thread;
 };
 } // namespace
 
@@ -98,14 +103,14 @@ int main(int argc, char* argv[]) // clang-format off
 try // clang-format on
 {
     QCoreApplication app(argc, argv);
-    QCoreApplication::setApplicationVersion(multipass::version_string);
+    QCoreApplication::setApplicationVersion(mp::version_string);
     UnixSignalHandler handler;
 
-    auto builder = multipass::cli::parse(app);
+    auto builder = mp::cli::parse(app);
     auto config = builder.build();
     auto server_address = config->server_address;
 
-    multipass::Daemon daemon(std::move(config));
+    mp::Daemon daemon(std::move(config));
 
     set_server_permissions(server_address);
 

--- a/src/daemon/daemon_rpc.h
+++ b/src/daemon/daemon_rpc.h
@@ -38,7 +38,8 @@ class DaemonRpc : public QObject, public multipass::Rpc::Service
 {
     Q_OBJECT
 public:
-    DaemonRpc(const std::string& server_address, multipass::RpcConnectionType type, const CertProvider& cert_provider);
+    DaemonRpc(const std::string& server_address, multipass::RpcConnectionType type, const CertProvider& cert_provider,
+              const CertStore& client_cert_store);
     DaemonRpc(const DaemonRpc&) = delete;
     DaemonRpc& operator=(const DaemonRpc&) = delete;
 

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -343,12 +343,12 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type, co
             }
             else
             {
-                auto image_filename = filename_for(image_url.path());
+                const auto image_filename = filename_for(image_url.path());
                 // Attempt to make a sane directory name based on the filename of the image
-                auto image_dir_name = QString("%1-%2")
+                const auto image_dir_name = QString("%1-%2")
                                           .arg(image_filename.section(".", 0, image_filename.endsWith(".xz") ? -3 : -2))
                                           .arg(last_modified.toString("yyyyMMdd"));
-                auto image_dir = mp::utils::make_dir(images_dir, image_dir_name);
+                const QDir image_dir{mp::utils::make_dir(images_dir, image_dir_name)};
 
                 source_image.id = hash;
                 source_image.image_path = image_dir.filePath(image_filename);
@@ -427,8 +427,8 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type, co
             }
         }
 
-        auto image_dir_name = QString("%1-%2").arg(info.release).arg(info.version);
-        auto image_dir = mp::utils::make_dir(images_dir, image_dir_name);
+        const auto image_dir_name = QString("%1-%2").arg(info.release).arg(info.version);
+        const QDir image_dir{mp::utils::make_dir(images_dir, image_dir_name)};
 
         VMImage source_image;
         source_image.id = id;
@@ -477,7 +477,7 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type, co
 
 void mp::DefaultVMImageVault::remove(const std::string& name)
 {
-    auto name_entry = instance_image_records.find(name);
+    const auto& name_entry = instance_image_records.find(name);
     if (name_entry == instance_image_records.end())
         return;
 
@@ -548,7 +548,7 @@ mp::VMImage mp::DefaultVMImageVault::extract_image_from(const std::string& insta
                                                         const ProgressMonitor& monitor)
 {
     const auto name = QString::fromStdString(instance_name);
-    const auto output_dir = mp::utils::make_dir(instances_dir, name);
+    const QDir output_dir{mp::utils::make_dir(instances_dir, name)};
     QFileInfo file_info{source_image.image_path};
     const auto image_name = file_info.fileName().remove(".xz");
     const auto image_path = output_dir.filePath(image_name);

--- a/src/metrics/metrics_provider.cpp
+++ b/src/metrics/metrics_provider.cpp
@@ -31,7 +31,6 @@
 #include <QNetworkRequest>
 #include <QRegExp>
 #include <QString>
-#include <QUuid>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;
@@ -66,7 +65,7 @@ bool mp::MetricsProvider::send_metrics()
     metrics.push_back(metric);
 
     QJsonObject metric_batch;
-    metric_batch.insert("uuid", generate_unique_id());
+    metric_batch.insert("uuid", mp::utils::make_uuid());
     metric_batch.insert("created", QDateTime::currentDateTimeUtc().toString(Qt::ISODateWithMs));
     metric_batch.insert("metrics", metrics);
     metric_batch.insert("credentials", QString());
@@ -91,12 +90,6 @@ void mp::MetricsProvider::send_denied()
     auto body = QJsonDocument(denied_batches).toJson(QJsonDocument::Compact);
 
     post_request(body);
-}
-
-QString mp::MetricsProvider::generate_unique_id()
-{
-    auto uuid = QUuid::createUuid();
-    return uuid.toString().remove(QRegExp("[{}]"));
 }
 
 void mp::MetricsProvider::post_request(const QByteArray& body)

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -27,7 +27,9 @@
 #include <QProcess>
 #include <QUuid>
 
+#include <algorithm>
 #include <array>
+#include <cctype>
 #include <fstream>
 #include <random>
 #include <regex>
@@ -216,4 +218,9 @@ std::string mp::utils::contents_of(const multipass::Path& file_path)
     std::stringstream stream;
     stream << in.rdbuf();
     return stream.str();
+}
+
+bool mp::utils::has_only_digits(const std::string& value)
+{
+    return std::all_of(value.begin(), value.end(), [](char c) { return std::isdigit(c); });
 }

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -224,3 +224,23 @@ bool mp::utils::has_only_digits(const std::string& value)
 {
     return std::all_of(value.begin(), value.end(), [](char c) { return std::isdigit(c); });
 }
+
+void mp::utils::validate_server_address(const std::string& address)
+{
+    if (address.empty())
+        throw std::runtime_error("empty server address");
+
+    const auto tokens = mp::utils::split(address, ":");
+    const auto server_name = tokens[0];
+    if (tokens.size() == 1u)
+    {
+        if (server_name == "unix")
+            throw std::runtime_error(fmt::format("missing socket file in address '{}'", address));
+        else
+            throw std::runtime_error(fmt::format("missing port number in address '{}'", address));
+    }
+
+    const auto port = tokens[1];
+    if (server_name != "unix" && !mp::utils::has_only_digits(port))
+        throw std::runtime_error(fmt::format("invalid port number in address '{}'", address));
+}

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -25,6 +25,7 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QProcess>
+#include <QUuid>
 
 #include <array>
 #include <random>
@@ -41,7 +42,7 @@ auto quote_for(const std::string& arg, mp::utils::QuoteType quote_type)
         return "";
     return arg.find('\'') == std::string::npos ? "'" : "\"";
 }
-}
+} // namespace
 
 QDir mp::utils::base_dir(const QString& path)
 {
@@ -193,4 +194,12 @@ mp::Path mp::utils::make_dir(const QDir& a_dir, const QString& name)
         throw std::runtime_error(fmt::format("unable to create directory '{}'", dir.toStdString()));
     }
     return a_dir.filePath(name);
+}
+
+QString mp::utils::make_uuid()
+{
+    auto uuid = QUuid::createUuid().toString();
+
+    // Remove curly brackets enclosing uuid
+    return uuid.mid(1, uuid.size() - 2);
 }

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -185,7 +185,7 @@ void mp::utils::wait_for_cloud_init(mp::VirtualMachine* virtual_machine, std::ch
     mp::utils::try_action_for(on_timeout, timeout, action);
 }
 
-QDir mp::utils::make_dir(const QDir& a_dir, const QString& name)
+mp::Path mp::utils::make_dir(const QDir& a_dir, const QString& name)
 {
     if (!a_dir.mkpath(name))
     {

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -28,8 +28,10 @@
 #include <QUuid>
 
 #include <array>
+#include <fstream>
 #include <random>
 #include <regex>
+#include <sstream>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;
@@ -202,4 +204,16 @@ QString mp::utils::make_uuid()
 
     // Remove curly brackets enclosing uuid
     return uuid.mid(1, uuid.size() - 2);
+}
+
+std::string mp::utils::contents_of(const multipass::Path& file_path)
+{
+    const std::string name{file_path.toStdString()};
+    std::ifstream in(name, std::ios::in | std::ios::binary);
+    if (!in)
+        throw std::runtime_error(fmt::format("failed to open file '{}': {}({})", name, strerror(errno), errno));
+
+    std::stringstream stream;
+    stream << in.rdbuf();
+    return stream.str();
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(multipass_tests
   temp_dir.cpp
   temp_file.cpp
   test_cli_client.cpp
+  test_client_cert_store.cpp
   test_cloud_init_iso.cpp
   test_daemon.cpp
   test_format_utils.cpp

--- a/tests/file_operations.cpp
+++ b/tests/file_operations.cpp
@@ -43,6 +43,11 @@ QByteArray mpt::load_test_file(const char* file_name)
 
 qint64 mpt::make_file_with_content(const QString& file_name)
 {
+    return make_file_with_content(file_name, "this is a test file");
+}
+
+qint64 mpt::make_file_with_content(const QString& file_name, const std::string& content)
+{
     QFile file(file_name);
     if (file.exists())
         throw std::runtime_error("test file already exists");
@@ -50,8 +55,6 @@ qint64 mpt::make_file_with_content(const QString& file_name)
     if (!file.open(QFile::WriteOnly))
         throw std::runtime_error("failed to open test file");
 
-    std::string content{"this is a test file"};
     file.write(content.data(), content.size());
-
     return file.size();
 }

--- a/tests/file_operations.h
+++ b/tests/file_operations.h
@@ -31,6 +31,7 @@ namespace test
 QByteArray load(QString path);
 QByteArray load_test_file(const char* file_name);
 qint64 make_file_with_content(const QString& file_name);
+qint64 make_file_with_content(const QString& file_name, const std::string& content);
 }
 }
 #endif // MULTIPASS_FILE_READER_H

--- a/tests/stub_cert_store.h
+++ b/tests/stub_cert_store.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <multipass/cert_store.h>
+
+namespace multipass
+{
+namespace test
+{
+class StubCertStore : public CertStore
+{
+public:
+    void add_cert(const std::string& pem_cert) override
+    {
+    }
+    std::string PEM_cert_chain() const override
+    {
+        return {};
+    }
+};
+} // namespace test
+} // namespace multipass

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -62,7 +62,8 @@ struct Client : public Test
 #endif
     std::stringstream null_stream;
     mpt::StubCertProvider cert_provider;
-    mp::DaemonRpc stub_daemon{server_address, mp::RpcConnectionType::insecure, cert_provider};
+    mpt::StubCertStore cert_store;
+    mp::DaemonRpc stub_daemon{server_address, mp::RpcConnectionType::insecure, cert_provider, cert_store};
 };
 
 // Tests for no postional args given

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "path.h"
+#include "stub_cert_store.h"
 #include "stub_certprovider.h"
 
 #include <multipass/logging/log.h>
@@ -42,7 +43,8 @@ struct Client : public Test
 
     int send_command(const std::vector<std::string>& command, std::ostream& cout)
     {
-        mp::ClientConfig client_config{server_address, mp::RpcConnectionType::insecure, cout, null_stream};
+        mp::ClientConfig client_config{server_address, mp::RpcConnectionType::insecure,
+                                       std::make_unique<mpt::StubCertProvider>(), cout, null_stream};
         mp::Client client{client_config};
         QStringList args = QStringList() << "multipass_test";
 

--- a/tests/test_client_cert_store.cpp
+++ b/tests/test_client_cert_store.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <multipass/client_cert_store.h>
+#include <multipass/utils.h>
+
+#include "file_operations.h"
+#include "temp_dir.h"
+
+#include <gmock/gmock.h>
+
+namespace mp = multipass;
+namespace mpt = multipass::test;
+
+using namespace testing;
+
+struct ClientCertStore : public testing::Test
+{
+    ClientCertStore()
+    {
+        cert_dir = mp::utils::make_dir(temp_dir.path(), "test-cert-store");
+    }
+    mpt::TempDir temp_dir;
+    mp::Path cert_dir;
+};
+
+TEST_F(ClientCertStore, returns_empty_chain_if_no_certificate_found)
+{
+    mp::ClientCertStore cert_store{cert_dir};
+
+    auto cert_chain = cert_store.PEM_cert_chain();
+    EXPECT_TRUE(cert_chain.empty());
+}
+
+TEST_F(ClientCertStore, returns_persisted_certificate_chain)
+{
+    mp::ClientCertStore cert_store{cert_dir};
+
+    constexpr auto cert_data = "-----BEGIN CERTIFICATE-----\n"
+                               "MIIBUjCB+AIBKjAKBggqhkjOPQQDAjA1MQswCQYDVQQGEwJDQTESMBAGA1UECgwJ\n"
+                               "Q2Fub25pY2FsMRIwEAYDVQQDDAlsb2NhbGhvc3QwHhcNMTgwNjIxMTM0MjI5WhcN\n"
+                               "MTkwNjIxMTM0MjI5WjA1MQswCQYDVQQGEwJDQTESMBAGA1UECgwJQ2Fub25pY2Fs\n"
+                               "MRIwEAYDVQQDDAlsb2NhbGhvc3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQA\n"
+                               "FGNAqq7c5IMDeQ/cV4+EmogmkfpbTLSPfXgXVLHRsvL04xUAkqGpL+eyGFVE6dqa\n"
+                               "J7sAPJJwlVj1xD0r5DX5MAoGCCqGSM49BAMCA0kAMEYCIQCvI0PYv9f201fbe4LP\n"
+                               "BowTeYWSqMQtLNjvZgd++AAGhgIhALNPW+NRSKCXwadiIFgpbjPInLPqXPskLWSc\n"
+                               "aXByaQyt\n"
+                               "-----END CERTIFICATE-----\n";
+
+    const QDir dir{cert_dir};
+    const auto cert_path = dir.filePath("multipass_client_certs.pem");
+    mpt::make_file_with_content(cert_path, cert_data);
+
+    auto cert_chain = cert_store.PEM_cert_chain();
+    EXPECT_THAT(cert_chain, StrEq(cert_data));
+}

--- a/tests/test_client_cert_store.cpp
+++ b/tests/test_client_cert_store.cpp
@@ -68,3 +68,30 @@ TEST_F(ClientCertStore, returns_persisted_certificate_chain)
     auto cert_chain = cert_store.PEM_cert_chain();
     EXPECT_THAT(cert_chain, StrEq(cert_data));
 }
+
+TEST_F(ClientCertStore, add_cert_throws_on_invalid_data)
+{
+    mp::ClientCertStore cert_store{cert_dir};
+
+    EXPECT_THROW(cert_store.add_cert("not a certificate"), std::runtime_error);
+}
+
+TEST_F(ClientCertStore, add_cert_stores_certificate)
+{
+    constexpr auto cert_data = "-----BEGIN CERTIFICATE-----\n"
+                               "MIIBUjCB+AIBKjAKBggqhkjOPQQDAjA1MQswCQYDVQQGEwJDQTESMBAGA1UECgwJ\n"
+                               "Q2Fub25pY2FsMRIwEAYDVQQDDAlsb2NhbGhvc3QwHhcNMTgwNjIxMTM0MjI5WhcN\n"
+                               "MTkwNjIxMTM0MjI5WjA1MQswCQYDVQQGEwJDQTESMBAGA1UECgwJQ2Fub25pY2Fs\n"
+                               "MRIwEAYDVQQDDAlsb2NhbGhvc3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQA\n"
+                               "FGNAqq7c5IMDeQ/cV4+EmogmkfpbTLSPfXgXVLHRsvL04xUAkqGpL+eyGFVE6dqa\n"
+                               "J7sAPJJwlVj1xD0r5DX5MAoGCCqGSM49BAMCA0kAMEYCIQCvI0PYv9f201fbe4LP\n"
+                               "BowTeYWSqMQtLNjvZgd++AAGhgIhALNPW+NRSKCXwadiIFgpbjPInLPqXPskLWSc\n"
+                               "aXByaQyt\n"
+                               "-----END CERTIFICATE-----\n";
+
+    mp::ClientCertStore cert_store{cert_dir};
+    EXPECT_NO_THROW(cert_store.add_cert(cert_data));
+
+    const auto content = cert_store.PEM_cert_chain();
+    EXPECT_THAT(content, StrEq(cert_data));
+}

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -116,8 +116,7 @@ struct Daemon : public Test
         ON_CALL(*mock_factory_ptr, create_virtual_machine(_, _))
             .WillByDefault(Return(ByMove(std::make_unique<mpt::StubVirtualMachine>())));
 
-        ON_CALL(*mock_factory_ptr, prepare_source_image(_))
-            .WillByDefault(ReturnArg<0>());
+        ON_CALL(*mock_factory_ptr, prepare_source_image(_)).WillByDefault(ReturnArg<0>());
 
         config_builder.factory = std::move(mock_factory);
         return mock_factory_ptr;
@@ -145,7 +144,8 @@ struct Daemon : public Test
         // Commands need to be sent from a thread different from that the QEventLoop is on.
         // Event loop is started/stopped to ensure all signals are delivered
         mp::AutoJoinThread t([this, &commands, &cout] {
-            mp::ClientConfig client_config{server_address, mp::RpcConnectionType::insecure, cout, std::cerr};
+            mp::ClientConfig client_config{server_address, mp::RpcConnectionType::insecure,
+                                           std::make_unique<mpt::StubCertProvider>(), cout, std::cerr};
             mp::Client client{client_config};
             for (const auto& command : commands)
             {
@@ -372,7 +372,7 @@ public:
 private:
     std::string key;
 };
-}
+} // namespace
 
 TEST_F(Daemon, adds_ssh_keys_to_cloud_init_config)
 {

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -29,6 +29,7 @@
 #include <multipass/vm_image_vault.h>
 
 #include "mock_virtual_machine_factory.h"
+#include "stub_cert_store.h"
 #include "stub_certprovider.h"
 #include "stub_image_host.h"
 #include "stub_logger.h"
@@ -100,6 +101,7 @@ struct Daemon : public Test
         config_builder.image_hosts.push_back(std::make_unique<mpt::StubVMImageHost>());
         config_builder.ssh_key_provider = std::make_unique<mpt::StubSSHKeyProvider>();
         config_builder.cert_provider = std::make_unique<mpt::StubCertProvider>();
+        config_builder.client_cert_store = std::make_unique<mpt::StubCertStore>();
         config_builder.connection_type = mp::RpcConnectionType::insecure;
         config_builder.logger = std::make_unique<mpt::StubLogger>();
 

--- a/tests/test_metrics_provider.cpp
+++ b/tests/test_metrics_provider.cpp
@@ -15,7 +15,8 @@
  *
  */
 
-#include "multipass/metrics_provider.h"
+#include <multipass/metrics_provider.h>
+#include <multipass/utils.h>
 
 #include "temp_file.h"
 
@@ -43,7 +44,7 @@ struct MetricsProvider : public testing::Test
 
 TEST_F(MetricsProvider, opt_in_metrics_valid)
 {
-    auto unique_id = mp::MetricsProvider::generate_unique_id();
+    const auto unique_id = mp::utils::make_uuid();
     mp::MetricsProvider metrics_provider{metrics_file.url(), unique_id};
 
     metrics_provider.send_metrics();
@@ -108,7 +109,7 @@ TEST_F(MetricsProvider, opt_in_metrics_valid)
 
 TEST_F(MetricsProvider, opt_out_denied_valid)
 {
-    auto unique_id = mp::MetricsProvider::generate_unique_id();
+    const auto unique_id = mp::utils::make_uuid();
     mp::MetricsProvider metrics_provider{metrics_file.url(), unique_id};
 
     metrics_provider.send_denied();

--- a/tests/test_ssl_cert_provider.cpp
+++ b/tests/test_ssl_cert_provider.cpp
@@ -18,9 +18,9 @@
 #include <multipass/ssl_cert_provider.h>
 #include <multipass/utils.h>
 
+#include "file_operations.h"
 #include "temp_dir.h"
 
-#include <QTemporaryDir>
 #include <gmock/gmock.h>
 
 namespace mp = multipass;
@@ -28,23 +28,6 @@ namespace mpt = multipass::test;
 
 using namespace testing;
 
-namespace
-{
-template <typename T>
-void write(const QDir& dir, const char* name, const T& t)
-{
-    QFile output{dir.filePath(name)};
-    auto opened = output.open(QIODevice::WriteOnly);
-    if (!opened)
-        throw std::runtime_error("test unable to open file for writing");
-
-    auto written = output.write(t);
-    if (written == -1)
-        throw std::runtime_error("test unable to write data");
-
-    output.close();
-}
-} // namespace
 struct SSLCertProvider : public testing::Test
 {
     SSLCertProvider()
@@ -84,9 +67,12 @@ TEST_F(SSLCertProvider, imports_existing_cert_and_key)
                                "aXByaQyt\n"
                                "-----END CERTIFICATE-----\n";
 
-    QDir dir{cert_dir};
-    write(dir, "multipass_cert_key.pem", key_data);
-    write(dir, "multipass_cert.pem", cert_data);
+    const QDir dir{cert_dir};
+    const auto key_path = dir.filePath("multipass_cert_key.pem");
+    const auto cert_path = dir.filePath("multipass_cert.pem");
+
+    mpt::make_file_with_content(key_path, key_data);
+    mpt::make_file_with_content(cert_path, cert_data);
 
     mp::SSLCertProvider cert_provider{cert_dir};
 

--- a/tests/test_ssl_cert_provider.cpp
+++ b/tests/test_ssl_cert_provider.cpp
@@ -116,3 +116,16 @@ TEST_F(SSLCertProvider, persists_cert_and_key)
     EXPECT_TRUE(QFile::exists(key_file));
     EXPECT_TRUE(QFile::exists(cert_file));
 }
+
+TEST_F(SSLCertProvider, creates_different_certs_per_server_name)
+{
+    mp::SSLCertProvider cert_provider1{cert_dir.path(), "test_server1"};
+    mp::SSLCertProvider cert_provider2{cert_dir.path(), "test_server2"};
+
+    auto pem_cert1 = cert_provider1.PEM_certificate();
+    auto pem_key1 = cert_provider1.PEM_signing_key();
+    auto pem_cert2 = cert_provider2.PEM_certificate();
+    auto pem_key2 = cert_provider2.PEM_signing_key();
+    EXPECT_THAT(pem_cert1, StrNe(pem_cert2));
+    EXPECT_THAT(pem_key1, StrNe(pem_key2));
+}

--- a/tests/test_ssl_cert_provider.cpp
+++ b/tests/test_ssl_cert_provider.cpp
@@ -15,12 +15,17 @@
  *
  */
 
-#include "multipass/ssl_cert_provider.h"
+#include <multipass/ssl_cert_provider.h>
+#include <multipass/utils.h>
+
+#include "temp_dir.h"
 
 #include <QTemporaryDir>
 #include <gmock/gmock.h>
 
 namespace mp = multipass;
+namespace mpt = multipass::test;
+
 using namespace testing;
 
 namespace
@@ -44,15 +49,15 @@ struct SSLCertProvider : public testing::Test
 {
     SSLCertProvider()
     {
-        if (!cert_dir.isValid())
-            throw std::runtime_error("test failed to create temp directory");
+        cert_dir = mp::utils::make_dir(temp_dir.path(), "test-cert");
     }
-    QTemporaryDir cert_dir;
+    mpt::TempDir temp_dir;
+    mp::Path cert_dir;
 };
 
 TEST_F(SSLCertProvider, creates_cert_and_key)
 {
-    mp::SSLCertProvider cert_provider{cert_dir.path()};
+    mp::SSLCertProvider cert_provider{cert_dir};
 
     auto pem_cert = cert_provider.PEM_certificate();
     auto pem_key = cert_provider.PEM_signing_key();
@@ -79,18 +84,11 @@ TEST_F(SSLCertProvider, imports_existing_cert_and_key)
                                "aXByaQyt\n"
                                "-----END CERTIFICATE-----\n";
 
-    constexpr auto cert_dir_name = "certificate";
-    QDir dir{cert_dir.path()};
-    auto made_path = dir.mkpath(cert_dir_name);
-    if (!made_path)
-        throw std::runtime_error("test failed to create temporary certificate directory");
-
-    dir.cd(cert_dir_name);
-
+    QDir dir{cert_dir};
     write(dir, "multipass_cert_key.pem", key_data);
     write(dir, "multipass_cert.pem", cert_data);
 
-    mp::SSLCertProvider cert_provider{cert_dir.path()};
+    mp::SSLCertProvider cert_provider{cert_dir};
 
     EXPECT_THAT(cert_provider.PEM_signing_key(), StrEq(key_data));
     EXPECT_THAT(cert_provider.PEM_certificate(), StrEq(cert_data));
@@ -98,20 +96,14 @@ TEST_F(SSLCertProvider, imports_existing_cert_and_key)
 
 TEST_F(SSLCertProvider, persists_cert_and_key)
 {
-    constexpr auto cert_dir_name = "certificate";
-    QDir dir{cert_dir.path()};
-    auto made_path = dir.mkpath(cert_dir_name);
-    if (!made_path)
-        throw std::runtime_error("test failed to create temporary certificate directory");
-    dir.cd(cert_dir_name);
-
+    QDir dir{cert_dir};
     auto key_file = dir.filePath("multipass_cert_key.pem");
     auto cert_file = dir.filePath("multipass_cert.pem");
 
     EXPECT_FALSE(QFile::exists(key_file));
     EXPECT_FALSE(QFile::exists(cert_file));
 
-    mp::SSLCertProvider cert_provider{cert_dir.path()};
+    mp::SSLCertProvider cert_provider{cert_dir};
 
     EXPECT_TRUE(QFile::exists(key_file));
     EXPECT_TRUE(QFile::exists(cert_file));
@@ -119,8 +111,8 @@ TEST_F(SSLCertProvider, persists_cert_and_key)
 
 TEST_F(SSLCertProvider, creates_different_certs_per_server_name)
 {
-    mp::SSLCertProvider cert_provider1{cert_dir.path(), "test_server1"};
-    mp::SSLCertProvider cert_provider2{cert_dir.path(), "test_server2"};
+    mp::SSLCertProvider cert_provider1{cert_dir, "test_server1"};
+    mp::SSLCertProvider cert_provider2{cert_dir, "test_server2"};
 
     auto pem_cert1 = cert_provider1.PEM_certificate();
     auto pem_key1 = cert_provider1.PEM_signing_key();

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -17,6 +17,8 @@
 
 #include <multipass/utils.h>
 
+#include <QRegExp>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -255,4 +257,10 @@ TEST(Utils, try_action_does_not_timeout)
 
     EXPECT_FALSE(on_timeout_called);
     EXPECT_TRUE(action_called);
+}
+
+TEST(Utils, uuid_has_no_curly_brackets)
+{
+    auto uuid = mp::utils::make_uuid();
+    EXPECT_FALSE(uuid.contains(QRegExp("[{}]")));
 }

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -17,12 +17,17 @@
 
 #include <multipass/utils.h>
 
+#include "file_operations.h"
+#include "temp_dir.h"
+
 #include <QRegExp>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 namespace mp = multipass;
+namespace mpt = multipass::test;
+
 using namespace testing;
 
 TEST(Utils, KB_is_valid)
@@ -263,4 +268,30 @@ TEST(Utils, uuid_has_no_curly_brackets)
 {
     auto uuid = mp::utils::make_uuid();
     EXPECT_FALSE(uuid.contains(QRegExp("[{}]")));
+}
+
+TEST(Utils, contents_of_actually_reads_contents)
+{
+    mpt::TempDir temp_dir;
+    auto file_name = temp_dir.path() + "/test-file";
+    std::string expected_content{"just a bit of test content here"};
+    mpt::make_file_with_content(file_name, expected_content);
+
+    auto content = mp::utils::contents_of(file_name);
+    EXPECT_THAT(content, StrEq(expected_content));
+}
+
+TEST(Utils, contents_of_throws_on_missing_file)
+{
+    EXPECT_THROW(mp::utils::contents_of("this-file-does-not-exist"), std::runtime_error);
+}
+
+TEST(Utils, contents_of_empty_contents_on_empty_file)
+{
+    mpt::TempDir temp_dir;
+    auto file_name = temp_dir.path() + "/empty_test_file";
+    mpt::make_file_with_content(file_name, "");
+
+    auto content = mp::utils::contents_of(file_name);
+    EXPECT_TRUE(content.empty());
 }

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -335,3 +335,17 @@ TEST(Utils, has_only_digits_works)
     EXPECT_TRUE(mp::utils::has_only_digits("0123456789"));
     EXPECT_FALSE(mp::utils::has_only_digits("0123456789:'`'"));
 }
+
+TEST(Utils, validate_server_address_throws_on_invalid_address)
+{
+    EXPECT_THROW(mp::utils::validate_server_address("unix"), std::runtime_error);
+    EXPECT_THROW(mp::utils::validate_server_address("unix:"), std::runtime_error);
+    EXPECT_THROW(mp::utils::validate_server_address("test:test"), std::runtime_error);
+    EXPECT_THROW(mp::utils::validate_server_address(""), std::runtime_error);
+}
+
+TEST(Utils, validate_server_address_does_not_throw_on_good_address)
+{
+    EXPECT_NO_THROW(mp::utils::validate_server_address("unix:/tmp/a_socket"));
+    EXPECT_NO_THROW(mp::utils::validate_server_address("test-server.net:123"));
+}

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -25,6 +25,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <sstream>
+
 namespace mp = multipass;
 namespace mpt = multipass::test;
 
@@ -294,4 +296,35 @@ TEST(Utils, contents_of_empty_contents_on_empty_file)
 
     auto content = mp::utils::contents_of(file_name);
     EXPECT_TRUE(content.empty());
+}
+
+TEST(Utils, split_returns_token_list)
+{
+    std::vector<std::string> expected_tokens;
+    expected_tokens.push_back("Hello");
+    expected_tokens.push_back("World");
+    expected_tokens.push_back("Bye!");
+
+    const std::string delimiter{":"};
+
+    std::stringstream content;
+    for (const auto& token : expected_tokens)
+    {
+        content << token;
+        content << delimiter;
+    }
+
+    const auto tokens = mp::utils::split(content.str(), delimiter);
+    EXPECT_THAT(tokens, ContainerEq(expected_tokens));
+}
+
+TEST(Utils, split_returns_one_token_if_no_delimiter)
+{
+    const std::string content{"no delimiter here"};
+    const std::string delimiter{":"};
+
+    const auto tokens = mp::utils::split(content, delimiter);
+    ASSERT_THAT(tokens.size(), Eq(1u));
+
+    EXPECT_THAT(tokens[0], StrEq(content));
 }

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -328,3 +328,10 @@ TEST(Utils, split_returns_one_token_if_no_delimiter)
 
     EXPECT_THAT(tokens[0], StrEq(content));
 }
+
+TEST(Utils, has_only_digits_works)
+{
+    EXPECT_FALSE(mp::utils::has_only_digits("124ft:,"));
+    EXPECT_TRUE(mp::utils::has_only_digits("0123456789"));
+    EXPECT_FALSE(mp::utils::has_only_digits("0123456789:'`'"));
+}


### PR DESCRIPTION
Split from albaguirre:support-remote-clients, as we may do passphrases instead of local registration.

