### PR TITLE
sftp-server: Remove QDir::System filter

### DIFF
--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -518,7 +518,7 @@ int mp::SftpServer::handle_opendir(sftp_client_message msg)
     if (!dir.isReadable())
         return reply_perm_denied(msg);
 
-    auto entry_list = std::make_unique<QStringList>(dir.entryList(QDir::AllEntries | QDir::System | QDir::Hidden));
+    auto entry_list = std::make_unique<QStringList>(dir.entryList(QDir::AllEntries | QDir::Hidden));
 
     SftpHandleUPtr sftp_handle{sftp_handle_alloc(sftp_server_session.get(), entry_list.get()), ssh_string_free};
     open_dir_handles.emplace(entry_list.get(), std::move(entry_list));


### PR DESCRIPTION
Remove the QDir::System filter as it can sometimes lead to unpredictable behavior when
listing files.

Fixes #335