### PR TITLE
metrics: Use a YAML config file for holding the metrics opt-in data

### DIFF
--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -52,6 +52,12 @@ struct VMSpecs
     std::unordered_map<std::string, VMMount> mounts;
 };
 
+struct MetricsOptInData
+{
+    OptInStatus::Status opt_in_status;
+    int delay_opt_in_count;
+};
+
 struct DaemonConfig;
 class Daemon : public QObject, public multipass::Rpc::Service, public multipass::VMStatusMonitor
 {
@@ -110,7 +116,7 @@ private:
     DaemonRpc daemon_rpc;
     QTimer source_images_maintenance_task;
     MetricsProvider metrics_provider;
-    OptInStatus::Status metrics_opt_in;
+    MetricsOptInData metrics_opt_in;
 };
 }
 #endif // MULTIPASS_DAEMON_H

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -104,10 +104,6 @@ struct Daemon : public Test
         config_builder.client_cert_store = std::make_unique<mpt::StubCertStore>();
         config_builder.connection_type = mp::RpcConnectionType::insecure;
         config_builder.logger = std::make_unique<mpt::StubLogger>();
-
-        QFile opt_in_file{QDir(data_dir.path()).filePath("multipassd-send-metrics")};
-        opt_in_file.open(QIODevice::WriteOnly);
-        opt_in_file.write(QByteArray::number(static_cast<int>(mp::OptInStatus::DENIED)));
     }
 
     mpt::MockVirtualMachineFactory* use_a_mock_vm_factory()


### PR DESCRIPTION
This includes the status of the opt-in as well as a counter that will prompt the
user on the third launch and every third launch if the user chooses `Later`.