### PR TITLE
metrics_provider: Persist metrics in case daemon exits

### DIFF
--- a/include/multipass/metrics_provider.h
+++ b/include/multipass/metrics_provider.h
@@ -19,6 +19,7 @@
 #define MULTIPASS_METRICS_PROVIDER_H
 
 #include <multipass/auto_join_thread.h>
+#include <multipass/path.h>
 
 #include <QByteArray>
 #include <QJsonArray>
@@ -34,8 +35,8 @@ namespace multipass
 class MetricsProvider
 {
 public:
-    MetricsProvider(const QUrl& url, const QString& unique_id);
-    MetricsProvider(const QString& metrics_url, const QString& unique_id);
+    MetricsProvider(const QUrl& url, const QString& unique_id, const Path& path);
+    MetricsProvider(const QString& metrics_url, const QString& unique_id, const Path& path);
     ~MetricsProvider();
 
     bool send_metrics();
@@ -46,6 +47,7 @@ private:
 
     const QUrl metrics_url;
     const QString unique_id;
+    const Path& data_path;
     QJsonArray metric_batches;
 
     std::mutex metrics_mutex;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -396,7 +396,7 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
     : config{std::move(the_config)},
       vm_instance_specs{load_db(config->data_directory, config->cache_directory)},
       daemon_rpc{config->server_address, config->connection_type, *config->cert_provider, *config->client_cert_store},
-      metrics_provider{metrics_url, get_unique_id(config->data_directory)},
+      metrics_provider{metrics_url, get_unique_id(config->data_directory), config->data_directory},
       metrics_opt_in{get_metrics_opt_in(config->data_directory)}
 {
     connect_rpc(daemon_rpc, *this);

--- a/tests/test_metrics_provider.cpp
+++ b/tests/test_metrics_provider.cpp
@@ -18,6 +18,7 @@
 #include <multipass/metrics_provider.h>
 #include <multipass/utils.h>
 
+#include "temp_dir.h"
 #include "temp_file.h"
 
 #include <QDateTime>
@@ -57,13 +58,14 @@ struct MetricsProvider : public testing::Test
     }
 
     mpt::TempFile metrics_file;
+    mpt::TempDir metrics_dir;
 };
 } // namespace
 
 TEST_F(MetricsProvider, opt_in_metrics_valid)
 {
     const auto unique_id = mp::utils::make_uuid();
-    mp::MetricsProvider metrics_provider{metrics_file.url(), unique_id};
+    mp::MetricsProvider metrics_provider{metrics_file.url(), unique_id, metrics_dir.path()};
     metrics_provider.send_metrics();
 
     wait_for_metrics();
@@ -129,7 +131,7 @@ TEST_F(MetricsProvider, opt_in_metrics_valid)
 TEST_F(MetricsProvider, opt_out_denied_valid)
 {
     const auto unique_id = mp::utils::make_uuid();
-    mp::MetricsProvider metrics_provider{metrics_file.url(), unique_id};
+    mp::MetricsProvider metrics_provider{metrics_file.url(), unique_id, metrics_dir.path()};
     metrics_provider.send_denied();
 
     wait_for_metrics();


### PR DESCRIPTION
In case the daemon exits while the provider is trying to send the metrics,
persist the metrics so they can be retried after the daemon starts again.