### PR TITLE
Release 2018.12.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ add_subdirectory(3rd-party)
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Network REQUIRED)
 
-execute_process(COMMAND git describe --dirty
+execute_process(COMMAND git describe
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                 OUTPUT_VARIABLE MULTIPASS_VERSION
                 OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
### Highlights

- On Linux, suspending/resuming the instance to/from disk is now supported. (#374)
- Better handling of delayed shutdown including posting `wall` messages to logged in users and allowing log ins to the instance unless 1 minute or less remains until shutdown. (#461, #50) 
- On Linux, all CPU flags should be passed into the running instance on newly created instances. (#516)
- Fixed some races around mount handling. (#514, #520)

### Bugs fixed:

- make the recover command idempotent (#528)
- explicitly stop mounts when deleting an instance to avoid a race (#520)
- be smarter about what group owns the multipass socket (#513, #523) 
- pass through all CPU flags when launching QEMU or libvirt instances (#516)
- use `info` log level for metrics issues (#515)
- fix potential race when starting a mount (#514)
- use `wall` shutdown messages for users logged into VM when delayed shutdown is initiated (#501)
- fix crash if exception during daemon start up (#487)
- refactor CLI code (#468)
- add default uid/gid mapping (#331)
- fix file metadata passthrough
- display uid/gid maps in info command (#439)
- add support for the suspend command (#374)
- shell to machine in delayed stop state (#461)
- improve uid/gid validation (#479)
- avoid leaking the libvirt bridge (#327, #413)
- add a restart command (#217)
- upgrade 3rd-party versions (#471)