### PR TITLE
Add ellipsis for long instance names in `list`.

### DIFF
--- a/src/client/formatter/table_formatter.cpp
+++ b/src/client/formatter/table_formatter.cpp
@@ -127,7 +127,7 @@ std::string mp::TableFormatter::format(const ListReply& reply) const
 
     for (const auto& instance : reply.instances())
     {
-        fmt::format_to(buf, "{:<24}{:<18}{:<17}{:<}\n", instance.name(),
+        fmt::format_to(buf, "{:<24}{:<18}{:<17}{:<}\n", instance.name().size() > 20 ? instance.name().substr(0, 20) + "..." : instance.name(),
                        mp::format::status_string_for(instance.instance_status()),
                        instance.ipv4().empty() ? "--" : instance.ipv4(),
                        instance.current_release().empty() ? "Not Available"


### PR DESCRIPTION
Fix #500