### PR TITLE
Update googletest (sub-)submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "3rd-party/grpc"]
 	path = 3rd-party/grpc
-	url = https://github.com/albaguirre/grpc.git
+	url = https://github.com/CanonicalLtd/grpc.git
 	ignore = dirty
 [submodule "3rd-party/yaml-cpp"]
 	path = 3rd-party/yaml-cpp

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -1342,4 +1342,4 @@ INSTANTIATE_TEST_SUITE_P(
         MessageAndReply{SFTP_EXTENDED, SSH_FX_FAILURE}),
     string_for_param);
 
-}
+} // namespace

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -1297,7 +1297,9 @@ TEST_P(Stat, handles)
     EXPECT_THAT(num_calls, Eq(1));
 }
 
-INSTANTIATE_TEST_CASE_P(SftpServer, Stat, ::testing::Values(SFTP_LSTAT, SFTP_STAT), string_for_message);
+namespace
+{
+INSTANTIATE_TEST_SUITE_P(SftpServer, Stat, ::testing::Values(SFTP_LSTAT, SFTP_STAT), string_for_message);
 
 TEST_P(WhenInvalidMessageReceived, replies_failure)
 {
@@ -1327,7 +1329,7 @@ TEST_P(WhenInvalidMessageReceived, replies_failure)
     EXPECT_THAT(num_calls, Eq(1));
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     SftpServer, WhenInvalidMessageReceived,
     ::testing::Values(
         MessageAndReply{SFTP_BAD_MESSAGE, SSH_FX_OP_UNSUPPORTED}, MessageAndReply{SFTP_CLOSE, SSH_FX_BAD_MESSAGE},
@@ -1339,3 +1341,5 @@ INSTANTIATE_TEST_CASE_P(
         MessageAndReply{SFTP_RENAME, SSH_FX_NO_SUCH_FILE}, MessageAndReply{SFTP_SETSTAT, SSH_FX_NO_SUCH_FILE},
         MessageAndReply{SFTP_EXTENDED, SSH_FX_FAILURE}),
     string_for_param);
+
+}


### PR DESCRIPTION
This fixes compilation errors with recent toolchains. Replace deprecated INSTANTIATE_TEST_CASE calls. Fix subobject-linkage warning by moving tests to anonymous namespace.