### PR TITLE
qemu: Remove QCoreApplication::processEvents() to avoid a crash

### DIFF
--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -27,7 +27,6 @@
 #include <thread>
 #include <vector>
 
-#include <QCoreApplication>
 #include <QDir>
 #include <QString>
 #include <QStringList>
@@ -65,9 +64,9 @@ std::string generate_mac_address();
 std::string timestamp();
 bool is_running(const VirtualMachine::State& state);
 void wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
-                       std::function<void()> const& process_vm_events = []() { QCoreApplication::processEvents(); });
+                       std::function<void()> const& process_vm_events = []() { });
 void wait_for_cloud_init(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
-                         std::function<void()> const& process_vm_events = []() { QCoreApplication::processEvents(); });
+                         std::function<void()> const& process_vm_events = []() { });
 
 enum class TimeoutAction
 {

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -433,8 +433,6 @@ void mp::QemuVirtualMachine::on_restart()
 
 void mp::QemuVirtualMachine::ensure_vm_is_running()
 {
-    QCoreApplication::processEvents();
-
     if (vm_process->state() == QProcess::NotRunning)
         throw mp::StartException(vm_name, saved_error_msg);
 }


### PR DESCRIPTION
Due to how we are interacting with the Qt event loop, it's possible to crash
when deleting an instance while it's still launching. The after effect of this
is that concurrent client connections will block until launch (or other long
running commands) finishes.

A plan has been fleshed out to alleviate the concurrent blocking and will be
implemented later.

Fixes #585