### PR TITLE
ssh_process: Return any data already read if the channel is closed

### DIFF
--- a/src/ssh/ssh_process.cpp
+++ b/src/ssh/ssh_process.cpp
@@ -129,7 +129,7 @@ std::string mp::SSHProcess::read_stream(StreamType type, int timeout)
     {
         num_bytes = ssh_channel_read_timeout(channel.get(), buffer.data(), buffer.size(), is_std_err, timeout);
         mpl::log(mpl::Level::debug, category,
-                 fmt::format("{}:{} {}(): num_bytes={}", __FILE__, __LINE__, __FUNCTION__, num_bytes));
+                 fmt::format("{}:{} {}(): num_bytes = {}", __FILE__, __LINE__, __FUNCTION__, num_bytes));
         if (num_bytes < 0)
         {
             // Latest libssh now returns an error if the channel has been closed instead of returning 0 bytes

--- a/src/ssh/ssh_process.cpp
+++ b/src/ssh/ssh_process.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,6 +19,8 @@
 #include <multipass/ssh/ssh_session.h>
 #include <multipass/ssh/throw_on_error.h>
 
+#include <multipass/logging/log.h>
+
 #include <fmt/format.h>
 #include <libssh/callbacks.h>
 
@@ -26,9 +28,12 @@
 #include <sstream>
 
 namespace mp = multipass;
+namespace mpl = multipass::logging;
 
 namespace
 {
+constexpr auto category = "ssh process";
+
 class ExitStatusCallback
 {
 public:
@@ -105,9 +110,16 @@ std::string mp::SSHProcess::read_std_error()
 
 std::string mp::SSHProcess::read_stream(StreamType type, int timeout)
 {
+    mpl::log(mpl::Level::debug, category,
+             fmt::format("{}:{} {}(type = {}, timeout = {}): ", __FILE__, __LINE__, __FUNCTION__,
+                         static_cast<int>(type), timeout));
     // If the channel is closed there's no output to read
     if (ssh_channel_is_closed(channel.get()))
+    {
+        mpl::log(mpl::Level::debug, category,
+                 fmt::format("{}:{} {}(): channel closed", __FILE__, __LINE__, __FUNCTION__));
         return std::string();
+    }
 
     std::stringstream output;
     std::array<char, 256> buffer;
@@ -116,11 +128,17 @@ std::string mp::SSHProcess::read_stream(StreamType type, int timeout)
     do
     {
         num_bytes = ssh_channel_read_timeout(channel.get(), buffer.data(), buffer.size(), is_std_err, timeout);
+        mpl::log(mpl::Level::debug, category,
+                 fmt::format("{}:{} {}(): num_bytes={}", __FILE__, __LINE__, __FUNCTION__, num_bytes));
         if (num_bytes < 0)
         {
             // Latest libssh now returns an error if the channel has been closed instead of returning 0 bytes
             if (ssh_channel_is_closed(channel.get()))
-                return std::string();
+            {
+                mpl::log(mpl::Level::debug, category,
+                         fmt::format("{}:{} {}(): channel closed", __FILE__, __LINE__, __FUNCTION__));
+                return output.str();
+            }
 
             throw std::runtime_error(fmt::format("error while reading ssh channel for remote process '{}'"
                                                  " - error: {}",

--- a/src/sshfs_mount/sshfs_mount.cpp
+++ b/src/sshfs_mount/sshfs_mount.cpp
@@ -18,6 +18,7 @@
 #include <multipass/sshfs_mount/sshfs_mount.h>
 
 #include <multipass/exceptions/sshfs_missing_error.h>
+#include <multipass/logging/log.h>
 #include <multipass/ssh/ssh_session.h>
 #include <multipass/sshfs_mount/sftp_server.h>
 #include <multipass/utils.h>
@@ -25,9 +26,11 @@
 #include <fmt/format.h>
 
 namespace mp = multipass;
+namespace mpl = multipass::logging;
 
 namespace
 {
+constexpr auto category = "sshfs mount";
 template <typename Callable>
 auto run_cmd(mp::SSHSession& session, std::string&& cmd, Callable&& error_handler)
 {
@@ -94,12 +97,19 @@ auto create_sshfs_process(mp::SSHSession& session, const std::string& source, co
 auto make_sftp_server(mp::SSHSession&& session, const std::string& source, const std::string& target,
                       const std::unordered_map<int, int>& gid_map, const std::unordered_map<int, int>& uid_map)
 {
+    mpl::log(mpl::Level::debug, category,
+             fmt::format("{}:{} {}(source = {}, target = {}, …): ", __FILE__, __LINE__, __FUNCTION__, source, target));
+
     auto sshfs_proc =
         create_sshfs_process(session, mp::utils::escape_char(source, '"'), mp::utils::escape_char(target, '"'));
 
     auto output = run_cmd(session, "id -u");
+    mpl::log(mpl::Level::debug, category,
+             fmt::format("{}:{} {}(): `id -u` = {}", __FILE__, __LINE__, __FUNCTION__, output));
     auto default_uid = std::stoi(output);
     output = run_cmd(session, "id -g");
+    mpl::log(mpl::Level::debug, category,
+             fmt::format("{}:{} {}(): `id -g` = {}", __FILE__, __LINE__, __FUNCTION__, output));
     auto default_gid = std::stoi(output);
 
     return std::make_unique<mp::SftpServer>(std::move(session), std::move(sshfs_proc), source, gid_map, uid_map,


### PR DESCRIPTION
Also add more verbose debugging info for catching cases like this in the future.

Fixes #425

Co-authored-by: Chris Townsend <christopher.townsend@canonical.com>