### PR TITLE
[snap] reduce pull load

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -156,6 +156,7 @@ parts:
 
   qemu:
     plugin: nil
+    override-pull: ""
     stage-packages:
     - on amd64: [qemu-system-x86]
     - on i386: [qemu-system-x86]
@@ -172,12 +173,11 @@ parts:
 
   kvm-support:
     plugin: nil
+    override-pull: ""
     stage-packages:
     - try: [msr-tools]
 
   libvirt:
-    # use the snap subdirectory as source to avoid copying the whole tree
-    source: snap
     source-subdir: libvirt-1.3.1
     plugin: autotools
     build-packages:
@@ -237,12 +237,11 @@ parts:
     - DNSMASQ=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/sbin/dnsmasq
     - DMIDECODE=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/sbin/dmidecode
     - EBTABLES_PATH=/snap/$SNAPCRAFT_PROJECT_NAME/current/sbin/ebtables
-    override-build: |
+    override-pull: |
       wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1.orig.tar.gz
       wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.24.debian.tar.xz
       wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.24.dsc
       dpkg-source -x libvirt*.dsc
-      snapcraftctl build
     organize:
       # Hack to shift installed libvirt back to root of snap
       # required to ensure that pathing to files etc works at
@@ -252,6 +251,7 @@ parts:
 
   network-utils:
     plugin: nil
+    override-pull: ""
     stage-packages:
     - iproute2
     - iputils-ping

--- a/tests/travis-Coverage.patch
+++ b/tests/travis-Coverage.patch
@@ -1,7 +1,7 @@
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
-@@ -115,11 +115,11 @@ parts:
-     - cmake-extras
+@@ -142,11 +142,11 @@ parts:
+     - git
      - golang
      - libsystemd-dev
 +    - lcov

--- a/tests/travis-Debug.patch
+++ b/tests/travis-Debug.patch
@@ -1,8 +1,8 @@
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
-@@ -117,9 +117,8 @@ parts:
+@@ -143,9 +143,8 @@ parts:
+     - golang
      - libsystemd-dev
-     source: .
      configflags:
 -    - -DCMAKE_BUILD_TYPE=RelWithDebInfo
 +    - -DCMAKE_BUILD_TYPE=Debug


### PR DESCRIPTION
Use `override-pull` to avoid pulling in any source when not needed.