### PR TITLE
Allow forwarding of log messages from daemon to client

### DIFF
--- a/include/multipass/cli/argparser.h
+++ b/include/multipass/cli/argparser.h
@@ -57,6 +57,8 @@ public:
     void forceCommandHelp();
     void forceGeneralHelp();
 
+    int verbosityLevel() const;
+
 private:
     QString generalHelpText();
     QString helpText(cmd::Command* command);
@@ -68,6 +70,7 @@ private:
     QCommandLineParser parser;
 
     bool help_requested;
+    int verbosity_level{0};
 
     std::ostream& cout;
     std::ostream& cerr;

--- a/include/multipass/logging/client_logger.h
+++ b/include/multipass/logging/client_logger.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_CLIENT_LOGGER_H
+#define MULTIPASS_CLIENT_LOGGER_H
+
+#include <multipass/logging/logger.h>
+#include <multipass/logging/multiplexing_logger.h>
+#include <multipass/rpc/multipass.grpc.pb.h>
+#include <multipass/utils.h>
+
+#include <fmt/format.h>
+
+namespace multipass
+{
+namespace logging
+{
+template <typename T>
+class ClientLogger : public Logger
+{
+public:
+    ClientLogger(Level level, MultiplexingLogger& mpx, grpc::ServerWriter<T>* server)
+        : logging_level{level}, server{server}, mpx_logger{mpx}
+    {
+        mpx_logger.add_logger(this);
+    }
+
+    ~ClientLogger()
+    {
+        mpx_logger.remove_logger(this);
+    }
+
+    void log(Level level, CString category, CString message) const override
+    {
+        if (level <= logging_level && server != nullptr)
+        {
+            T reply;
+            reply.set_log_line(fmt::format("[{}] [{}] [{}] {}\n", multipass::utils::timestamp(),
+                                           as_string(level).c_str(), category.c_str(), message.c_str()));
+            server->Write(reply);
+        }
+    }
+
+private:
+    Level logging_level;
+    grpc::ServerWriter<T>* server;
+    MultiplexingLogger& mpx_logger;
+};
+} // namespace logging
+} // namespace multipass
+
+#endif // MULTIPASS_CLIENT_LOGGER_H

--- a/include/multipass/logging/level.h
+++ b/include/multipass/logging/level.h
@@ -53,6 +53,11 @@ constexpr auto enum_type(Level e) noexcept
     return static_cast<std::underlying_type_t<Level>>(e);
 }
 
+constexpr Level level_from(std::underlying_type_t<Level> in)
+{
+    return static_cast<Level>(in);
+}
+
 constexpr bool operator<(Level a, Level b) noexcept
 {
     return enum_type(a) < enum_type(b);

--- a/include/multipass/logging/multiplexing_logger.h
+++ b/include/multipass/logging/multiplexing_logger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,31 +15,31 @@
  *
  */
 
-#ifndef MULTIPASS_MOUNT_H
-#define MULTIPASS_MOUNT_H
+#ifndef MULTIPASS_MULTIPLEXING_LOGGER_H
+#define MULTIPASS_MULTIPLEXING_LOGGER_H
 
-#include <multipass/cli/command.h>
+#include "logger.h"
+
+#include <memory>
+#include <shared_mutex>
+#include <vector>
 
 namespace multipass
 {
-namespace cmd
+namespace logging
 {
-class Mount final : public Command
+class MultiplexingLogger : public Logger
 {
 public:
-    using Command::Command;
-    ReturnCode run(ArgParser *parser) override;
-
-    std::string name() const override;
-    QString short_help() const override;
-    QString description() const override;
+    void log(Level level, CString category, CString message) const override;
+    void add_logger(const Logger* logger);
+    void remove_logger(const Logger* logger);
 
 private:
-    MountRequest request;
-
-    ParseCode parse_args(ArgParser *parser) override;
-    ReturnCode install_sshfs(const std::string& instance_name, int verbosity_level);
+    mutable std::shared_timed_mutex mutex;
+    std::vector<const Logger*> loggers;
 };
-}
-}
-#endif // MULTIPASS_MOUNT_H
+} // namespace logging
+} // namespace multipass
+
+#endif // MULTIPASS_MULTIPLEXING_LOGGER_H

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -61,6 +61,7 @@ std::string& trim_end(std::string& s);
 std::string escape_char(const std::string& s, char c);
 std::vector<std::string> split(const std::string& string, const std::string& delimiter);
 std::string generate_mac_address();
+std::string timestamp();
 void wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
                        std::function<void()> const& process_vm_events = []() { QCoreApplication::processEvents(); });
 void wait_for_cloud_init(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,

--- a/src/client/argparser.cpp
+++ b/src/client/argparser.cpp
@@ -40,8 +40,7 @@ namespace
 {
 auto max_command_string_length(const std::vector<cmd::Command::UPtr>& commands)
 {
-    auto string_len_compare = [](const cmd::Command::UPtr& a, const cmd::Command::UPtr& b)
-    {
+    auto string_len_compare = [](const cmd::Command::UPtr& a, const cmd::Command::UPtr& b) {
         return a->name().length() < b->name().length();
     };
     const auto& max_elem = *std::max_element(commands.begin(), commands.end(), string_len_compare);
@@ -64,7 +63,21 @@ QString format_short_help_for(const std::vector<cmd::Command::UPtr>& commands)
     }
     return output;
 }
+
+auto verbosity_level_in(const QStringList& arguments)
+{
+    for (const QString& arg : arguments)
+    {
+        if (arg == QStringLiteral("-v") || arg == QStringLiteral("--verbose"))
+            return 1;
+        if (arg == QStringLiteral("-vv"))
+            return 2;
+        if (arg == QStringLiteral("-vvv"))
+            return 3;
+    }
+    return 0;
 }
+} // namespace
 
 mp::ArgParser::ArgParser(const QStringList& arguments, const std::vector<cmd::Command::UPtr>& commands,
                          std::ostream& cout, std::ostream& cerr)
@@ -90,16 +103,7 @@ mp::ParseCode mp::ArgParser::parse()
 
     if (parser.isSet(verbose_option))
     {
-        // Need to manually count number of times it is set, QCommandLineParser doesn't do that
-        int count = 0;
-        for (const QString& arg : arguments)
-        {
-            if (arg == QStringLiteral("-v") || arg == QStringLiteral("--verbose"))
-            {
-                count++;
-            }
-        }
-        qDebug("Verbose level: %i", count); // TODO: use this how?
+        verbosity_level = verbosity_level_in(arguments);
     }
 
     help_requested = parser.isSet(help_option);
@@ -309,4 +313,9 @@ QStringList mp::ArgParser::positionalArguments() const
         positionalArguments.pop_front();
     }
     return positionalArguments;
+}
+
+int mp::ArgParser::verbosityLevel() const
+{
+    return verbosity_level;
 }

--- a/src/client/cmd/copy_files.cpp
+++ b/src/client/cmd/copy_files.cpp
@@ -81,6 +81,7 @@ mp::ReturnCode cmd::CopyFiles::run(mp::ArgParser* parser)
         return return_code_for(status.error_code());
     };
 
+    request.set_verbosity_level(parser->verbosityLevel());
     return dispatch(&RpcMethod::ssh_info, request, on_success, on_failure);
 }
 
@@ -212,6 +213,5 @@ mp::ParseCode cmd::CopyFiles::parse_args(mp::ArgParser* parser)
     }
 
     destination = std::make_pair(instance_name.toStdString(), destination_path.toStdString());
-
     return ParseCode::Ok;
 }

--- a/src/client/cmd/delete.cpp
+++ b/src/client/cmd/delete.cpp
@@ -38,6 +38,7 @@ mp::ReturnCode cmd::Delete::run(mp::ArgParser* parser)
         return return_code_for(status.error_code());
     };
 
+    request.set_verbosity_level(parser->verbosityLevel());
     return dispatch(&RpcMethod::delet, request, on_success, on_failure);
 }
 

--- a/src/client/cmd/exec.cpp
+++ b/src/client/cmd/exec.cpp
@@ -13,8 +13,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
 #include "exec.h"
@@ -45,6 +43,7 @@ mp::ReturnCode cmd::Exec::run(mp::ArgParser* parser)
         return return_code_for(status.error_code());
     };
 
+    request.set_verbosity_level(parser->verbosityLevel());
     return dispatch(&RpcMethod::ssh_info, request, on_success, on_failure);
 }
 

--- a/src/client/cmd/find.cpp
+++ b/src/client/cmd/find.cpp
@@ -103,6 +103,7 @@ mp::ReturnCode cmd::Find::run(mp::ArgParser* parser)
         return return_code_for(status.error_code());
     };
 
+    request.set_verbosity_level(parser->verbosityLevel());
     return dispatch(&RpcMethod::find, request, on_success, on_failure);
 }
 

--- a/src/client/cmd/info.cpp
+++ b/src/client/cmd/info.cpp
@@ -46,6 +46,7 @@ mp::ReturnCode cmd::Info::run(mp::ArgParser* parser)
         return return_code_for(status.error_code());
     };
 
+    request.set_verbosity_level(parser->verbosityLevel());
     return dispatch(&RpcMethod::info, request, on_success, on_failure);
 }
 

--- a/src/client/cmd/launch.cpp
+++ b/src/client/cmd/launch.cpp
@@ -167,6 +167,8 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
         }
     }
 
+    request.set_verbosity_level(parser->verbosityLevel());
+
     return status;
 }
 

--- a/src/client/cmd/list.cpp
+++ b/src/client/cmd/list.cpp
@@ -13,8 +13,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
 #include "list.h"
@@ -47,6 +45,7 @@ mp::ReturnCode cmd::List::run(mp::ArgParser* parser)
     };
 
     ListRequest request;
+    request.set_verbosity_level(parser->verbosityLevel());
     return dispatch(&RpcMethod::list, request, on_success, on_failure);
 }
 

--- a/src/client/cmd/purge.cpp
+++ b/src/client/cmd/purge.cpp
@@ -39,6 +39,7 @@ mp::ReturnCode cmd::Purge::run(mp::ArgParser* parser)
     };
 
     mp::PurgeRequest request;
+    request.set_verbosity_level(parser->verbosityLevel());
     return dispatch(&RpcMethod::purge, request, on_success, on_failure);
 }
 

--- a/src/client/cmd/recover.cpp
+++ b/src/client/cmd/recover.cpp
@@ -13,8 +13,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
 #include "recover.h"
@@ -42,6 +40,7 @@ mp::ReturnCode cmd::Recover::run(mp::ArgParser* parser)
         return return_code_for(status.error_code());
     };
 
+    request.set_verbosity_level(parser->verbosityLevel());
     return dispatch(&RpcMethod::recover, request, on_success, on_failure);
 }
 

--- a/src/client/cmd/shell.cpp
+++ b/src/client/cmd/shell.cpp
@@ -13,8 +13,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
 #include "shell.h"
@@ -65,6 +63,7 @@ mp::ReturnCode cmd::Shell::run(mp::ArgParser* parser)
         return return_code_for(status.error_code());
     };
 
+    request.set_verbosity_level(parser->verbosityLevel());
     return dispatch(&RpcMethod::ssh_info, request, on_success, on_failure);
 }
 

--- a/src/client/cmd/start.cpp
+++ b/src/client/cmd/start.cpp
@@ -13,8 +13,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
 #include "start.h"
@@ -84,6 +82,8 @@ mp::ReturnCode cmd::Start::run(mp::ArgParser* parser)
     else
         message.append(request.instance_name().Get(0));
     spinner.start(message);
+
+    request.set_verbosity_level(parser->verbosityLevel());
     return dispatch(&RpcMethod::start, request, on_success, on_failure);
 }
 

--- a/src/client/cmd/stop.cpp
+++ b/src/client/cmd/stop.cpp
@@ -13,8 +13,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
 #include "stop.h"
@@ -55,6 +53,7 @@ mp::ReturnCode cmd::Stop::run(mp::ArgParser* parser)
     else
         message.append(request.instance_name().Get(0));
     spinner.start(message);
+    request.set_verbosity_level(parser->verbosityLevel());
     return dispatch(&RpcMethod::stop, request, on_success, on_failure);
 }
 

--- a/src/client/cmd/umount.cpp
+++ b/src/client/cmd/umount.cpp
@@ -40,6 +40,7 @@ mp::ReturnCode cmd::Umount::run(mp::ArgParser* parser)
         return return_code_for(status.error_code());
     };
 
+    request.set_verbosity_level(parser->verbosityLevel());
     return dispatch(&RpcMethod::umount, request, on_success, on_failure);
 }
 

--- a/src/client/cmd/version.cpp
+++ b/src/client/cmd/version.cpp
@@ -13,8 +13,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
 #include "version.h"
@@ -44,6 +42,7 @@ mp::ReturnCode cmd::Version::run(mp::ArgParser* parser)
     auto on_failure = [](grpc::Status& status) { return ReturnCode::Ok; };
 
     mp::VersionRequest request;
+    request.set_verbosity_level(parser->verbosityLevel());
     return dispatch(&RpcMethod::version, request, on_success, on_failure);
 }
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -22,6 +22,7 @@
 #include <multipass/cloud_init_iso.h>
 #include <multipass/exceptions/sshfs_missing_error.h>
 #include <multipass/exceptions/start_exception.h>
+#include <multipass/logging/client_logger.h>
 #include <multipass/logging/log.h>
 #include <multipass/name_generator.h>
 #include <multipass/platform.h>
@@ -499,6 +500,7 @@ grpc::Status mp::Daemon::launch(grpc::ServerContext* context, const LaunchReques
                                 grpc::ServerWriter<LaunchReply>* server) // clang-format off
 try // clang-format on
 {
+    mpl::ClientLogger<LaunchReply> logger{mpl::level_from(request->verbosity_level()), *config->logger, server};
     if (metrics_opt_in.opt_in_status == OptInStatus::UNKNOWN || metrics_opt_in.opt_in_status == OptInStatus::LATER)
     {
         if (++metrics_opt_in.delay_opt_in_count % 3 == 0)
@@ -646,7 +648,7 @@ catch (const std::exception& e)
 }
 
 grpc::Status mp::Daemon::purge(grpc::ServerContext* context, const PurgeRequest* request,
-                               PurgeReply* response) // clang-format off
+                               grpc::ServerWriter<PurgeReply>* server) // clang-format off
 try // clang-format on
 {
     std::vector<decltype(deleted_instances)::key_type> keys_to_delete;
@@ -673,9 +675,12 @@ catch (const std::exception& e)
 }
 
 grpc::Status mp::Daemon::find(grpc::ServerContext* context, const FindRequest* request,
-                              FindReply* response) // clang-format off
+                              grpc::ServerWriter<FindReply>* server) // clang-format off
 try // clang-format on
 {
+    mpl::ClientLogger<FindReply> logger{mpl::level_from(request->verbosity_level()), *config->logger, server};
+    FindReply response;
+
     if (!request->search_string().empty())
     {
         if (!request->remote_name().empty())
@@ -717,7 +722,7 @@ try // clang-format on
                 name.resize(12);
             }
 
-            auto entry = response->add_images_info();
+            auto entry = response.add_images_info();
             entry->set_release(info.release_title.toStdString());
             entry->set_version(info.version.toStdString());
             auto alias_entry = entry->add_aliases_info();
@@ -738,7 +743,7 @@ try // clang-format on
         {
             if (!info.aliases.empty())
             {
-                auto entry = response->add_images_info();
+                auto entry = response.add_images_info();
                 for (const auto& alias : info.aliases)
                 {
                     if (!mp::platform::is_alias_supported(alias.toStdString()))
@@ -758,7 +763,7 @@ try // clang-format on
     {
         {
             auto action = [&response](const std::string& dummy, const mp::VMImageInfo& info) {
-                auto entry = response->add_images_info();
+                auto entry = response.add_images_info();
                 for (const auto& alias : info.aliases)
                 {
                     if (!mp::platform::is_alias_supported(alias.toStdString()))
@@ -787,7 +792,7 @@ try // clang-format on
                     {
                         if (!info.aliases.empty())
                         {
-                            auto entry = response->add_images_info();
+                            auto entry = response.add_images_info();
                             for (const auto& alias : info.aliases)
                             {
                                 if (!mp::platform::is_alias_supported(alias.toStdString()))
@@ -809,6 +814,7 @@ try // clang-format on
             config->image_hosts.back()->for_each_entry_do(action);
         }
     }
+    server->Write(response);
     return grpc::Status::OK;
 }
 catch (const std::exception& e)
@@ -817,9 +823,12 @@ catch (const std::exception& e)
 }
 
 grpc::Status mp::Daemon::info(grpc::ServerContext* context, const InfoRequest* request,
-                              InfoReply* response) // clang-format off
+                              grpc::ServerWriter<InfoReply>* server) // clang-format off
 try // clang-format on
 {
+    mpl::ClientLogger<InfoReply> logger{mpl::level_from(request->verbosity_level()), *config->logger, server};
+    InfoReply response;
+
     fmt::memory_buffer errors;
     std::vector<decltype(vm_instances)::key_type> instances_for_info;
 
@@ -849,7 +858,7 @@ try // clang-format on
             deleted = true;
         }
 
-        auto info = response->add_info();
+        auto info = response.add_info();
         auto& vm = it->second;
         info->set_name(name);
         if (deleted)
@@ -947,6 +956,8 @@ try // clang-format on
 
     if (errors.size() > 0)
         return grpc_status_for(errors);
+
+    server->Write(response);
     return grpc::Status::OK;
 }
 catch (const std::exception& e)
@@ -955,9 +966,12 @@ catch (const std::exception& e)
 }
 
 grpc::Status mp::Daemon::list(grpc::ServerContext* context, const ListRequest* request,
-                              ListReply* response) // clang-format off
+                              grpc::ServerWriter<ListReply>* server) // clang-format off
 try // clang-format on
 {
+    mpl::ClientLogger<ListReply> logger{mpl::level_from(request->verbosity_level()), *config->logger, server};
+    ListReply response;
+
     auto status_for = [](mp::VirtualMachine::State state) {
         switch (state)
         {
@@ -980,7 +994,7 @@ try // clang-format on
     {
         const auto& name = instance.first;
         const auto& vm = instance.second;
-        auto entry = response->add_instances();
+        auto entry = response.add_instances();
         entry->set_name(name);
         entry->mutable_instance_status()->set_status(status_for(vm->current_state()));
 
@@ -1011,11 +1025,12 @@ try // clang-format on
     for (const auto& instance : deleted_instances)
     {
         const auto& name = instance.first;
-        auto entry = response->add_instances();
+        auto entry = response.add_instances();
         entry->set_name(name);
         entry->mutable_instance_status()->set_status(mp::InstanceStatus::DELETED);
     }
 
+    server->Write(response);
     return grpc::Status::OK;
 }
 catch (const std::exception& e)
@@ -1024,9 +1039,11 @@ catch (const std::exception& e)
 }
 
 grpc::Status mp::Daemon::mount(grpc::ServerContext* context, const MountRequest* request,
-                               MountReply* response) // clang-format off
+                               grpc::ServerWriter<MountReply>* server) // clang-format off
 try // clang-format on
 {
+    mpl::ClientLogger<MountReply> logger{mpl::level_from(request->verbosity_level()), *config->logger, server};
+
     QFileInfo source_dir(QString::fromStdString(request->source_path()));
     if (!source_dir.exists())
     {
@@ -1127,9 +1144,11 @@ catch (const std::exception& e)
 }
 
 grpc::Status mp::Daemon::recover(grpc::ServerContext* context, const RecoverRequest* request,
-                                 RecoverReply* response) // clang-format off
+                                 grpc::ServerWriter<RecoverReply>* server) // clang-format off
 try // clang-format on
 {
+    mpl::ClientLogger<RecoverReply> logger{mpl::level_from(request->verbosity_level()), *config->logger, server};
+
     fmt::memory_buffer errors;
     std::vector<decltype(deleted_instances)::key_type> instances_to_recover;
     for (const auto& name : request->instance_name())
@@ -1172,9 +1191,12 @@ catch (const std::exception& e)
 }
 
 grpc::Status mp::Daemon::ssh_info(grpc::ServerContext* context, const SSHInfoRequest* request,
-                                  SSHInfoReply* response) // clang-format off
+                                  grpc::ServerWriter<SSHInfoReply>* server) // clang-format off
 try // clang-format on
 {
+    mpl::ClientLogger<SSHInfoReply> logger{mpl::level_from(request->verbosity_level()), *config->logger, server};
+    SSHInfoReply response;
+
     for (const auto& name : request->instance_name())
     {
         auto it = vm_instances.find(name);
@@ -1195,9 +1217,10 @@ try // clang-format on
         ssh_info.set_port(it->second->ssh_port());
         ssh_info.set_priv_key_base64(config->ssh_key_provider->private_key_as_base64());
         ssh_info.set_username(it->second->ssh_username());
-        (*response->mutable_ssh_info())[name] = ssh_info;
+        (*response.mutable_ssh_info())[name] = ssh_info;
     }
 
+    server->Write(response);
     return grpc::Status::OK;
 }
 catch (const std::exception& e)
@@ -1206,9 +1229,11 @@ catch (const std::exception& e)
 }
 
 grpc::Status mp::Daemon::start(grpc::ServerContext* context, const StartRequest* request,
-                               StartReply* response) // clang-format off
+                               grpc::ServerWriter<StartReply>* server) // clang-format off
 try // clang-format on
 {
+    mpl::ClientLogger<StartReply> logger{mpl::level_from(request->verbosity_level()), *config->logger, server};
+
     config->factory->check_hypervisor_support();
 
     std::vector<decltype(vm_instances)::key_type> vms;
@@ -1318,9 +1343,11 @@ catch (const std::exception& e)
 }
 
 grpc::Status mp::Daemon::stop(grpc::ServerContext* context, const StopRequest* request,
-                              StopReply* response) // clang-format off
+                              grpc::ServerWriter<StopReply>* server) // clang-format off
 try // clang-format on
 {
+    mpl::ClientLogger<StopReply> logger{mpl::level_from(request->verbosity_level()), *config->logger, server};
+
     fmt::memory_buffer errors;
     std::vector<decltype(vm_instances)::key_type> instances_to_stop;
     for (const auto& name : request->instance_name())
@@ -1383,9 +1410,11 @@ catch (const std::exception& e)
 }
 
 grpc::Status mp::Daemon::delet(grpc::ServerContext* context, const DeleteRequest* request,
-                               DeleteReply* response) // clang-format off
+                               grpc::ServerWriter<DeleteReply>* server) // clang-format off
 try // clang-format on
 {
+    mpl::ClientLogger<DeleteReply> logger{mpl::level_from(request->verbosity_level()), *config->logger, server};
+
     fmt::memory_buffer errors;
     std::vector<decltype(vm_instances)::key_type> instances_to_delete;
     for (const auto& name : request->instance_name())
@@ -1442,9 +1471,11 @@ catch (const std::exception& e)
 }
 
 grpc::Status mp::Daemon::umount(grpc::ServerContext* context, const UmountRequest* request,
-                                UmountReply* response) // clang-format off
+                                grpc::ServerWriter<UmountReply>* server) // clang-format off
 try // clang-format on
 {
+    mpl::ClientLogger<UmountReply> logger{mpl::level_from(request->verbosity_level()), *config->logger, server};
+
     fmt::memory_buffer errors;
     for (const auto& path_entry : request->target_paths())
     {
@@ -1522,9 +1553,14 @@ catch (const std::exception& e)
     return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), "");
 }
 
-grpc::Status mp::Daemon::version(grpc::ServerContext* context, const VersionRequest* request, VersionReply* response)
+grpc::Status mp::Daemon::version(grpc::ServerContext* context, const VersionRequest* request,
+                                 grpc::ServerWriter<VersionReply>* server)
 {
-    response->set_version(multipass::version_string);
+    mpl::ClientLogger<VersionReply> logger{mpl::level_from(request->verbosity_level()), *config->logger, server};
+
+    VersionReply reply;
+    reply.set_version(multipass::version_string);
+    server->Write(reply);
     return grpc::Status::OK;
 }
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -13,8 +13,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
 #ifndef MULTIPASS_DAEMON_H
@@ -78,29 +76,41 @@ public slots:
     grpc::Status launch(grpc::ServerContext* context, const LaunchRequest* request,
                         grpc::ServerWriter<LaunchReply>* reply) override;
 
-    grpc::Status purge(grpc::ServerContext* context, const PurgeRequest* request, PurgeReply* response) override;
+    grpc::Status purge(grpc::ServerContext* context, const PurgeRequest* request,
+                       grpc::ServerWriter<PurgeReply>* response) override;
 
-    grpc::Status find(grpc::ServerContext* context, const FindRequest* request, FindReply* response) override;
+    grpc::Status find(grpc::ServerContext* context, const FindRequest* request,
+                      grpc::ServerWriter<FindReply>* response) override;
 
-    grpc::Status info(grpc::ServerContext* context, const InfoRequest* request, InfoReply* response) override;
+    grpc::Status info(grpc::ServerContext* context, const InfoRequest* request,
+                      grpc::ServerWriter<InfoReply>* response) override;
 
-    grpc::Status list(grpc::ServerContext* context, const ListRequest* request, ListReply* response) override;
+    grpc::Status list(grpc::ServerContext* context, const ListRequest* request,
+                      grpc::ServerWriter<ListReply>* response) override;
 
-    grpc::Status mount(grpc::ServerContext* context, const MountRequest* request, MountReply* response) override;
+    grpc::Status mount(grpc::ServerContext* context, const MountRequest* request,
+                       grpc::ServerWriter<MountReply>* response) override;
 
-    grpc::Status recover(grpc::ServerContext* context, const RecoverRequest* request, RecoverReply* response) override;
+    grpc::Status recover(grpc::ServerContext* context, const RecoverRequest* request,
+                         grpc::ServerWriter<RecoverReply>* response) override;
 
-    grpc::Status ssh_info(grpc::ServerContext* context, const SSHInfoRequest* request, SSHInfoReply* response) override;
+    grpc::Status ssh_info(grpc::ServerContext* context, const SSHInfoRequest* request,
+                          grpc::ServerWriter<SSHInfoReply>* response) override;
 
-    grpc::Status start(grpc::ServerContext* context, const StartRequest* request, StartReply* response) override;
+    grpc::Status start(grpc::ServerContext* context, const StartRequest* request,
+                       grpc::ServerWriter<StartReply>* response) override;
 
-    grpc::Status stop(grpc::ServerContext* context, const StopRequest* request, StopReply* response) override;
+    grpc::Status stop(grpc::ServerContext* context, const StopRequest* request,
+                      grpc::ServerWriter<StopReply>* response) override;
 
-    grpc::Status delet(grpc::ServerContext* context, const DeleteRequest* request, DeleteReply* response) override;
+    grpc::Status delet(grpc::ServerContext* context, const DeleteRequest* request,
+                       grpc::ServerWriter<DeleteReply>* response) override;
 
-    grpc::Status umount(grpc::ServerContext* context, const UmountRequest* request, UmountReply* response) override;
+    grpc::Status umount(grpc::ServerContext* context, const UmountRequest* request,
+                        grpc::ServerWriter<UmountReply>* response) override;
 
-    grpc::Status version(grpc::ServerContext* context, const VersionRequest* request, VersionReply* response) override;
+    grpc::Status version(grpc::ServerContext* context, const VersionRequest* request,
+                         grpc::ServerWriter<VersionReply>* response) override;
 
 private:
     void persist_instances();
@@ -119,5 +129,5 @@ private:
     MetricsProvider metrics_provider;
     MetricsOptInData metrics_opt_in;
 };
-}
+} // namespace multipass
 #endif // MULTIPASS_DAEMON_H

--- a/src/daemon/daemon_config.h
+++ b/src/daemon/daemon_config.h
@@ -22,6 +22,7 @@
 #include <multipass/cert_store.h>
 #include <multipass/days.h>
 #include <multipass/logging/logger.h>
+#include <multipass/logging/multiplexing_logger.h>
 #include <multipass/name_generator.h>
 #include <multipass/path.h>
 #include <multipass/rpc/multipass.grpc.pb.h>
@@ -39,6 +40,7 @@ namespace multipass
 {
 struct DaemonConfig
 {
+    ~DaemonConfig();
     const std::unique_ptr<URLDownloader> url_downloader;
     const std::unique_ptr<VirtualMachineFactory> factory;
     const std::vector<std::unique_ptr<VMImageHost>> image_hosts;
@@ -47,7 +49,8 @@ struct DaemonConfig
     const std::unique_ptr<SSHKeyProvider> ssh_key_provider;
     const std::unique_ptr<CertProvider> cert_provider;
     const std::unique_ptr<CertStore> client_cert_store;
-    const std::shared_ptr<logging::Logger> logger;
+    const std::unique_ptr<logging::Logger> system_logger;
+    const std::shared_ptr<logging::MultiplexingLogger> logger;
     const multipass::Path cache_directory;
     const multipass::Path data_directory;
     const std::string server_address;

--- a/src/daemon/daemon_rpc.cpp
+++ b/src/daemon/daemon_rpc.cpp
@@ -13,8 +13,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
 #include "daemon_rpc.h"
@@ -102,63 +100,74 @@ grpc::Status mp::DaemonRpc::launch(grpc::ServerContext* context, const LaunchReq
     return emit on_launch(context, request, reply); // must block until slot returns
 }
 
-grpc::Status mp::DaemonRpc::purge(grpc::ServerContext* context, const PurgeRequest* request, PurgeReply* response)
+grpc::Status mp::DaemonRpc::purge(grpc::ServerContext* context, const PurgeRequest* request,
+                                  grpc::ServerWriter<PurgeReply>* response)
 {
     return emit on_purge(context, request, response); // must block until slot returns
 }
 
-grpc::Status mp::DaemonRpc::find(grpc::ServerContext* context, const FindRequest* request, FindReply* response)
+grpc::Status mp::DaemonRpc::find(grpc::ServerContext* context, const FindRequest* request,
+                                 grpc::ServerWriter<FindReply>* response)
 {
     return emit on_find(context, request, response); // must block until slot returns
 }
 
-grpc::Status mp::DaemonRpc::info(grpc::ServerContext* context, const InfoRequest* request, InfoReply* response)
+grpc::Status mp::DaemonRpc::info(grpc::ServerContext* context, const InfoRequest* request,
+                                 grpc::ServerWriter<InfoReply>* response)
 {
     return emit on_info(context, request, response); // must block until slot returns
 }
 
-grpc::Status mp::DaemonRpc::list(grpc::ServerContext* context, const ListRequest* request, ListReply* response)
+grpc::Status mp::DaemonRpc::list(grpc::ServerContext* context, const ListRequest* request,
+                                 grpc::ServerWriter<ListReply>* response)
 {
     return emit on_list(context, request, response); // must block until slot returns
 }
 
-grpc::Status mp::DaemonRpc::mount(grpc::ServerContext* context, const MountRequest* request, MountReply* response)
+grpc::Status mp::DaemonRpc::mount(grpc::ServerContext* context, const MountRequest* request,
+                                  grpc::ServerWriter<MountReply>* response)
 {
     return emit on_mount(context, request, response); // must block until slot returns
 }
 
-grpc::Status mp::DaemonRpc::recover(grpc::ServerContext* context, const RecoverRequest* request, RecoverReply* response)
+grpc::Status mp::DaemonRpc::recover(grpc::ServerContext* context, const RecoverRequest* request,
+                                    grpc::ServerWriter<RecoverReply>* response)
 {
     return emit on_recover(context, request, response); // must block until slot returns
 }
 
 grpc::Status mp::DaemonRpc::ssh_info(grpc::ServerContext* context, const SSHInfoRequest* request,
-                                     SSHInfoReply* response)
+                                     grpc::ServerWriter<SSHInfoReply>* response)
 {
     return emit on_ssh_info(context, request, response); // must block until slot returns
 }
 
-grpc::Status mp::DaemonRpc::start(grpc::ServerContext* context, const StartRequest* request, StartReply* response)
+grpc::Status mp::DaemonRpc::start(grpc::ServerContext* context, const StartRequest* request,
+                                  grpc::ServerWriter<StartReply>* response)
 {
     return emit on_start(context, request, response); // must block until slot returns
 }
 
-grpc::Status mp::DaemonRpc::stop(grpc::ServerContext* context, const StopRequest* request, StopReply* response)
+grpc::Status mp::DaemonRpc::stop(grpc::ServerContext* context, const StopRequest* request,
+                                 grpc::ServerWriter<StopReply>* response)
 {
     return emit on_stop(context, request, response); // must block until slot returns
 }
 
-grpc::Status mp::DaemonRpc::delet(grpc::ServerContext* context, const DeleteRequest* request, DeleteReply* response)
+grpc::Status mp::DaemonRpc::delet(grpc::ServerContext* context, const DeleteRequest* request,
+                                  grpc::ServerWriter<DeleteReply>* response)
 {
     return emit on_delete(context, request, response); // must block until slot returns
 }
 
-grpc::Status mp::DaemonRpc::umount(grpc::ServerContext* context, const UmountRequest* request, UmountReply* response)
+grpc::Status mp::DaemonRpc::umount(grpc::ServerContext* context, const UmountRequest* request,
+                                   grpc::ServerWriter<UmountReply>* response)
 {
     return emit on_umount(context, request, response); // must block until slot returns
 }
 
-grpc::Status mp::DaemonRpc::version(grpc::ServerContext* context, const VersionRequest* request, VersionReply* response)
+grpc::Status mp::DaemonRpc::version(grpc::ServerContext* context, const VersionRequest* request,
+                                    grpc::ServerWriter<VersionReply>* response)
 {
     return emit on_version(context, request, response); // must block until slot returns
 }

--- a/src/daemon/daemon_rpc.h
+++ b/src/daemon/daemon_rpc.h
@@ -13,8 +13,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
 #ifndef MULTIPASS_DAEMON_RPC_H
@@ -47,18 +45,30 @@ signals:
     // All these signals must be connected to with a BlockingQueuedConnection!!!
     grpc::Status on_launch(grpc::ServerContext* context, const LaunchRequest* request,
                            grpc::ServerWriter<LaunchReply>* reply);
-    grpc::Status on_purge(grpc::ServerContext* context, const PurgeRequest* request, PurgeReply* response);
-    grpc::Status on_find(grpc::ServerContext* context, const FindRequest* request, FindReply* response);
-    grpc::Status on_info(grpc::ServerContext* context, const InfoRequest* request, InfoReply* response);
-    grpc::Status on_list(grpc::ServerContext* context, const ListRequest* request, ListReply* response);
-    grpc::Status on_mount(grpc::ServerContext* context, const MountRequest* request, MountReply* response);
-    grpc::Status on_recover(grpc::ServerContext* context, const RecoverRequest* request, RecoverReply* response);
-    grpc::Status on_ssh_info(grpc::ServerContext* context, const SSHInfoRequest* request, SSHInfoReply* response);
-    grpc::Status on_start(grpc::ServerContext* context, const StartRequest* request, StartReply* response);
-    grpc::Status on_stop(grpc::ServerContext* context, const StopRequest* request, StopReply* response);
-    grpc::Status on_delete(grpc::ServerContext* context, const DeleteRequest* request, DeleteReply* response);
-    grpc::Status on_umount(grpc::ServerContext* context, const UmountRequest* request, UmountReply* response);
-    grpc::Status on_version(grpc::ServerContext* context, const VersionRequest* request, VersionReply* response);
+    grpc::Status on_purge(grpc::ServerContext* context, const PurgeRequest* request,
+                          grpc::ServerWriter<PurgeReply>* response);
+    grpc::Status on_find(grpc::ServerContext* context, const FindRequest* request,
+                         grpc::ServerWriter<FindReply>* response);
+    grpc::Status on_info(grpc::ServerContext* context, const InfoRequest* request,
+                         grpc::ServerWriter<InfoReply>* response);
+    grpc::Status on_list(grpc::ServerContext* context, const ListRequest* request,
+                         grpc::ServerWriter<ListReply>* response);
+    grpc::Status on_mount(grpc::ServerContext* context, const MountRequest* request,
+                          grpc::ServerWriter<MountReply>* response);
+    grpc::Status on_recover(grpc::ServerContext* context, const RecoverRequest* request,
+                            grpc::ServerWriter<RecoverReply>* response);
+    grpc::Status on_ssh_info(grpc::ServerContext* context, const SSHInfoRequest* request,
+                             grpc::ServerWriter<SSHInfoReply>* response);
+    grpc::Status on_start(grpc::ServerContext* context, const StartRequest* request,
+                          grpc::ServerWriter<StartReply>* response);
+    grpc::Status on_stop(grpc::ServerContext* context, const StopRequest* request,
+                         grpc::ServerWriter<StopReply>* response);
+    grpc::Status on_delete(grpc::ServerContext* context, const DeleteRequest* request,
+                           grpc::ServerWriter<DeleteReply>* response);
+    grpc::Status on_umount(grpc::ServerContext* context, const UmountRequest* request,
+                           grpc::ServerWriter<UmountReply>* response);
+    grpc::Status on_version(grpc::ServerContext* context, const VersionRequest* request,
+                            grpc::ServerWriter<VersionReply>* response);
 
 private:
     const std::string server_address;
@@ -67,18 +77,30 @@ private:
 protected:
     grpc::Status launch(grpc::ServerContext* context, const LaunchRequest* request,
                         grpc::ServerWriter<LaunchReply>* reply) override;
-    grpc::Status purge(grpc::ServerContext* context, const PurgeRequest* request, PurgeReply* response) override;
-    grpc::Status find(grpc::ServerContext* context, const FindRequest* request, FindReply* response) override;
-    grpc::Status info(grpc::ServerContext* context, const InfoRequest* request, InfoReply* response) override;
-    grpc::Status list(grpc::ServerContext* context, const ListRequest* request, ListReply* response) override;
-    grpc::Status mount(grpc::ServerContext* context, const MountRequest* request, MountReply* response) override;
-    grpc::Status recover(grpc::ServerContext* context, const RecoverRequest* request, RecoverReply* response) override;
-    grpc::Status ssh_info(grpc::ServerContext* context, const SSHInfoRequest* request, SSHInfoReply* response) override;
-    grpc::Status start(grpc::ServerContext* context, const StartRequest* request, StartReply* response) override;
-    grpc::Status stop(grpc::ServerContext* context, const StopRequest* request, StopReply* response) override;
-    grpc::Status delet(grpc::ServerContext* context, const DeleteRequest* request, DeleteReply* response) override;
-    grpc::Status umount(grpc::ServerContext* context, const UmountRequest* request, UmountReply* response) override;
-    grpc::Status version(grpc::ServerContext* context, const VersionRequest* request, VersionReply* response) override;
+    grpc::Status purge(grpc::ServerContext* context, const PurgeRequest* request,
+                       grpc::ServerWriter<PurgeReply>* response) override;
+    grpc::Status find(grpc::ServerContext* context, const FindRequest* request,
+                      grpc::ServerWriter<FindReply>* response) override;
+    grpc::Status info(grpc::ServerContext* context, const InfoRequest* request,
+                      grpc::ServerWriter<InfoReply>* response) override;
+    grpc::Status list(grpc::ServerContext* context, const ListRequest* request,
+                      grpc::ServerWriter<ListReply>* response) override;
+    grpc::Status mount(grpc::ServerContext* context, const MountRequest* request,
+                       grpc::ServerWriter<MountReply>* response) override;
+    grpc::Status recover(grpc::ServerContext* context, const RecoverRequest* request,
+                         grpc::ServerWriter<RecoverReply>* response) override;
+    grpc::Status ssh_info(grpc::ServerContext* context, const SSHInfoRequest* request,
+                          grpc::ServerWriter<SSHInfoReply>* response) override;
+    grpc::Status start(grpc::ServerContext* context, const StartRequest* request,
+                       grpc::ServerWriter<StartReply>* response) override;
+    grpc::Status stop(grpc::ServerContext* context, const StopRequest* request,
+                      grpc::ServerWriter<StopReply>* response) override;
+    grpc::Status delet(grpc::ServerContext* context, const DeleteRequest* request,
+                       grpc::ServerWriter<DeleteReply>* response) override;
+    grpc::Status umount(grpc::ServerContext* context, const UmountRequest* request,
+                        grpc::ServerWriter<UmountReply>* response) override;
+    grpc::Status version(grpc::ServerContext* context, const VersionRequest* request,
+                         grpc::ServerWriter<VersionReply>* response) override;
     grpc::Status ping(grpc::ServerContext* context, const PingRequest* request, PingReply* response) override;
 };
 } // namespace multipass

--- a/src/logging/CMakeLists.txt
+++ b/src/logging/CMakeLists.txt
@@ -15,8 +15,10 @@
 
 add_library(logger
   log.cpp
+  multiplexing_logger.cpp
   standard_logger.cpp)
 
 target_link_libraries(logger
   fmt
+  utils
   Qt5::Core)

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -163,7 +163,7 @@ mp::QemuVirtualMachine::QemuVirtualMachine(const VirtualMachineDescription& desc
 
     QObject::connect(vm_process.get(), &QProcess::readyReadStandardError, [this]() {
         saved_error_msg = vm_process->readAllStandardError().data();
-        mpl::log(mpl::Level::error, vm_name, saved_error_msg);
+        mpl::log(mpl::Level::warning, vm_name, saved_error_msg);
     });
 
     QObject::connect(vm_process.get(), &QProcess::stateChanged, [this](QProcess::ProcessState newState) {

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -12,26 +12,25 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
 
 syntax = "proto3";
 package multipass;
 
 service Rpc {
     rpc launch (LaunchRequest) returns (stream LaunchReply);
-    rpc purge (PurgeRequest) returns (PurgeReply);
-    rpc find (FindRequest) returns (FindReply);
-    rpc info (InfoRequest) returns (InfoReply);
-    rpc list (ListRequest) returns (ListReply);
-    rpc mount (MountRequest) returns (MountReply);
+    rpc purge (PurgeRequest) returns (stream PurgeReply);
+    rpc find (FindRequest) returns (stream FindReply);
+    rpc info (InfoRequest) returns (stream InfoReply);
+    rpc list (ListRequest) returns (stream ListReply);
+    rpc mount (MountRequest) returns (stream MountReply);
     rpc ping (PingRequest) returns (PingReply);
-    rpc recover (RecoverRequest) returns (RecoverReply);
-    rpc ssh_info (SSHInfoRequest) returns (SSHInfoReply);
-    rpc start (StartRequest) returns (StartReply);
-    rpc stop (StopRequest) returns (StopReply);
-    rpc delet (DeleteRequest) returns (DeleteReply);
-    rpc umount (UmountRequest) returns (UmountReply);
-    rpc version (VersionRequest) returns (VersionReply);
+    rpc recover (RecoverRequest) returns (stream RecoverReply);
+    rpc ssh_info (SSHInfoRequest) returns (stream SSHInfoReply);
+    rpc start (StartRequest) returns (stream StartReply);
+    rpc stop (StopRequest) returns (stream StopReply);
+    rpc delet (DeleteRequest) returns (stream DeleteReply);
+    rpc umount (UmountRequest) returns (stream UmountReply);
+    rpc version (VersionRequest) returns (stream VersionReply);
 }
 
 message OptInStatus {
@@ -56,6 +55,7 @@ message LaunchRequest {
     string cloud_init_user_data = 8;
     string remote_name = 9;
     OptInStatus opt_in_reply = 10;
+    int32 verbosity_level = 11;
 }
 
 message LaunchError {
@@ -102,17 +102,21 @@ message LaunchReply {
     }
     bool metrics_pending = 4;
     MetricsShowInfo metrics_show_info = 5;
+    string log_line = 6;
 }
 
 message PurgeRequest {
+    int32 verbosity_level = 1;
 }
 
 message PurgeReply {
+    string log_line = 1;
 }
 
 message FindRequest {
     string search_string = 1;
     string remote_name = 2;
+    int32 verbosity_level = 3;
 }
 
 message FindReply {
@@ -126,10 +130,12 @@ message FindReply {
         repeated AliasInfo aliases_info = 3;
     }
     repeated ImageInfo images_info = 1;
+    string log_line = 2;
 }
 
 message InfoRequest {
     repeated string instance_name = 1;
+    int32 verbosity_level = 2;
 }
 
 message MountInfo {
@@ -171,9 +177,11 @@ message InfoReply {
         MountInfo mount_info = 13;
     }
     repeated Info info = 1;
+    string log_line = 2;
 }
 
 message ListRequest {
+    int32 verbosity_level = 1;
 }
 
 message ListVMInstance {
@@ -186,6 +194,7 @@ message ListVMInstance {
 
 message ListReply {
     repeated ListVMInstance instances = 1;
+    string log_line = 2;
 }
 
 message TargetPathInfo {
@@ -218,9 +227,11 @@ message MountRequest {
     repeated TargetPathInfo target_paths = 2;
     repeated MountUidMap uid_maps = 3;
     repeated MountGidMap gid_maps = 4;
+    int32 verbosity_level = 5;
 }
 
 message MountReply {
+    string log_line = 1;
 }
 
 message PingRequest {
@@ -231,13 +242,16 @@ message PingReply {
 
 message RecoverRequest {
     repeated string instance_name = 1;
+    int32 verbosity_level = 2;
 }
 
 message RecoverReply {
+    string log_line = 1;
 }
 
 message SSHInfoRequest {
     repeated string instance_name = 1;
+    int32 verbosity_level = 2;
 }
 
 message SSHInfo {
@@ -249,6 +263,7 @@ message SSHInfo {
 
 message SSHInfoReply {
     map<string, SSHInfo> ssh_info = 1;
+    string log_line = 2;
 }
 
 message StartError {
@@ -264,38 +279,48 @@ message StartError {
 
 message StartRequest {
     repeated string instance_name = 1;
+    int32 verbosity_level = 2;
 }
 
 message StartReply {
+    string log_line = 1;
 }
 
 message StopRequest {
     repeated string instance_name = 1;
     int32 time_minutes = 2;
     bool cancel_shutdown = 3;
+    int32 verbosity_level = 4;
 }
 
 message StopReply {
+    string log_line = 1;
 }
 
 message DeleteRequest {
     repeated string instance_name = 1;
     bool purge = 2;
+    int32 verbosity_level = 3;
 }
 
 message DeleteReply {
+    string log_line = 1;
 }
 
 message UmountRequest {
     repeated TargetPathInfo target_paths = 1;
+    int32 verbosity_level = 2;
 }
 
 message UmountReply {
+    string log_line = 1;
 }
 
 message VersionRequest {
+    int32 verbosity_level = 1;
 }
 
 message VersionReply {
     string version = 1;
+    string log_line = 2;
 }

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -22,6 +22,7 @@
 
 #include <fmt/format.h>
 
+#include <QDateTime>
 #include <QDir>
 #include <QFileInfo>
 #include <QProcess>
@@ -253,4 +254,10 @@ std::string mp::utils::filename_for(const std::string& path)
 bool mp::utils::is_dir(const std::string& path)
 {
     return QFileInfo(QString::fromStdString(path)).isDir();
+}
+
+std::string mp::utils::timestamp()
+{
+    auto time = QDateTime::currentDateTime();
+    return time.toString(Qt::ISODateWithMs).toStdString();
 }

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -13,8 +13,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
 #include <src/client/client.h>
@@ -59,21 +57,27 @@ struct MockDaemon : public mp::Daemon
     using mp::Daemon::Daemon;
     MOCK_METHOD3(launch,
                  grpc::Status(grpc::ServerContext*, const mp::LaunchRequest*, grpc::ServerWriter<mp::LaunchReply>*));
-    MOCK_METHOD3(purge, grpc::Status(grpc::ServerContext*, const mp::PurgeRequest*, mp::PurgeReply*));
-    MOCK_METHOD3(find,
-                 grpc::Status(grpc::ServerContext* context, const mp::FindRequest* request, mp::FindReply* response));
-    MOCK_METHOD3(info, grpc::Status(grpc::ServerContext*, const mp::InfoRequest*, mp::InfoReply*));
-    MOCK_METHOD3(list, grpc::Status(grpc::ServerContext*, const mp::ListRequest*, mp::ListReply*));
-    MOCK_METHOD3(mount,
-                 grpc::Status(grpc::ServerContext* context, const mp::MountRequest* request, mp::MountReply* response));
-    MOCK_METHOD3(recover, grpc::Status(grpc::ServerContext*, const mp::RecoverRequest*, mp::RecoverReply*));
-    MOCK_METHOD3(ssh_info, grpc::Status(grpc::ServerContext*, const mp::SSHInfoRequest*, mp::SSHInfoReply*));
-    MOCK_METHOD3(start, grpc::Status(grpc::ServerContext*, const mp::StartRequest*, mp::StartReply*));
-    MOCK_METHOD3(stop, grpc::Status(grpc::ServerContext*, const mp::StopRequest*, mp::StopReply*));
-    MOCK_METHOD3(delet, grpc::Status(grpc::ServerContext*, const mp::DeleteRequest*, mp::DeleteReply*));
+    MOCK_METHOD3(purge,
+                 grpc::Status(grpc::ServerContext*, const mp::PurgeRequest*, grpc::ServerWriter<mp::PurgeReply>*));
+    MOCK_METHOD3(find, grpc::Status(grpc::ServerContext* context, const mp::FindRequest* request,
+                                    grpc::ServerWriter<mp::FindReply>*));
+    MOCK_METHOD3(info, grpc::Status(grpc::ServerContext*, const mp::InfoRequest*, grpc::ServerWriter<mp::InfoReply>*));
+    MOCK_METHOD3(list, grpc::Status(grpc::ServerContext*, const mp::ListRequest*, grpc::ServerWriter<mp::ListReply>*));
+    MOCK_METHOD3(mount, grpc::Status(grpc::ServerContext* context, const mp::MountRequest* request,
+                                     grpc::ServerWriter<mp::MountReply>*));
+    MOCK_METHOD3(recover,
+                 grpc::Status(grpc::ServerContext*, const mp::RecoverRequest*, grpc::ServerWriter<mp::RecoverReply>*));
+    MOCK_METHOD3(ssh_info,
+                 grpc::Status(grpc::ServerContext*, const mp::SSHInfoRequest*, grpc::ServerWriter<mp::SSHInfoReply>*));
+    MOCK_METHOD3(start,
+                 grpc::Status(grpc::ServerContext*, const mp::StartRequest*, grpc::ServerWriter<mp::StartReply>*));
+    MOCK_METHOD3(stop, grpc::Status(grpc::ServerContext*, const mp::StopRequest*, grpc::ServerWriter<mp::StopReply>*));
+    MOCK_METHOD3(delet,
+                 grpc::Status(grpc::ServerContext*, const mp::DeleteRequest*, grpc::ServerWriter<mp::DeleteReply>*));
     MOCK_METHOD3(umount, grpc::Status(grpc::ServerContext* context, const mp::UmountRequest* request,
-                                      mp::UmountReply* response));
-    MOCK_METHOD3(version, grpc::Status(grpc::ServerContext*, const mp::VersionRequest*, mp::VersionReply*));
+                                      grpc::ServerWriter<mp::UmountReply>* response));
+    MOCK_METHOD3(version,
+                 grpc::Status(grpc::ServerContext*, const mp::VersionRequest*, grpc::ServerWriter<mp::VersionReply>*));
 };
 
 struct StubNameGenerator : public mp::NameGenerator


### PR DESCRIPTION
The verbosity option (no -v=only errors, -v=warnings, -vv=info,
-vvv=debug) specifies the level to forward to the client

Fixes #312 