### PR TITLE
backends: Use host CPU passthrough for all CPU features in the VM

### DIFF
--- a/src/platform/backends/libvirt/libvirt_virtual_machine.cpp
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine.cpp
@@ -166,6 +166,8 @@ auto generate_xml_config_for(const mp::VirtualMachineDescription& desc, const st
         "    <apic/>\n"
         "    <vmport state=\'off\'/>\n"
         "  </features>\n"
+        "  <cpu mode=\'host-passthrough\'>\n"
+        "  </cpu>\n"
         "  <devices>\n"
         "    <emulator>{}</emulator>\n"
         "    <disk type=\'file\' device=\'disk\'>\n"

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -84,6 +84,9 @@ auto make_qemu_process(const mp::VirtualMachineDescription& desc, const std::str
     // Control interface
     args << "-qmp"
          << "stdio";
+    // Pass host CPU flags to VM
+    args << "-cpu"
+         << "host";
     // No console
     args << "-chardev"
          // TODO Read and log machine output when verbose


### PR DESCRIPTION
Fixes #505 

Notes:
- Any QEMU based instances will need to start from cold, ie, not suspended to enable this.
- Any LIBVIRT based instances will need be launched anew.
