### PR TITLE
Revert "[cmake] mark dirty tree in the version string"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ add_subdirectory(3rd-party)
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Network REQUIRED)
 
-execute_process(COMMAND git describe --dirty
+execute_process(COMMAND git describe
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                 OUTPUT_VARIABLE MULTIPASS_VERSION
                 OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
This reverts commit 760c9e2dd57df5d5291e0a989dfc46903d5825f9.

Unfortunately snapcraft dirtifies the build dir on Launchpad, so all our builds from there now have a `-dirty` suffix.