### PR TITLE
tests: ssh: Ensure ssh_channel_is_closed is mocked

### DIFF
--- a/tests/c_mock_defines.cmake
+++ b/tests/c_mock_defines.cmake
@@ -33,6 +33,7 @@ add_c_mocks(
   ssh_is_connected
   ssh_options_set
   ssh_userauth_publickey
+  ssh_channel_is_closed
   ssh_channel_new
   ssh_channel_open_session
   ssh_channel_request_exec

--- a/tests/mock_ssh.cpp
+++ b/tests/mock_ssh.cpp
@@ -23,6 +23,7 @@ extern "C"
     IMPL_MOCK_DEFAULT(1, ssh_is_connected);
     IMPL_MOCK_DEFAULT(3, ssh_options_set);
     IMPL_MOCK_DEFAULT(3, ssh_userauth_publickey);
+    IMPL_MOCK_DEFAULT(1, ssh_channel_is_closed);
     IMPL_MOCK_DEFAULT(1, ssh_channel_new);
     IMPL_MOCK_DEFAULT(1, ssh_channel_open_session);
     IMPL_MOCK_DEFAULT(2, ssh_channel_request_exec);

--- a/tests/mock_ssh.h
+++ b/tests/mock_ssh.h
@@ -28,6 +28,7 @@ DECL_MOCK(ssh_connect);
 DECL_MOCK(ssh_is_connected);
 DECL_MOCK(ssh_options_set);
 DECL_MOCK(ssh_userauth_publickey);
+DECL_MOCK(ssh_channel_is_closed);
 DECL_MOCK(ssh_channel_new);
 DECL_MOCK(ssh_channel_open_session);
 DECL_MOCK(ssh_channel_request_exec);

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -104,6 +104,7 @@ struct SshfsMount : public mp::test::SftpServerTest
     SshfsMount()
     {
         channel_read.returnValue(0);
+        channel_is_closed.returnValue(0);
     }
 
     mp::SshfsMount make_sshfsmount()
@@ -143,6 +144,7 @@ struct SshfsMount : public mp::test::SftpServerTest
 
     ExitStatusMock exit_status_mock;
     decltype(MOCK(ssh_channel_read_timeout)) channel_read{MOCK(ssh_channel_read_timeout)};
+    decltype(MOCK(ssh_channel_is_closed)) channel_is_closed{MOCK(ssh_channel_is_closed)};
 
     std::string default_source{"source"};
     std::string default_target{"target"};


### PR DESCRIPTION
Mock ssh_channel_is_closed.

Include tests that verify SSHProcess deals with closed channels
appropriately.