### PR TITLE
qemu: Save qemu "machine type" as metadata for the instance

### DIFF
--- a/include/multipass/vm_status_monitor.h
+++ b/include/multipass/vm_status_monitor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -13,14 +13,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
 #ifndef MULTIPASS_VM_STATUS_MONITOR_H
 #define MULTIPASS_VM_STATUS_MONITOR_H
 
 #include <string>
+
+#include <QJsonObject>
 
 namespace multipass
 {
@@ -34,6 +34,8 @@ public:
     virtual void on_suspend() = 0;
     virtual void on_restart(const std::string& name) = 0;
     virtual void persist_state_for(const std::string& name) = 0;
+    virtual void update_metadata_for(const std::string& name, const QJsonObject& metadata) = 0;
+    virtual QJsonObject retrieve_metadata_for(const std::string& name) = 0;
 
 protected:
     VMStatusMonitor() = default;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -49,6 +49,7 @@ struct VMSpecs
     VirtualMachine::State state;
     std::unordered_map<std::string, VMMount> mounts;
     bool deleted;
+    QJsonObject metadata;
 };
 
 struct MetricsOptInData
@@ -73,6 +74,8 @@ protected:
     void on_suspend() override;
     void on_restart(const std::string& name) override;
     void persist_state_for(const std::string& name) override;
+    void update_metadata_for(const std::string& name, const QJsonObject& metadata) override;
+    QJsonObject retrieve_metadata_for(const std::string& name) override;
 
 public slots:
     grpc::Status launch(grpc::ServerContext* context, const LaunchRequest* request,

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -321,6 +321,10 @@ void mp::QemuVirtualMachine::start()
         update_shutdown_status = true;
         delete_memory_snapshot = true;
     }
+    else
+    {
+        monitor->update_metadata_for(vm_name, get_metadata());
+    }
 
     vm_process->start();
     auto started = vm_process->waitForStarted();
@@ -360,7 +364,6 @@ void mp::QemuVirtualMachine::suspend()
     {
         vm_process->write(hmc_to_qmp_json("savevm " + QString::fromStdString(suspend_tag)));
 
-        monitor->update_metadata_for(vm_name, get_metadata());
         if (update_shutdown_status)
         {
             state = State::suspending;

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -39,6 +39,7 @@
 #include <QString>
 #include <QStringList>
 #include <QSysInfo>
+#include <QTemporaryFile>
 
 #include <thread>
 
@@ -51,6 +52,21 @@ const QHash<QString, QString> cpu_to_arch{{"x86_64", "x86_64"}, {"arm", "arm"}, 
                                           {"i386", "i386"},     {"power", "ppc"}, {"power64", "ppc64le"},
                                           {"s390x", "s390x"}};
 constexpr auto suspend_tag = "suspend";
+constexpr auto default_machine_type = "pc-i440fx-xenial";
+
+auto set_qemu_exec()
+{
+    auto process = std::make_unique<QProcess>();
+    auto snap = qgetenv("SNAP");
+    if (!snap.isEmpty())
+    {
+        process->setWorkingDirectory(snap.append("/qemu"));
+    }
+
+    process->setProgram("qemu-system-" + cpu_to_arch.value(QSysInfo::currentCpuArchitecture()));
+
+    return process;
+}
 
 auto make_qemu_process(const mp::VirtualMachineDescription& desc, const std::string& tap_device_name,
                        const std::string& mac_addr)
@@ -96,14 +112,7 @@ auto make_qemu_process(const mp::VirtualMachineDescription& desc, const std::str
          // TODO Add a debugging mode with access to console
          << "-nographic";
 
-    auto process = std::make_unique<QProcess>();
-    auto snap = qgetenv("SNAP");
-    if (!snap.isEmpty())
-    {
-        process->setWorkingDirectory(snap.append("/qemu"));
-    }
-
-    process->setProgram("qemu-system-" + cpu_to_arch.value(QSysInfo::currentCpuArchitecture()));
+    auto process = set_qemu_exec();
     process->setArguments(args);
 
     mpl::log(mpl::Level::debug, desc.vm_name,
@@ -157,6 +166,34 @@ bool instance_image_has_snapshot(const mp::Path& image_path)
     }
 
     return false;
+}
+
+auto get_qemu_machine_type()
+{
+    QTemporaryFile dump_file;
+    if (!dump_file.open())
+    {
+        return QString();
+    }
+
+    auto process = set_qemu_exec();
+    process->setArguments({"-nographic", "-dump-vmstate", dump_file.fileName()});
+    process->start();
+    process->waitForFinished();
+
+    auto vmstate = QJsonDocument::fromJson(dump_file.readAll()).object();
+
+    auto machine_type = vmstate["vmschkmachine"].toObject()["Name"].toString();
+    return machine_type;
+}
+
+auto get_metadata()
+{
+    QJsonObject metadata;
+
+    metadata["machine_type"] = get_qemu_machine_type();
+
+    return metadata;
 }
 } // namespace
 
@@ -265,9 +302,21 @@ void mp::QemuVirtualMachine::start()
     vm_process->setArguments(original_args);
     if (state == State::suspended)
     {
+        auto metadata = monitor->retrieve_metadata_for(vm_name);
+
+        auto machine_type = metadata["machine_type"].toString();
+
+        if (machine_type.isNull())
+        {
+            mpl::log(mpl::Level::info, vm_name,
+                     fmt::format("Cannot determine QEMU machine type. Defaulting to '{}'.", default_machine_type));
+            machine_type = default_machine_type;
+        }
+
         mpl::log(mpl::Level::info, vm_name, fmt::format("Resuming from a suspended state"));
         auto args = vm_process->arguments();
         args << "-loadvm" << suspend_tag;
+        args << "-machine" << machine_type;
         vm_process->setArguments(args);
         update_shutdown_status = true;
         delete_memory_snapshot = true;
@@ -311,6 +360,7 @@ void mp::QemuVirtualMachine::suspend()
     {
         vm_process->write(hmc_to_qmp_json("savevm " + QString::fromStdString(suspend_tag)));
 
+        monitor->update_metadata_for(vm_name, get_metadata());
         if (update_shutdown_status)
         {
             state = State::suspending;

--- a/tests/mock_qemu_system.cpp
+++ b/tests/mock_qemu_system.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,6 +24,10 @@
 int main(int argc, char* argv[])
 {
     std::string input;
+
+    if (strcmp(argv[1], "-dump-vmstate") == 0)
+        return 0;
+
     while (true)
     {
         char c;

--- a/tests/mock_status_monitor.h
+++ b/tests/mock_status_monitor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,8 +12,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
  *
  */
 
@@ -35,6 +33,8 @@ struct MockVMStatusMonitor : public VMStatusMonitor
     MOCK_METHOD0(on_suspend, void());
     MOCK_METHOD1(on_restart, void(const std::string&));
     MOCK_METHOD1(persist_state_for, void(const std::string&));
+    MOCK_METHOD2(update_metadata_for, void(const std::string&, const QJsonObject&));
+    MOCK_METHOD1(retrieve_metadata_for, QJsonObject(const std::string&));
 };
 }
 }

--- a/tests/stub_status_monitor.h
+++ b/tests/stub_status_monitor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,8 +12,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
  *
  */
 
@@ -34,6 +32,11 @@ struct StubVMStatusMonitor : public multipass::VMStatusMonitor
     void on_suspend() override{};
     void on_restart(const std::string& name) override{};
     void persist_state_for(const std::string& name) override{};
+    void update_metadata_for(const std::string& name, const QJsonObject& metadata) override{};
+    QJsonObject retrieve_metadata_for(const std::string& name) override
+    {
+        return QJsonObject();
+    };
 };
 }
 }


### PR DESCRIPTION
This is to allow resuming from suspend when changing QEMU versions in the snap.

Fixes #598