### PR TITLE
client: Add 2 newlines after CLI parser error for better readability

### DIFF
--- a/src/client/argparser.cpp
+++ b/src/client/argparser.cpp
@@ -112,7 +112,7 @@ mp::ParseCode mp::ArgParser::parse()
     {
         if (!parser_result)
         {
-            cerr << qPrintable(parser.errorText());
+            cerr << qPrintable(parser.errorText()) << "\n\n";
         }
         cout << qPrintable(generalHelpText());
         return (help_requested) ? ParseCode::HelpRequested : ParseCode::CommandFail;


### PR DESCRIPTION
Fixes #483