### PR TITLE
tests/qemu: Fix arg that qemu-system mock looks for

### DIFF
--- a/tests/mock_qemu_system.cpp
+++ b/tests/mock_qemu_system.cpp
@@ -25,7 +25,7 @@ int main(int argc, char* argv[])
 {
     std::string input;
 
-    if (strcmp(argv[1], "-dump-vmstate") == 0)
+    if (strcmp(argv[2], "-dump-vmstate") == 0)
         return 0;
 
     while (true)


### PR DESCRIPTION
The qemu-system mock was looking in the wrong position for the `-dump-vmstate` arg.

Fixes #629