### PR TITLE
Persistify deleted state and load it on daemon startup.

### DIFF
--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -48,6 +48,7 @@ struct VMSpecs
     std::string ssh_username;
     VirtualMachine::State state;
     std::unordered_map<std::string, VMMount> mounts;
+    bool deleted;
 };
 
 struct MetricsOptInData


### PR DESCRIPTION
Fixes #536. This adds a boolean field to each instance specification indicating whether or not it is deleted. 

This change is backward compatible: the daemon can still load VM specs that do not contain the new flag. Such VMs are regarded as not deleted.