### PR TITLE
[snap] add git to build packages and change libvirt's source

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -139,6 +139,7 @@ parts:
     build-packages:
     - build-essential
     - cmake-extras
+    - git
     - golang
     - libsystemd-dev
     source: .
@@ -175,7 +176,7 @@ parts:
     - try: [msr-tools]
 
   libvirt:
-    source: .
+    source: snap
     source-subdir: libvirt-1.3.1
     plugin: autotools
     build-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -176,6 +176,7 @@ parts:
     - try: [msr-tools]
 
   libvirt:
+    # use the snap subdirectory as source to avoid copying the whole tree
     source: snap
     source-subdir: libvirt-1.3.1
     plugin: autotools


### PR DESCRIPTION
Without git our version script doesn't work in build environments, and
setting libvirt's source to `snap` means we no longer copy the whole
source.