### PR TITLE
cloud-init: use status subcommand

### DIFF
--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -177,7 +177,7 @@ void mp::utils::wait_for_cloud_init(mp::VirtualMachine* virtual_machine, std::ch
         {
             mp::SSHSession session{virtual_machine->ssh_hostname(), virtual_machine->ssh_port(),
                                    virtual_machine->ssh_username(), virtual_machine->key_provider};
-            auto ssh_process = session.exec({"[ -e /var/lib/cloud/instance/boot-finished ]"});
+            auto ssh_process = session.exec({"cloud-init status"});
             return ssh_process.exit_code() == 0 ? mp::utils::TimeoutAction::done : mp::utils::TimeoutAction::retry;
         }
         catch (const std::exception& e)


### PR DESCRIPTION
The cloud-init command has a status subcommand that can be used to
determine when cloud-init is complete instead of waiting for the
specific file.

There is also a --wait flag that can be used to wait while boot is on-going as well, but to remain consistent with the previous behavior of checking and re-trying I omitted this option flag.