### PR TITLE
Try to make log message's meaning easier to perceive at a glance.

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1892,7 +1892,7 @@ void mp::Daemon::start_mount(const VirtualMachine::UPtr& vm, const std::string& 
                      [this, name, target_path]() {
                          mount_threads[name].erase(target_path);
                          mpl::log(mpl::Level::debug, category,
-                                  fmt::format("Mount '{}' in instance \"{}\" has stopped", target_path, name));
+                                  fmt::format("Mount stopped: '{}' in instance \"{}\"", target_path, name));
                      },
                      Qt::QueuedConnection);
 }


### PR DESCRIPTION
Just a tiny detail: while the log message `Mount '/this/and/that' in instance "something_another" stopped` is perfectly correct, when glancing at it, it is easy to mistakenly read only the first bit, interpret "mount" as a verb, and think something was mounted (which is the opposite). 

This happened to me at least and this PR attempts to improve that.