### PR TITLE
[daemon] add missing QEventLoop include

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -42,6 +42,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include <QDir>
+#include <QEventLoop>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>


### PR DESCRIPTION
Removing QCoreApplication in #632 resulted in this symbol being missing.