### PR TITLE
Release resources consistently

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -771,18 +771,12 @@ grpc::Status mp::Daemon::purge(grpc::ServerContext* context, const PurgeRequest*
                                grpc::ServerWriter<PurgeReply>* server) // clang-format off
 try // clang-format on
 {
-    std::vector<decltype(deleted_instances)::key_type> keys_to_delete;
-    for (auto& del : deleted_instances)
-    {
-        const auto& name = del.first;
-        release_resources(name);
-        keys_to_delete.push_back(name);
-    }
+    for (const auto& del : deleted_instances)
+        release_resources(del.first);
 
-    for (auto const& key : keys_to_delete)
-        deleted_instances.erase(key);
-
+    deleted_instances.clear();
     persist_instances();
+
     return grpc::Status::OK;
 }
 catch (const std::exception& e)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -756,9 +756,7 @@ catch (const mp::StartException& e)
 {
     auto name = e.name();
 
-    config->factory->remove_resources_for(name);
-    config->vault->remove(name);
-    vm_instance_specs.erase(name);
+    release_resources(name);
     vm_instances.erase(name);
     persist_instances();
 
@@ -777,16 +775,12 @@ try // clang-format on
     for (auto& del : deleted_instances)
     {
         const auto& name = del.first;
-        config->factory->remove_resources_for(name);
-        config->vault->remove(name);
+        release_resources(name);
         keys_to_delete.push_back(name);
     }
 
     for (auto const& key : keys_to_delete)
-    {
         deleted_instances.erase(key);
-        vm_instance_specs.erase(key);
-    }
 
     persist_instances();
     return grpc::Status::OK;


### PR DESCRIPTION
This picks up refactoring changes to how VM resources are released and extends them to other places that do the same thing, simplifying the corresponding code along the way.