### PR TITLE
shell to machine in delayed-shutdown state

### DIFF
--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -57,6 +57,7 @@ public:
     virtual void wait_until_ssh_up(std::chrono::milliseconds timeout) = 0;
     virtual void wait_for_cloud_init(std::chrono::milliseconds timeout) = 0;
     virtual void update_state() = 0;
+    virtual bool is_running() { return current_state() == State::running || current_state() == State::delayed_shutdown; }
 
     VirtualMachine::State state;
     const SSHKeyProvider& key_provider;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1236,7 +1236,7 @@ try // clang-format on
                                 "");
         }
 
-        if (it->second->current_state() != mp::VirtualMachine::State::running)
+        if (!it->second->is_running())
         {
             return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
                                 fmt::format("instance \"{}\" is not running", name), "");


### PR DESCRIPTION
Fix bug #461 
ssh_info returns connection data if machine is still running