### PR TITLE
[snap] log up to debug level by default

### DIFF
--- a/snap-wrappers/bin/launch-multipassd
+++ b/snap-wrappers/bin/launch-multipassd
@@ -7,4 +7,4 @@ export http_proxy
 export https_proxy
 export MULTIPASS_VM_DRIVER
 
-exec "$SNAP/bin/multipassd"
+exec "$SNAP/bin/multipassd" --verbosity debug --logger platform


### PR DESCRIPTION
This way we can ask for debug logs when people report issues, and they can choose with `--priority` what they're interested in.