### PR TITLE
test/metricsprovider sigsegv fix

### DIFF
--- a/include/multipass/metrics_provider.h
+++ b/include/multipass/metrics_provider.h
@@ -47,7 +47,7 @@ private:
 
     const QUrl metrics_url;
     const QString unique_id;
-    const Path& data_path;
+    const Path data_path;
     QJsonArray metric_batches;
 
     std::mutex metrics_mutex;


### PR DESCRIPTION
The method mpt::TempDir::path() returns by value, which is passed by reference to the mp::MetricsProvider class constructor and stored as reference in the class member mp::MetricsProvider::Path. 

Memory corruption will happen when the stack contents at the referenced address change.

[core.txt](https://github.com/CanonicalLtd/multipass/files/2576437/core.txt)
