### PR TITLE
[sshfs] fix file metadata passthrough

### DIFF
--- a/include/multipass/sshfs_mount/sftp_server.h
+++ b/include/multipass/sshfs_mount/sftp_server.h
@@ -72,7 +72,7 @@ private:
     SSHSession ssh_session;
     const SftpSessionUptr sftp_server_session;
     const std::string source_path;
-    std::unordered_map<void*, std::unique_ptr<QStringList>> open_dir_handles;
+    std::unordered_map<void*, std::unique_ptr<QFileInfoList>> open_dir_handles;
     std::unordered_map<void*, std::unique_ptr<QFile>> open_file_handles;
     const std::unordered_map<int, int> gid_map;
     const std::unordered_map<int, int> uid_map;

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -518,7 +518,8 @@ int mp::SftpServer::handle_opendir(sftp_client_message msg)
     if (!dir.isReadable())
         return reply_perm_denied(msg);
 
-    auto entry_list = std::make_unique<QStringList>(dir.entryList(QDir::AllEntries | QDir::System | QDir::Hidden));
+    auto entry_list =
+        std::make_unique<QFileInfoList>(dir.entryInfoList(QDir::AllEntries | QDir::System | QDir::Hidden));
 
     SftpHandleUPtr sftp_handle{sftp_handle_alloc(sftp_server_session.get(), entry_list.get()), ssh_string_free};
     open_dir_handles.emplace(entry_list.get(), std::move(entry_list));
@@ -554,7 +555,7 @@ int mp::SftpServer::handle_readdir(sftp_client_message msg)
     if (dir_entries == nullptr)
         return reply_bad_handle(msg, "readdir");
 
-    if (dir_entries->isEmpty())
+    if (dir_entries->empty())
         return sftp_reply_status(msg, SSH_FX_EOF, nullptr);
 
     const auto max_num_entries_per_packet = 50;
@@ -562,7 +563,7 @@ int mp::SftpServer::handle_readdir(sftp_client_message msg)
 
     for (int i = 0; i < num_entries; i++)
     {
-        QFileInfo entry(dir_entries->takeFirst());
+        const QFileInfo entry = dir_entries->takeFirst();
         const auto filename = entry.fileName().toStdString();
         sftp_attributes_struct attr{};
         if (entry.isSymLink())


### PR DESCRIPTION
handle_opendir only put file names on the open_dir_handles so handle_readdir had no directory information. QFileInfo returns default file attributes if the file it points to does not exist. Combination
of these facts meant sometimes incorrect file metadata could be returned.

The test I added fails without the patch, so this is correcting something. 