### PR TITLE
change boot wait message

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -621,7 +621,7 @@ try // clang-format on
     vm->start();
     vm->wait_until_ssh_up(std::chrono::minutes(5));
 
-    reply.set_create_message("Waiting for boot and initialization to complete");
+    reply.set_create_message("Waiting for initialization to complete");
     server->Write(reply);
     vm->wait_for_cloud_init(std::chrono::minutes(5));
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -621,7 +621,7 @@ try // clang-format on
     vm->start();
     vm->wait_until_ssh_up(std::chrono::minutes(5));
 
-    reply.set_create_message("Waiting for cloud-init to complete");
+    reply.set_create_message("Waiting for boot and initialization to complete");
     server->Write(reply);
     vm->wait_for_cloud_init(std::chrono::minutes(5));
 


### PR DESCRIPTION
Rather than make the user think cloud-init is the only thing running in the background, update the message to instead be more generic while waiting for system to boot and initialize.