### PR TITLE
tests: Use namespace on function paramaters to fix build errors

### DIFF
--- a/tests/image_host_remote_count.cpp
+++ b/tests/image_host_remote_count.cpp
@@ -23,9 +23,10 @@
 #include <set>
 #include <string>
 
+namespace mp = multipass;
 namespace mpt = multipass::test;
 
-size_t mpt::count_remotes(VMImageHost& host)
+size_t mpt::count_remotes(mp::VMImageHost& host)
 {
     std::set<std::string> remotes;
     auto counting_action = [&remotes](const std::string& remote, const VMImageInfo&) { remotes.insert(remote); };

--- a/tests/mischievous_url_downloader.cpp
+++ b/tests/mischievous_url_downloader.cpp
@@ -17,6 +17,7 @@
 
 #include "mischievous_url_downloader.h"
 
+namespace mp = multipass;
 namespace mpt = multipass::test;
 
 mpt::MischievousURLDownloader::MischievousURLDownloader(std::chrono::milliseconds timeout) : URLDownloader(timeout)
@@ -24,7 +25,7 @@ mpt::MischievousURLDownloader::MischievousURLDownloader(std::chrono::millisecond
 }
 
 void mpt::MischievousURLDownloader::download_to(const QUrl& url, const QString& file_name, int64_t size,
-                                                const int download_type, const ProgressMonitor& monitor)
+                                                const int download_type, const mp::ProgressMonitor& monitor)
 {
     URLDownloader::download_to(choose_url(url), file_name, size, download_type, monitor);
 }


### PR DESCRIPTION
Some platforms are sensitive to name spacing and have build errors
when the namespace is left out.