### PR TITLE
Revert "sftp-server: Remove QDir::System filter"

### DIFF
--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -518,7 +518,7 @@ int mp::SftpServer::handle_opendir(sftp_client_message msg)
     if (!dir.isReadable())
         return reply_perm_denied(msg);
 
-    auto entry_list = std::make_unique<QStringList>(dir.entryList(QDir::AllEntries | QDir::Hidden));
+    auto entry_list = std::make_unique<QStringList>(dir.entryList(QDir::AllEntries | QDir::System | QDir::Hidden));
 
     SftpHandleUPtr sftp_handle{sftp_handle_alloc(sftp_server_session.get(), entry_list.get()), ssh_string_free};
     open_dir_handles.emplace(entry_list.get(), std::move(entry_list));


### PR DESCRIPTION
Removing the filter has even more unintended consequences than leaving it there.

This reverts commit 6c7b340f539c16acac9873b6625de41be16442a2.