### PR TITLE
[client] Make copy-files work with stdin and stdout

### DIFF
--- a/include/multipass/ssh/sftp_client.h
+++ b/include/multipass/ssh/sftp_client.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_SFTP_CLIENT_H
+#define MULTIPASS_SFTP_CLIENT_H
+
+#include <multipass/ssh/ssh_session.h>
+
+#include <libssh/libssh.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace multipass
+{
+using SSHSessionUPtr = std::unique_ptr<SSHSession>;
+
+class SFTPClient
+{
+public:
+    SFTPClient(const std::string& host, int port, const std::string& username, const std::string& priv_key_blob);
+    SFTPClient(SSHSessionUPtr ssh_session);
+
+    void push_file(const std::string& source_path, const std::string& destination_path);
+    void pull_file(const std::string& source_path, const std::string& destination_path);
+    void stream_file(const std::string& destination_path);
+
+private:
+    SSHSessionUPtr ssh_session;
+};
+}
+#endif // MULTIPASS_SFTP_CLIENT_H

--- a/include/multipass/ssh/sftp_client.h
+++ b/include/multipass/ssh/sftp_client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/client/cmd/copy_files.cpp
+++ b/src/client/cmd/copy_files.cpp
@@ -25,7 +25,6 @@
 
 #include <QDir>
 #include <QFileInfo>
-#include <QTemporaryFile>
 
 namespace mp = multipass;
 namespace cmd = multipass::cmd;

--- a/src/client/cmd/copy_files.cpp
+++ b/src/client/cmd/copy_files.cpp
@@ -33,8 +33,8 @@ using RpcMethod = mp::Rpc::Stub;
 
 namespace
 {
-const char* teplateMask{"temp"};
-const char* templateSymbol{"-"};
+const char* teplate_mask{"temp"};
+const char* template_symbol{"-"};
 const char* stdin_path {"/dev/stdin"};
 const char* stdout_path{"/dev/stdout"};
 }
@@ -61,7 +61,7 @@ mp::ReturnCode cmd::CopyFiles::run(mp::ArgParser* parser)
             {
                 if (stdin_path == source.second)
                 {
-                    temp_file.setFileTemplate(teplateMask);
+                    temp_file.setFileTemplate(teplate_mask);
                     if (!temp_file.open())
                         return ReturnCode::CommandFail;
 
@@ -159,7 +159,7 @@ mp::ParseCode cmd::CopyFiles::parse_args(mp::ArgParser* parser)
         const auto arguments = parser->positionalArguments();
         const auto is_valid_template = !std::all_of(arguments.begin(), arguments.end(), [](const QString& argument)
         {
-            return (templateSymbol == argument);
+            return (template_symbol == argument);
         });
 
         if (!is_valid_template)
@@ -201,7 +201,7 @@ multipass::ParseCode cmd::CopyFiles::parse_sources(multipass::ArgParser *parser,
             return ParseCode::CommandLineError;
         }
 
-        if (allow_templates && templateSymbol == source_path)
+        if (allow_templates && template_symbol == source_path)
         {
             sources.emplace_back("", stdin_path);
             return ParseCode::Ok;
@@ -246,7 +246,7 @@ multipass::ParseCode cmd::CopyFiles::parse_destination(multipass::ArgParser *par
     QString destination_path, instance_name;
 
     mcp::parse_copy_files_entry(destination_entry, destination_path, instance_name);
-    if (allow_templates && templateSymbol == destination_path)
+    if (allow_templates && template_symbol == destination_path)
     {
         destination = std::make_pair("", stdout_path);
         return ParseCode::Ok;

--- a/src/client/cmd/copy_files.cpp
+++ b/src/client/cmd/copy_files.cpp
@@ -21,6 +21,7 @@
 #include <multipass/cli/argparser.h>
 #include <multipass/cli/client_platform.h>
 #include <multipass/ssh/scp_client.h>
+#include <multipass/ssh/sftp_client.h>
 
 #include <QDir>
 #include <QFileInfo>
@@ -33,14 +34,13 @@ using RpcMethod = mp::Rpc::Stub;
 
 namespace
 {
-const char* teplate_mask{"temp"};
-const char* template_symbol{"-"};
-const char* stdin_path {"/dev/stdin"};
+const char template_symbol{'-'};
 const char* stdout_path{"/dev/stdout"};
 }
 
 mp::ReturnCode cmd::CopyFiles::run(mp::ArgParser* parser)
 {
+    streaming_enabled = false;
     auto ret = parse_args(parser);
     if (ret != ParseCode::Ok)
     {
@@ -51,31 +51,6 @@ mp::ReturnCode cmd::CopyFiles::run(mp::ArgParser* parser)
         // TODO: mainly for testing - need a better way to test parsing
         if (reply.ssh_info().empty())
             return ReturnCode::Ok;
-
-        // NOTE: need temp file before pushing copy to an instance, because we need to know size of file
-        QTemporaryFile temp_file;
-        if (sources.size() == 1)
-        {
-            auto& source = sources.front();
-            if (source.second == stdin_path)
-            {
-                if (stdin_path == source.second)
-                {
-                    temp_file.setFileTemplate(teplate_mask);
-                    if (!temp_file.open())
-                        return ReturnCode::CommandFail;
-
-                    QTextStream in_stream(stdin);
-                    QTextStream out_stream(&temp_file);
-
-                    while (!in_stream.atEnd())
-                        out_stream << in_stream.readAll();
-
-                    source.second = temp_file.fileName().toStdString();
-                }
-
-            }
-        }
 
         for (const auto& source : sources)
         {
@@ -96,6 +71,15 @@ mp::ReturnCode cmd::CopyFiles::run(mp::ArgParser* parser)
 
             try
             {
+                // NOTE: asked only for streaming, but also has
+                // functionality for pushing and pulling files
+                if (streaming_enabled)
+                {
+                    mp::SFTPClient sftp_client{host, port, username, priv_key_blob};
+                    sftp_client.stream_file(destination.second);
+                    continue;
+                }
+
                 mp::SCPClient scp_client{host, port, username, priv_key_blob};
                 if (!destination.first.empty())
                     scp_client.push_file(source.second, destination.second);
@@ -203,7 +187,8 @@ multipass::ParseCode cmd::CopyFiles::parse_sources(multipass::ArgParser *parser,
 
         if (allow_templates && template_symbol == source_path)
         {
-            sources.emplace_back("", stdin_path);
+            streaming_enabled = true;
+            sources.emplace_back(instance_name.toStdString(), "");
             return ParseCode::Ok;
         }
 

--- a/src/client/cmd/copy_files.h
+++ b/src/client/cmd/copy_files.h
@@ -43,6 +43,8 @@ private:
     std::pair<std::string, std::string> destination;
 
     ParseCode parse_args(ArgParser* parser) override;
+    ParseCode parse_sources(ArgParser* parser, bool allow_templates);
+    ParseCode parse_destination(ArgParser* parser, bool allow_templates);
 };
 }
 }

--- a/src/client/cmd/copy_files.h
+++ b/src/client/cmd/copy_files.h
@@ -41,6 +41,7 @@ private:
     SSHInfoRequest request;
     std::vector<std::pair<std::string, std::string>> sources;
     std::pair<std::string, std::string> destination;
+    bool streaming_enabled;
 
     ParseCode parse_args(ArgParser* parser) override;
     ParseCode parse_sources(ArgParser* parser, bool allow_templates);

--- a/src/ssh/CMakeLists.txt
+++ b/src/ssh/CMakeLists.txt
@@ -34,6 +34,7 @@ endif()
 
 function(add_scp_client_target TARGET_NAME)
   add_library(${TARGET_NAME} STATIC
+    sftp_client.cpp
     scp_client.cpp
     ssh_session.cpp)
 

--- a/src/ssh/sftp_client.cpp
+++ b/src/ssh/sftp_client.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "libssh/sftp.h"
+
+#include <multipass/ssh/sftp_client.h>
+#include <multipass/ssh/throw_on_error.h>
+#include <multipass/utils.h>
+
+#include "ssh_client_key_provider.h"
+
+#include <fmt/format.h>
+
+#include <array>
+#include <fcntl.h>
+
+#include <QFile>
+#include <QTextStream>
+
+namespace mp = multipass;
+
+namespace
+{
+constexpr int file_mode = 0664;
+const std::string stream_file_name{"stream_output.dat"};
+
+using SFTPUPtr = std::unique_ptr<sftp_session_struct, void (*)(sftp_session)>;
+
+SFTPUPtr make_sftp_session(ssh_session session)
+{
+    SFTPUPtr sftp{sftp_new(session), sftp_free};
+
+    if (sftp == nullptr)
+        throw std::runtime_error(fmt::format("could not create new sftp session: {}", ssh_get_error(session)));
+
+    return sftp;
+}
+
+std::string full_destination(const std::string& destination_path, const std::string& filename)
+{
+    if (destination_path.empty())
+    {
+        return filename;
+    }
+    else if (mp::utils::is_dir(destination_path))
+    {
+        return fmt::format("{}/{}", destination_path, filename);
+    }
+
+    return destination_path;
+}
+} // namespace
+
+mp::SFTPClient::SFTPClient(const std::string& host, int port, const std::string& username,
+                         const std::string& priv_key_blob)
+    : SFTPClient{std::make_unique<mp::SSHSession>(host, port, username, mp::SSHClientKeyProvider(priv_key_blob))}
+{ }
+
+mp::SFTPClient::SFTPClient(SSHSessionUPtr ssh_session) : ssh_session{std::move(ssh_session)}
+{ }
+
+void mp::SFTPClient::push_file(const std::string& source_path, const std::string& destination_path)
+{
+    auto full_destination_path = full_destination(destination_path, mp::utils::filename_for(source_path));
+    SFTPUPtr sftp{make_sftp_session(*ssh_session)};
+    SSH::throw_on_error(sftp, *ssh_session, "[sftp push] init failed", sftp_init);
+
+    QFile source(QString::fromStdString(source_path));
+    const auto size{source.size()};
+    auto file_handle = sftp_open(sftp.get(), full_destination_path.c_str(), O_WRONLY|O_CREAT|O_TRUNC, file_mode);
+    SSH::throw_on_error(sftp, *ssh_session, "[sftp push] failed", sftp_get_error);
+
+    int total{0};
+    std::array<char, 65536u> data;
+
+    if (!source.open(QIODevice::ReadOnly))
+        throw std::runtime_error(
+            fmt::format("[sftp push] error opening file for reading: {}", source.errorString().toStdString()));
+
+    do
+    {
+        auto r = source.read(data.data(), data.size());
+
+        if (r == -1)
+            throw std::runtime_error(
+                fmt::format("[sftp push] error reading file: {}" + source.errorString().toStdString()));
+        if (r == 0)
+            break;
+
+        sftp_write(file_handle, data.data(), r);
+        SSH::throw_on_error(sftp, *ssh_session, "[sftp push] remote write failed", sftp_get_error);
+
+        total += r;
+    } while (total < size);
+
+    sftp_close(file_handle);
+    SSH::throw_on_error(sftp, *ssh_session, "[sftp push] close failed", sftp_get_error);
+}
+
+void mp::SFTPClient::pull_file(const std::string& source_path, const std::string& destination_path)
+{
+    SFTPUPtr sftp{make_sftp_session(*ssh_session)};
+    SSH::throw_on_error(sftp, *ssh_session, "[sftp pull] init failed", sftp_init);
+
+    const auto file_attributes = sftp_stat(sftp.get(), source_path.c_str());
+    SSH::throw_on_error(sftp, *ssh_session, "[sftp pull] getting stat failed", sftp_get_error);
+
+    const auto size = file_attributes->size;
+    const std::string filename{file_attributes->name};
+
+    auto total{0u};
+    std::array<char, 65536u> data;
+
+    auto full_destination_path = full_destination(destination_path, filename);
+    QFile destination(QString::fromStdString(full_destination_path));
+    if (!destination.open(QIODevice::WriteOnly))
+        throw std::runtime_error(
+            fmt::format("[sftp pull] error opening file for writing: {}", destination.errorString().toStdString()));
+
+    auto file_handle = sftp_open(sftp.get(), destination_path.c_str(), O_RDONLY, 0664);
+    SSH::throw_on_error(sftp, *ssh_session, "[sftp pull] failed", sftp_get_error);
+
+    int r;
+    do
+    {
+        r = sftp_read(file_handle, data.data(), data.size());
+
+        if (r == 0)
+            break;
+
+        if (destination.write(data.data(), r) == -1)
+            throw std::runtime_error(
+                fmt::format("[sftp pull] error writing to file: {}", destination.errorString().toStdString()));
+
+        total += r;
+    } while (total < size);
+
+    sftp_close(file_handle);
+    SSH::throw_on_error(sftp, *ssh_session, "[sftp push] close failed", sftp_get_error);
+}
+
+void mp::SFTPClient::stream_file(const std::string &destination_path)
+{
+    auto full_destination_path = full_destination(destination_path, stream_file_name);
+    SFTPUPtr sftp{make_sftp_session(*ssh_session)};
+    SSH::throw_on_error(sftp, *ssh_session, "[sftp stream] init session failed", sftp_init);
+
+    auto file_handle = sftp_open(sftp.get(), full_destination_path.c_str(), O_WRONLY|O_CREAT|O_TRUNC, 0664);
+    SSH::throw_on_error(sftp, *ssh_session, "[sftp stream] open failed", sftp_get_error);
+
+    QTextStream in_stream(stdin);
+    QString text = in_stream.readAll();
+    QByteArray data = text.toUtf8();
+
+    int total{0};
+    do
+    {
+        total += sftp_write(file_handle, data.data(), data.size());
+        SSH::throw_on_error(sftp, *ssh_session, "[sftp push] remote write failed", sftp_get_error);
+    } while (total < data.size());
+
+    sftp_close(file_handle);
+    SSH::throw_on_error(sftp, *ssh_session, "[sftp push] close failed", sftp_get_error);
+}

--- a/src/ssh/sftp_client.cpp
+++ b/src/ssh/sftp_client.cpp
@@ -132,7 +132,7 @@ void mp::SFTPClient::pull_file(const std::string& source_path, const std::string
         throw std::runtime_error(
             fmt::format("[sftp pull] error opening file for writing: {}", destination.errorString().toStdString()));
 
-    auto file_handle = sftp_open(sftp.get(), destination_path.c_str(), O_RDONLY, 0664);
+    auto file_handle = sftp_open(sftp.get(), destination_path.c_str(), O_RDONLY, file_mode);
     SSH::throw_on_error(sftp, *ssh_session, "[sftp pull] failed", sftp_get_error);
 
     int r;
@@ -160,7 +160,7 @@ void mp::SFTPClient::stream_file(const std::string &destination_path)
     SFTPUPtr sftp{make_sftp_session(*ssh_session)};
     SSH::throw_on_error(sftp, *ssh_session, "[sftp stream] init session failed", sftp_init);
 
-    auto file_handle = sftp_open(sftp.get(), full_destination_path.c_str(), O_WRONLY|O_CREAT|O_TRUNC, 0664);
+    auto file_handle = sftp_open(sftp.get(), full_destination_path.c_str(), O_WRONLY|O_CREAT|O_TRUNC, file_mode);
     SSH::throw_on_error(sftp, *ssh_session, "[sftp stream] open failed", sftp_get_error);
 
     QTextStream in_stream(stdin);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,7 @@ add_executable(multipass_tests
   file_operations.cpp
   main.cpp
   mock_scp.cpp
+  mock_sftp.cpp
   mock_sftpserver.cpp
   mock_ssh.cpp
   mock_ssh_client.cpp
@@ -90,6 +91,7 @@ add_executable(multipass_tests
   test_simple_streams_index.cpp
   test_simple_streams_manifest.cpp
   test_scp_client.cpp
+  test_sftp_client.cpp
   test_sftpserver.cpp
   test_ssl_cert_provider.cpp
   test_sshfsmount.cpp

--- a/tests/c_mock_defines.cmake
+++ b/tests/c_mock_defines.cmake
@@ -61,6 +61,15 @@ add_c_mocks(
   sftp_handle
   sftp_handle_alloc
   sftp_handle_remove
+  sftp_new
+  sftp_init
+  sftp_open
+  sftp_write
+  sftp_stat
+  sftp_read
+  sftp_free
+  sftp_get_error
+  sftp_close
   ssh_scp_new
   ssh_scp_free
   ssh_scp_init

--- a/tests/mock_sftp.cpp
+++ b/tests/mock_sftp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/mock_sftp.cpp
+++ b/tests/mock_sftp.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "mock_sftp.h"
+extern "C" {
+IMPL_MOCK_DEFAULT(1, sftp_new);
+IMPL_MOCK_DEFAULT(1, sftp_free);
+IMPL_MOCK_DEFAULT(1, sftp_init);
+IMPL_MOCK_DEFAULT(4, sftp_open);
+IMPL_MOCK_DEFAULT(3, sftp_write);
+IMPL_MOCK_DEFAULT(2, sftp_stat);
+IMPL_MOCK_DEFAULT(3, sftp_read);
+IMPL_MOCK_DEFAULT(1, sftp_get_error);
+IMPL_MOCK_DEFAULT(1, sftp_close);
+}

--- a/tests/mock_sftp.h
+++ b/tests/mock_sftp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/mock_sftp.h
+++ b/tests/mock_sftp.h
@@ -15,29 +15,21 @@
  *
  */
 
-#ifndef MULTIPASS_MOCK_SFTPSERVER_H
-#define MULTIPASS_MOCK_SFTPSERVER_H
+#ifndef MULTIPASS_MOCK_SFTP_H
+#define MULTIPASS_MOCK_SFTP_H
 
 #include <premock.hpp>
 
-#define WITH_SERVER
 #include <libssh/sftp.h>
 
-DECL_MOCK(sftp_server_new);
-DECL_MOCK(sftp_server_init);
-DECL_MOCK(sftp_reply_status);
-DECL_MOCK(sftp_reply_attr);
-DECL_MOCK(sftp_reply_data);
-DECL_MOCK(sftp_reply_name);
-DECL_MOCK(sftp_reply_names);
-DECL_MOCK(sftp_reply_names_add);
-DECL_MOCK(sftp_reply_handle);
-DECL_MOCK(sftp_get_client_message);
-DECL_MOCK(sftp_client_message_free);
-DECL_MOCK(sftp_client_message_get_data);
-DECL_MOCK(sftp_client_message_get_filename);
-DECL_MOCK(sftp_handle);
-DECL_MOCK(sftp_handle_alloc);
-DECL_MOCK(sftp_handle_remove);
+DECL_MOCK(sftp_new);
+DECL_MOCK(sftp_free);
+DECL_MOCK(sftp_init);
+DECL_MOCK(sftp_open);
+DECL_MOCK(sftp_write);
+DECL_MOCK(sftp_stat);
+DECL_MOCK(sftp_read);
+DECL_MOCK(sftp_get_error);
+DECL_MOCK(sftp_close);
 
-#endif // MULTIPASS_MOCK_SFTPSERVER_H
+#endif // MULTIPASS_MOCK_SFTP_H

--- a/tests/mock_sftpserver.cpp
+++ b/tests/mock_sftpserver.cpp
@@ -19,7 +19,6 @@
 extern "C"
 {
     IMPL_MOCK_DEFAULT(2, sftp_server_new);
-    IMPL_MOCK_DEFAULT(1, sftp_free);
     IMPL_MOCK_DEFAULT(1, sftp_server_init);
     IMPL_MOCK_DEFAULT(3, sftp_reply_status);
     IMPL_MOCK_DEFAULT(2, sftp_reply_attr);

--- a/tests/sftp_server_test_fixture.h
+++ b/tests/sftp_server_test_fixture.h
@@ -19,6 +19,7 @@
 #define MULTIPASS_SFTP_SERVER_TEST_FIXTURE_H
 
 #include "mock_sftpserver.h"
+#include "mock_sftp.h"
 #include "mock_ssh.h"
 
 #include <gtest/gtest.h>

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -132,6 +132,19 @@ TEST_F(Client, copy_file_cmd_multiple_sources_destination_file_fails)
                 Eq(mp::ReturnCode::CommandLineError));
 }
 
+TEST_F(Client, copy_file_stdout_stdin_template_only_fails)
+{
+    EXPECT_THAT(send_command({"copy-files", "-", "-"}),
+                Eq(mp::ReturnCode::CommandLineError));
+}
+
+TEST_F(Client, copy_file_stdout_stdin_template_declaration_fails)
+{
+    EXPECT_THAT(send_command({"copy-files", "test-vm1:foo", "-", "-",
+                              mpt::test_data_path().toStdString() + "good_index.json"}),
+                Eq(mp::ReturnCode::CommandLineError));
+}
+
 // shell cli test
 TEST_F(Client, shell_cmd_good_arguments)
 {

--- a/tests/test_sftp_client.cpp
+++ b/tests/test_sftp_client.cpp
@@ -109,22 +109,6 @@ TEST_F(SFTPClient, push_throws_on_sftp_read_failed)
     EXPECT_THROW(sftp.push_file("foo", "bar"), std::runtime_error);
 }
 
-TEST_F(SFTPClient, push_throws_on_sftp_read_error)
-{
-    mpt::TempDir temp_dir;
-    auto file_name = temp_dir.path() + "/test-file";
-    mpt::make_file_with_content(file_name);
-
-    auto sftp = make_sftp_client();
-
-    REPLACE(sftp_new, [](auto...) { return new sftp_session_struct; });
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
-    REPLACE(sftp_open, [](auto...) { return nullptr; });
-    REPLACE(sftp_write, [](auto...) { return -1; });
-
-    EXPECT_THROW(sftp.push_file(file_name.toStdString(), "bar"), std::runtime_error);
-}
-
 TEST_F(SFTPClient, push_throws_on_sftp_write_error)
 {
     mpt::TempDir temp_dir;

--- a/tests/test_sftp_client.cpp
+++ b/tests/test_sftp_client.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "mock_sftp.h"
+#include "mock_ssh.h"
+
+#include "file_operations.h"
+#include "path.h"
+#include "temp_dir.h"
+
+#include <multipass/ssh/sftp_client.h>
+#include <multipass/ssh/ssh_session.h>
+
+#include <gmock/gmock.h>
+
+namespace mp = multipass;
+namespace mpt = multipass::test;
+
+namespace
+{
+struct SFTPClient : public testing::Test
+{
+    SFTPClient()
+    {
+        connect.returnValue(SSH_OK);
+        is_connected.returnValue(true);
+        open_session.returnValue(SSH_OK);
+    }
+
+    mp::SFTPClient make_sftp_client()
+    {
+        return {std::make_unique<mp::SSHSession>("b", 43)};
+    }
+
+    decltype(MOCK(ssh_connect)) connect{MOCK(ssh_connect)};
+    decltype(MOCK(ssh_is_connected)) is_connected{MOCK(ssh_is_connected)};
+    decltype(MOCK(ssh_channel_open_session)) open_session{MOCK(ssh_channel_open_session)};
+};
+}
+
+TEST_F(SFTPClient, throws_when_unable_to_allocate_scp_session)
+{
+    auto sftp = make_sftp_client();
+
+    REPLACE(sftp_new, [](auto...) { return nullptr; });
+
+    EXPECT_THROW(sftp.push_file("foo", "bar"), std::runtime_error);
+}
+
+TEST_F(SFTPClient, throws_when_failed_to_init)
+{
+    auto sftp = make_sftp_client();
+
+    REPLACE(sftp_init, [](auto...) { return SSH_ERROR; });
+
+    EXPECT_THROW(sftp.push_file("foo", "bar"), std::runtime_error);
+}
+
+TEST_F(SFTPClient, throws_on_sftp_write_error)
+{
+    mpt::TempDir temp_dir;
+    auto file_name = temp_dir.path() + "/test-file";
+    mpt::make_file_with_content(file_name);
+
+    auto sftp = make_sftp_client();
+
+    REPLACE(sftp_open, [](auto...) { return new sftp_file_struct; });
+
+    EXPECT_THROW(sftp.push_file(file_name.toStdString(), "bar"), std::runtime_error);
+}
+
+TEST_F(SFTPClient, throws_on_push_file_sftp_close_error)
+{
+    mpt::TempDir temp_dir;
+    auto file_name = temp_dir.path() + "/test-file";
+    mpt::make_file_with_content(file_name);
+
+    auto sftp = make_sftp_client();
+
+    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_open, [](auto...) { return new sftp_file_struct;});
+    REPLACE(sftp_write, [](auto...) { return 0; });
+    REPLACE(sftp_close, [](auto...) { return SSH_ERROR; });
+
+    EXPECT_THROW(sftp.push_file(file_name.toStdString(), "bar"), std::runtime_error);
+}
+
+TEST_F(SFTPClient, throws_on_push_file_invalid_source)
+{
+    auto sftp = make_sftp_client();
+
+    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_open, [](auto...) { return new sftp_file_struct; });
+    REPLACE(sftp_get_error, [](auto...) { return SSH_OK; });
+
+    EXPECT_THROW(sftp.push_file("/foo/bar", "bar"), std::runtime_error);
+}
+
+TEST_F(SFTPClient, throws_when_pull_file_error_getting_stat)
+{
+    auto sftp = make_sftp_client();
+
+    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+
+    EXPECT_THROW(sftp.pull_file("foo", "bar"), std::runtime_error);
+}
+
+TEST_F(SFTPClient, throws_on_pull_file_invalid_source)
+{
+    auto sftp = make_sftp_client();
+
+    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_open, [](auto...) { return new sftp_file_struct; });
+
+    EXPECT_THROW(sftp.pull_file("foo", "bar"), std::runtime_error);
+}
+
+TEST_F(SFTPClient, throws_on_sftp_read_error)
+{
+    mpt::TempDir temp_dir;
+    auto file_name = temp_dir.path() + "/test-file";
+    mpt::make_file_with_content(file_name);
+
+    auto sftp = make_sftp_client();
+
+    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_stat, [](auto...) { return new sftp_attributes_struct; });
+    REPLACE(sftp_open, [](auto...) { return new sftp_file_struct; });
+
+    EXPECT_THROW(sftp.push_file(file_name.toStdString(), "bar"), std::runtime_error);
+}
+
+TEST_F(SFTPClient, throws_on_pull_file_scp_close_error)
+{
+    mpt::TempDir temp_dir;
+    auto file_name = temp_dir.path() + "/test-file";
+
+    auto sftp = make_sftp_client();
+
+    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_stat, [](auto...) { return new sftp_attributes_struct; });
+    REPLACE(sftp_open, [](auto...) { return new sftp_file_struct; });
+    REPLACE(sftp_read, [](auto...) { return 0; });
+    REPLACE(sftp_close, [](auto...) { return SSH_ERROR; });
+
+    EXPECT_THROW(sftp.pull_file("foo", file_name.toStdString()), std::runtime_error);
+}


### PR DESCRIPTION
#578 Now working with stdin and stdout if template was setted from command line. Seems to be not a good solution, but if you have some thought how to optimaze, would be glad to hear it :-).