### PR TITLE
platform: Split out the no_id_info_available const so it can be used …

### DIFF
--- a/include/multipass/cli/client_platform.h
+++ b/include/multipass/cli/client_platform.h
@@ -22,6 +22,9 @@
 
 namespace multipass
 {
+const auto default_id = -1;
+const auto no_id_info_available = -2;
+
 namespace cli
 {
 namespace platform

--- a/include/multipass/sshfs_mount/sftp_server.h
+++ b/include/multipass/sshfs_mount/sftp_server.h
@@ -30,12 +30,6 @@
 
 namespace multipass
 {
-
-namespace sftp_server
-{
-const int default_id = -1;
-} // namespace sftp_server
-
 class SSHSession;
 class SftpServer
 {

--- a/src/client/cmd/mount.cpp
+++ b/src/client/cmd/mount.cpp
@@ -209,11 +209,11 @@ mp::ParseCode cmd::Mount::parse_args(mp::ArgParser* parser)
                  fmt::format("{}:{} {}(): adding default uid/gid mapping", __FILE__, __LINE__, __FUNCTION__));
         auto uid_entry = request.add_uid_maps();
         uid_entry->set_host_uid(mcp::getuid());
-        uid_entry->set_instance_uid(mp::sftp_server::default_id);
+        uid_entry->set_instance_uid(mp::default_id);
 
         auto gid_entry = request.add_gid_maps();
         gid_entry->set_host_gid(mcp::getgid());
-        gid_entry->set_instance_gid(mp::sftp_server::default_id);
+        gid_entry->set_instance_gid(mp::default_id);
     }
 
     return ParseCode::Ok;

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -17,6 +17,7 @@
 
 #include <multipass/sshfs_mount/sftp_server.h>
 
+#include <multipass/cli/client_platform.h>
 #include <multipass/logging/log.h>
 #include <multipass/platform.h>
 #include <multipass/ssh/ssh_session.h>
@@ -266,14 +267,13 @@ sftp_attributes_struct mp::SftpServer::attr_from(const QFileInfo& file_info)
 
 int mp::SftpServer::mapped_uid_for(const int uid)
 {
-    const auto no_id_info_available = -2;
-    if (uid == no_id_info_available)
+    if (uid == mp::no_id_info_available)
         return default_uid;
 
     auto map = uid_map.find(uid);
     if (map != uid_map.end())
     {
-        if (map->second == mp::sftp_server::default_id)
+        if (map->second == mp::default_id)
             return default_uid;
         else
             return map->second;
@@ -284,14 +284,13 @@ int mp::SftpServer::mapped_uid_for(const int uid)
 
 int mp::SftpServer::mapped_gid_for(const int gid)
 {
-    const auto no_id_info_available = -2;
-    if (gid == no_id_info_available)
+    if (gid == mp::no_id_info_available)
         return default_gid;
 
     auto map = gid_map.find(gid);
     if (map != gid_map.end())
     {
-        if (map->second == mp::sftp_server::default_id)
+        if (map->second == mp::default_id)
             return default_gid;
         else
             return map->second;


### PR DESCRIPTION
…elsewhere