### PR TITLE
daemon/suspend: Use a QueuedConnection to avoid missing a signal

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1576,7 +1576,7 @@ try // clang-format on
         QTimer timer;
         QEventLoop event_loop;
 
-        QObject::connect(this, &Daemon::suspend_finished, &event_loop, &QEventLoop::quit);
+        QObject::connect(this, &Daemon::suspend_finished, &event_loop, &QEventLoop::quit, Qt::QueuedConnection);
         QObject::connect(&timer, &QTimer::timeout, &event_loop, &QEventLoop::quit);
 
         auto it = vm_instances.find(name);


### PR DESCRIPTION
It's possible that the suspend_finished signal is missed when the backend's suspend function is fast.