### PR TITLE
3rd-party: Update libssh

### DIFF
--- a/3rd-party/libssh/CMakeLists.txt
+++ b/3rd-party/libssh/CMakeLists.txt
@@ -37,7 +37,10 @@ include_directories(${LIBSSH_INCLUDE_DIR})
 include_directories(${OPENSSL_INCLUDE_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/libssh)
 
+find_package(Threads)
+
 # libssh source needs the config.h header to be generated
+include(libssh/cmake/Modules/AddCCompilerFlag.cmake)
 include(libssh/ConfigureChecks.cmake)
 configure_file(libssh/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/libssh/config.h)
 

--- a/src/ssh/ssh_process.cpp
+++ b/src/ssh/ssh_process.cpp
@@ -64,7 +64,7 @@ auto make_channel(ssh_session ssh_session, const std::string& cmd)
     mp::SSH::throw_on_error(ssh_channel_request_exec, channel, cmd.c_str());
     return channel;
 }
-}
+} // namespace
 
 mp::SSHProcess::SSHProcess(ssh_session session, const std::string& cmd)
     : session{session}, cmd{cmd}, channel{make_channel(session, cmd)}
@@ -104,6 +104,10 @@ std::string mp::SSHProcess::read_std_error()
 
 std::string mp::SSHProcess::read_stream(StreamType type, int timeout)
 {
+    // If the channel is closed there's no output to read
+    if (ssh_channel_is_closed(channel.get()))
+        return std::string();
+
     std::stringstream output;
     std::array<char, 256> buffer;
     int num_bytes{0};
@@ -112,7 +116,16 @@ std::string mp::SSHProcess::read_stream(StreamType type, int timeout)
     {
         num_bytes = ssh_channel_read_timeout(channel.get(), buffer.data(), buffer.size(), is_std_err, timeout);
         if (num_bytes < 0)
-            throw std::runtime_error("error reading ssh channel");
+        {
+            // Latest libssh now returns an error if the channel has been closed instead of returning 0 bytes
+            //
+            if (ssh_channel_is_closed(channel.get()))
+                return std::string();
+
+            throw std::runtime_error(fmt::format("error while reading ssh channel for remote process '{}'"
+                                                 " - error: {}",
+                                                 cmd, num_bytes));
+        }
         output.write(buffer.data(), num_bytes);
     } while (num_bytes > 0);
 

--- a/src/ssh/ssh_session.cpp
+++ b/src/ssh/ssh_session.cpp
@@ -13,8 +13,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
 #include <multipass/ssh/ssh_session.h>
@@ -25,71 +23,14 @@
 #include <libssh/callbacks.h>
 #include <libssh/socket.h>
 
-#include <mutex>
 #include <sstream>
 #include <stdexcept>
-#include <thread>
 
 namespace mp = multipass;
 
-namespace
-{
-int mutex_init(void** priv)
-{
-    auto mutex = new std::mutex();
-    *priv = mutex;
-    return 0;
-}
-
-int mutex_destroy(void** lock)
-{
-    auto mutex = reinterpret_cast<std::mutex*>(*lock);
-    delete mutex;
-    return 0;
-}
-
-int mutex_lock(void** lock)
-{
-    auto mutex = reinterpret_cast<std::mutex*>(*lock);
-    mutex->lock();
-    return 0;
-}
-
-int mutex_unlock(void** lock)
-{
-    auto mutex = reinterpret_cast<std::mutex*>(*lock);
-    mutex->unlock();
-    return 0;
-}
-
-unsigned long thread_id()
-{
-    // libssh + boringSSL do not use the given thread id
-    return 0;
-}
-
-void init_ssh()
-{
-    static struct ssh_threads_callbacks_struct mutex_wrappers
-    {
-        "cpp11_mutex", mutex_init, mutex_destroy, mutex_lock, mutex_unlock, thread_id
-    };
-    ssh_threads_set_callbacks(&mutex_wrappers);
-    ssh_init();
-}
-
-auto initialize_session()
-{
-    static std::once_flag flag;
-    std::call_once(flag, init_ssh);
-
-    return ssh_new();
-}
-}
-
 mp::SSHSession::SSHSession(const std::string& host, int port, const std::string& username,
                            const SSHKeyProvider* key_provider)
-    : session{initialize_session(), ssh_free}
+    : session{ssh_new(), ssh_free}
 {
     if (session == nullptr)
         throw std::runtime_error("Could not allocate ssh session");


### PR DESCRIPTION
Use newest libssh version.

When attempting to read a stream, a closed channel means there's
no data - make sure to check this condition instead of reporting
an error.

Since 0.8, libssh no longer requires a mutex/threads implementation
nor does it need an explicit call to ssh_init() to initialize the
library.