### PR TITLE
delayed_shutdown: Only broadcast `wall` messages if SSHSession is valid 

### DIFF
--- a/include/multipass/delayed_shutdown_timer.h
+++ b/include/multipass/delayed_shutdown_timer.h
@@ -33,7 +33,7 @@ class DelayedShutdownTimer : public QObject
     Q_OBJECT
 
 public:
-    DelayedShutdownTimer(VirtualMachine* virtual_machine, SSHSession&& session);
+    DelayedShutdownTimer(VirtualMachine* virtual_machine, optional<SSHSession>&& session);
     ~DelayedShutdownTimer();
 
     void start(const std::chrono::milliseconds delay);
@@ -47,7 +47,7 @@ private:
 
     QTimer shutdown_timer;
     VirtualMachine* virtual_machine;
-    SSHSession ssh_session;
+    optional<SSHSession> ssh_session;
     std::chrono::milliseconds delay;
     std::chrono::milliseconds time_remaining;
 };

--- a/include/multipass/optional.h
+++ b/include/multipass/optional.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -13,8 +13,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
 #ifndef MULTIPASS_OPTIONAL_H
@@ -25,8 +23,8 @@
 #include <optional>
 namespace multipass
 {
-using std::optional;
 using std::nullopt;
+using std::optional;
 }
 
 #elif __has_include(<experimental/optional>)
@@ -34,8 +32,8 @@ using std::nullopt;
 #include <experimental/optional>
 namespace multipass
 {
-using std::experimental::optional;
 using std::experimental::nullopt;
+using std::experimental::optional;
 }
 
 #else

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1972,7 +1972,15 @@ grpc::Status mp::Daemon::shutdown_vm(VirtualMachine& vm, const std::chrono::mill
     {
         delayed_shutdown_instances.erase(name);
 
-        mp::SSHSession session{vm.ssh_hostname(), vm.ssh_port(), vm.ssh_username(), *config->ssh_key_provider};
+        mp::optional<mp::SSHSession> session{mp::nullopt};
+        try
+        {
+            session = mp::SSHSession{vm.ssh_hostname(), vm.ssh_port(), vm.ssh_username(), *config->ssh_key_provider};
+        }
+        catch (...)
+        {
+        }
+
         auto& shutdown_timer = delayed_shutdown_instances[name] =
             std::make_unique<DelayedShutdownTimer>(&vm, std::move(session));
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1972,13 +1972,15 @@ grpc::Status mp::Daemon::shutdown_vm(VirtualMachine& vm, const std::chrono::mill
     {
         delayed_shutdown_instances.erase(name);
 
-        mp::optional<mp::SSHSession> session{mp::nullopt};
+        mp::optional<mp::SSHSession> session;
         try
         {
             session = mp::SSHSession{vm.ssh_hostname(), vm.ssh_port(), vm.ssh_username(), *config->ssh_key_provider};
         }
-        catch (...)
+        catch (const std::exception& e)
         {
+            mpl::log(mpl::Level::info, category,
+                     fmt::format("Cannot open ssh session on \"{}\" shutdown: {}", name, e.what()));
         }
 
         auto& shutdown_timer = delayed_shutdown_instances[name] =


### PR DESCRIPTION
Fixes #539