### PR TITLE
Extract instance creation from launch

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -98,15 +98,13 @@ mp::Client::Client(ClientConfig& config)
     add_command<cmd::Umount>();
     add_command<cmd::Version>();
 
-    auto name_sort = [](cmd::Command::UPtr& a, cmd::Command::UPtr& b) { return a->name() < b->name(); };
-    std::sort(commands.begin(), commands.end(), name_sort);
+    sort_commands();
 }
 
-template <typename T>
-void mp::Client::add_command()
+void mp::Client::sort_commands()
 {
-    auto cmd = std::make_unique<T>(*rpc_channel, *stub, term);
-    commands.push_back(std::move(cmd));
+    auto name_sort = [](cmd::Command::UPtr& a, cmd::Command::UPtr& b) { return a->name() < b->name(); };
+    std::sort(commands.begin(), commands.end(), name_sort);
 }
 
 int mp::Client::run(const QStringList& arguments)

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -43,11 +43,15 @@ class Client
 {
 public:
     explicit Client(ClientConfig& context);
+    virtual ~Client() = default;
     int run(const QStringList& arguments);
 
-private:
+protected:
     template <typename T>
     void add_command();
+    void sort_commands();
+
+private:
     const std::unique_ptr<CertProvider> cert_provider;
     std::shared_ptr<grpc::Channel> rpc_channel;
     std::unique_ptr<multipass::Rpc::Stub> stub;
@@ -57,4 +61,12 @@ private:
     Terminal* term;
 };
 } // namespace multipass
+
+template <typename T>
+void multipass::Client::add_command()
+{
+    auto cmd = std::make_unique<T>(*rpc_channel, *stub, term);
+    commands.push_back(std::move(cmd));
+}
+
 #endif // MULTIPASS_CLIENT_H

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -625,101 +625,12 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
     source_images_maintenance_task.start(config->image_refresh_timer);
 }
 
-// TODO @ricab move below
-grpc::Status mp::Daemon::create_aux(grpc::ServerContext* context, const CreateRequest* request,
-                                    grpc::ServerWriter<CreateReply>* server, const std::string& name)
-{
-    if (vm_instances.find(name) != vm_instances.end() || deleted_instances.find(name) != deleted_instances.end())
-    {
-        CreateError create_error;
-        create_error.add_error_codes(CreateError::INSTANCE_EXISTS);
-
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, fmt::format("instance \"{}\" already exists", name),
-                            create_error.SerializeAsString());
-    }
-
-    auto query = query_from(request, name);
-
-    config->factory->check_hypervisor_support();
-
-    auto option_errors = validate_create_arguments(request);
-
-    if (!option_errors.error_codes().empty())
-    {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "Invalid arguments supplied",
-                            option_errors.SerializeAsString());
-    }
-
-    auto progress_monitor = [server](int progress_type, int percentage) {
-        CreateReply create_reply;
-        create_reply.mutable_launch_progress()->set_percent_complete(std::to_string(percentage));
-        create_reply.mutable_launch_progress()->set_type((CreateProgress::ProgressTypes)progress_type);
-        return server->Write(create_reply);
-    };
-
-    auto prepare_action = [this, server, &name](const VMImage& source_image) -> VMImage {
-        CreateReply reply;
-        reply.set_create_message("Preparing image for " + name);
-        server->Write(reply);
-
-        return config->factory->prepare_source_image(source_image);
-    };
-
-    auto fetch_type = config->factory->fetch_type();
-
-    CreateReply reply;
-    reply.set_create_message("Creating " + name);
-    server->Write(reply);
-    auto vm_image = config->vault->fetch_image(fetch_type, query, prepare_action, progress_monitor);
-
-    reply.set_create_message("Configuring " + name);
-    server->Write(reply);
-    auto vendor_data_cloud_init_config =
-        make_cloud_init_vendor_config(*config->ssh_key_provider, request->time_zone(), config->ssh_username);
-    auto meta_data_cloud_init_config = make_cloud_init_meta_config(name);
-    auto user_data_cloud_init_config = YAML::Load(request->cloud_init_user_data());
-    prepare_user_data(user_data_cloud_init_config, vendor_data_cloud_init_config);
-    config->factory->configure(name, meta_data_cloud_init_config, vendor_data_cloud_init_config);
-
-    std::string mac_addr;
-    while (true)
-    {
-        mac_addr = mp::utils::generate_mac_address();
-
-        auto it = allocated_mac_addrs.find(mac_addr);
-        if (it == allocated_mac_addrs.end())
-        {
-            allocated_mac_addrs.insert(mac_addr);
-            break;
-        }
-    }
-    auto vm_desc =
-        to_machine_desc(request, name, mac_addr, config->ssh_username, vm_image, meta_data_cloud_init_config,
-                        user_data_cloud_init_config, vendor_data_cloud_init_config, *config->ssh_key_provider);
-
-    config->factory->prepare_instance_image(vm_image, vm_desc);
-
-    vm_instances[name] = config->factory->create_virtual_machine(vm_desc, *this);
-    vm_instance_specs[name] = {vm_desc.num_cores,
-                               vm_desc.mem_size,
-                               vm_desc.disk_space,
-                               vm_desc.mac_addr,
-                               config->ssh_username,
-                               VirtualMachine::State::off,
-                               {},
-                               false,
-                               QJsonObject()};
-    persist_instances();
-
-    return grpc::Status::OK;
-}
-
 grpc::Status mp::Daemon::create(grpc::ServerContext* context, const CreateRequest* request,
                                 grpc::ServerWriter<CreateReply>* server) // clang-format off
 try // clang-format on
 {
     mpl::ClientLogger<CreateReply> logger{mpl::level_from(request->verbosity_level()), *config->logger, server};
-    return create_aux(context, request, server, name_from(request, *config->name_generator, vm_instances));
+    return create_vm(context, request, server, name_from(request, *config->name_generator, vm_instances));
 }
 catch (const std::exception& e)
 {
@@ -763,7 +674,7 @@ try // clang-format on
         metrics_provider.send_metrics();
 
     auto name = name_from(request, *config->name_generator, vm_instances);
-    auto status = create_aux(context, request, server, name);
+    auto status = create_vm(context, request, server, name);
     if (status.ok())
     {
         LaunchReply reply;
@@ -1986,6 +1897,94 @@ std::string mp::Daemon::check_instance_exists(const std::string& instance_name) 
         return fmt::format("instance \"{}\" does not exist\n", instance_name);
 
     return {};
+}
+
+grpc::Status mp::Daemon::create_vm(grpc::ServerContext* context, const CreateRequest* request,
+                                   grpc::ServerWriter<CreateReply>* server, const std::string& name)
+{
+    if (vm_instances.find(name) != vm_instances.end() || deleted_instances.find(name) != deleted_instances.end())
+    {
+        CreateError create_error;
+        create_error.add_error_codes(CreateError::INSTANCE_EXISTS);
+
+        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, fmt::format("instance \"{}\" already exists", name),
+                            create_error.SerializeAsString());
+    }
+
+    auto query = query_from(request, name);
+
+    config->factory->check_hypervisor_support();
+
+    auto option_errors = validate_create_arguments(request);
+
+    if (!option_errors.error_codes().empty())
+    {
+        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "Invalid arguments supplied",
+                            option_errors.SerializeAsString());
+    }
+
+    auto progress_monitor = [server](int progress_type, int percentage) {
+        CreateReply create_reply;
+        create_reply.mutable_launch_progress()->set_percent_complete(std::to_string(percentage));
+        create_reply.mutable_launch_progress()->set_type((CreateProgress::ProgressTypes)progress_type);
+        return server->Write(create_reply);
+    };
+
+    auto prepare_action = [this, server, &name](const VMImage& source_image) -> VMImage {
+        CreateReply reply;
+        reply.set_create_message("Preparing image for " + name);
+        server->Write(reply);
+
+        return config->factory->prepare_source_image(source_image);
+    };
+
+    auto fetch_type = config->factory->fetch_type();
+
+    CreateReply reply;
+    reply.set_create_message("Creating " + name);
+    server->Write(reply);
+    auto vm_image = config->vault->fetch_image(fetch_type, query, prepare_action, progress_monitor);
+
+    reply.set_create_message("Configuring " + name);
+    server->Write(reply);
+    auto vendor_data_cloud_init_config =
+        make_cloud_init_vendor_config(*config->ssh_key_provider, request->time_zone(), config->ssh_username);
+    auto meta_data_cloud_init_config = make_cloud_init_meta_config(name);
+    auto user_data_cloud_init_config = YAML::Load(request->cloud_init_user_data());
+    prepare_user_data(user_data_cloud_init_config, vendor_data_cloud_init_config);
+    config->factory->configure(name, meta_data_cloud_init_config, vendor_data_cloud_init_config);
+
+    std::string mac_addr;
+    while (true)
+    {
+        mac_addr = mp::utils::generate_mac_address();
+
+        auto it = allocated_mac_addrs.find(mac_addr);
+        if (it == allocated_mac_addrs.end())
+        {
+            allocated_mac_addrs.insert(mac_addr);
+            break;
+        }
+    }
+    auto vm_desc =
+        to_machine_desc(request, name, mac_addr, config->ssh_username, vm_image, meta_data_cloud_init_config,
+                        user_data_cloud_init_config, vendor_data_cloud_init_config, *config->ssh_key_provider);
+
+    config->factory->prepare_instance_image(vm_image, vm_desc);
+
+    vm_instances[name] = config->factory->create_virtual_machine(vm_desc, *this);
+    vm_instance_specs[name] = {vm_desc.num_cores,
+                               vm_desc.mem_size,
+                               vm_desc.disk_space,
+                               vm_desc.mac_addr,
+                               config->ssh_username,
+                               VirtualMachine::State::off,
+                               {},
+                               false,
+                               QJsonObject()};
+    persist_instances();
+
+    return grpc::Status::OK;
 }
 
 grpc::Status mp::Daemon::reboot_vm(VirtualMachine& vm)

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -124,6 +124,9 @@ public slots:
                          grpc::ServerWriter<VersionReply>* response) override;
 
 private:
+    grpc::Status create(grpc::ServerContext* context, const LaunchRequest* request,
+                        grpc::ServerWriter<LaunchReply>* server,
+                        const std::string& name); // TODO @ricab rename request/reply
     void persist_instances();
     void start_mount(const VirtualMachine::UPtr& vm, const std::string& name, const std::string& source_path,
                      const std::string& target_path, const std::unordered_map<int, int>& gid_map,

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -136,7 +136,7 @@ private:
     std::string check_instance_operational(const std::string& instance_name) const;
     std::string check_instance_exists(const std::string& instance_name) const;
     grpc::Status create_vm(grpc::ServerContext* context, const CreateRequest* request,
-                           grpc::ServerWriter<CreateReply>* server, const std::string& name);
+                           grpc::ServerWriter<CreateReply>* server, bool start);
     grpc::Status reboot_vm(VirtualMachine& vm);
     grpc::Status shutdown_vm(VirtualMachine& vm, const std::chrono::milliseconds delay);
     grpc::Status cancel_vm_shutdown(const VirtualMachine& vm);

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -135,8 +135,8 @@ private:
     void release_resources(const std::string& instance);
     std::string check_instance_operational(const std::string& instance_name) const;
     std::string check_instance_exists(const std::string& instance_name) const;
-    grpc::Status create_aux(grpc::ServerContext* context, const CreateRequest* request,
-                            grpc::ServerWriter<CreateReply>* server, const std::string& name);
+    grpc::Status create_vm(grpc::ServerContext* context, const CreateRequest* request,
+                           grpc::ServerWriter<CreateReply>* server, const std::string& name);
     grpc::Status reboot_vm(VirtualMachine& vm);
     grpc::Status shutdown_vm(VirtualMachine& vm, const std::chrono::milliseconds delay);
     grpc::Status cancel_vm_shutdown(const VirtualMachine& vm);

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -78,6 +78,9 @@ protected:
     QJsonObject retrieve_metadata_for(const std::string& name) override;
 
 public slots:
+    grpc::Status create(grpc::ServerContext* context, const CreateRequest* request,
+                        grpc::ServerWriter<CreateReply>* reply) override;
+
     grpc::Status launch(grpc::ServerContext* context, const LaunchRequest* request,
                         grpc::ServerWriter<LaunchReply>* reply) override;
 
@@ -124,9 +127,6 @@ public slots:
                          grpc::ServerWriter<VersionReply>* response) override;
 
 private:
-    grpc::Status create(grpc::ServerContext* context, const LaunchRequest* request,
-                        grpc::ServerWriter<LaunchReply>* server,
-                        const std::string& name); // TODO @ricab rename request/reply
     void persist_instances();
     void start_mount(const VirtualMachine::UPtr& vm, const std::string& name, const std::string& source_path,
                      const std::string& target_path, const std::unordered_map<int, int>& gid_map,
@@ -135,6 +135,8 @@ private:
     void release_resources(const std::string& instance);
     std::string check_instance_operational(const std::string& instance_name) const;
     std::string check_instance_exists(const std::string& instance_name) const;
+    grpc::Status create_aux(grpc::ServerContext* context, const CreateRequest* request,
+                            grpc::ServerWriter<CreateReply>* server, const std::string& name);
     grpc::Status reboot_vm(VirtualMachine& vm);
     grpc::Status shutdown_vm(VirtualMachine& vm, const std::chrono::milliseconds delay);
     grpc::Status cancel_vm_shutdown(const VirtualMachine& vm);

--- a/src/daemon/daemon_rpc.cpp
+++ b/src/daemon/daemon_rpc.cpp
@@ -94,6 +94,12 @@ mp::DaemonRpc::DaemonRpc(const std::string& server_address, mp::RpcConnectionTyp
     mpl::log(mpl::Level::info, category, fmt::format("gRPC listening on {}, SSL:{}", server_address, ssl_enabled));
 }
 
+grpc::Status mp::DaemonRpc::create(grpc::ServerContext* context, const CreateRequest* request,
+                                   grpc::ServerWriter<CreateReply>* reply)
+{
+    return emit on_create(context, request, reply); // must block until slot returns
+}
+
 grpc::Status mp::DaemonRpc::launch(grpc::ServerContext* context, const LaunchRequest* request,
                                    grpc::ServerWriter<LaunchReply>* reply)
 {

--- a/src/daemon/daemon_rpc.h
+++ b/src/daemon/daemon_rpc.h
@@ -31,6 +31,11 @@
 
 namespace multipass
 {
+using CreateRequest = LaunchRequest;
+using CreateReply = LaunchReply;
+using CreateError = LaunchError;
+using CreateProgress = LaunchProgress;
+
 struct DaemonConfig;
 class DaemonRpc : public QObject, public multipass::Rpc::Service
 {
@@ -43,6 +48,8 @@ public:
 
 signals:
     // All these signals must be connected to with a BlockingQueuedConnection!!!
+    grpc::Status on_create(grpc::ServerContext* context, const CreateRequest* request,
+                           grpc::ServerWriter<CreateReply>* reply);
     grpc::Status on_launch(grpc::ServerContext* context, const LaunchRequest* request,
                            grpc::ServerWriter<LaunchReply>* reply);
     grpc::Status on_purge(grpc::ServerContext* context, const PurgeRequest* request,
@@ -79,6 +86,8 @@ private:
     const std::unique_ptr<grpc::Server> server;
 
 protected:
+    grpc::Status create(grpc::ServerContext* context, const CreateRequest* request,
+                        grpc::ServerWriter<CreateReply>* reply) override;
     grpc::Status launch(grpc::ServerContext* context, const LaunchRequest* request,
                         grpc::ServerWriter<LaunchReply>* reply) override;
     grpc::Status purge(grpc::ServerContext* context, const PurgeRequest* request,

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package multipass;
 
 service Rpc {
+    rpc create (LaunchRequest) returns (stream LaunchReply);
     rpc launch (LaunchRequest) returns (stream LaunchReply);
     rpc purge (PurgeRequest) returns (stream PurgeReply);
     rpc find (FindRequest) returns (stream FindReply);

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -209,7 +209,7 @@ TEST_F(Daemon, receives_commands)
                    {"umount", "instance"}});
 }
 
-TEST_F(Daemon, creates_virtual_machines)
+TEST_F(Daemon, launches_virtual_machines)
 {
     auto mock_factory = use_a_mock_vm_factory();
     mp::Daemon daemon{config_builder.build()};
@@ -218,7 +218,7 @@ TEST_F(Daemon, creates_virtual_machines)
     send_command({"launch"});
 }
 
-TEST_F(Daemon, on_creation_hooks_up_platform_prepare_source_image)
+TEST_F(Daemon, on_launch_hooks_up_platform_prepare_source_image)
 {
     auto mock_factory = use_a_mock_vm_factory();
     mp::Daemon daemon{config_builder.build()};
@@ -227,7 +227,7 @@ TEST_F(Daemon, on_creation_hooks_up_platform_prepare_source_image)
     send_command({"launch"});
 }
 
-TEST_F(Daemon, on_creation_hooks_up_platform_prepare_instance_image)
+TEST_F(Daemon, on_launch_hooks_up_platform_prepare_instance_image)
 {
     auto mock_factory = use_a_mock_vm_factory();
     mp::Daemon daemon{config_builder.build()};
@@ -246,7 +246,7 @@ TEST_F(Daemon, provides_version)
     EXPECT_THAT(stream.str(), HasSubstr(mp::version_string));
 }
 
-TEST_F(Daemon, generates_name_when_client_does_not_provide_one)
+TEST_F(Daemon, generates_name_on_launch_when_client_does_not_provide_one)
 {
     const std::string expected_name{"pied-piper-valley"};
 
@@ -340,7 +340,7 @@ MATCHER_P(YAMLNodeContainsSequence, key, "")
     return arg[key].IsSequence();
 }
 
-TEST_F(Daemon, default_cloud_init_grows_root_fs)
+TEST_F(Daemon, default_cloud_init_grows_root_fs_on_launch)
 {
     auto mock_factory = use_a_mock_vm_factory();
     mp::Daemon daemon{config_builder.build()};
@@ -380,7 +380,7 @@ private:
 };
 } // namespace
 
-TEST_F(Daemon, adds_ssh_keys_to_cloud_init_config)
+TEST_F(Daemon, adds_ssh_keys_to_cloud_init_config_on_launch)
 {
     auto mock_factory = use_a_mock_vm_factory();
     std::string expected_key{"thisitnotansshkeyactually"};

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -58,6 +58,8 @@ namespace
 struct MockDaemon : public mp::Daemon
 {
     using mp::Daemon::Daemon;
+    MOCK_METHOD3(create,
+                 grpc::Status(grpc::ServerContext*, const mp::CreateRequest*, grpc::ServerWriter<mp::CreateReply>*));
     MOCK_METHOD3(launch,
                  grpc::Status(grpc::ServerContext*, const mp::LaunchRequest*, grpc::ServerWriter<mp::LaunchReply>*));
     MOCK_METHOD3(purge,
@@ -85,8 +87,6 @@ struct MockDaemon : public mp::Daemon
                                       grpc::ServerWriter<mp::UmountReply>* response));
     MOCK_METHOD3(version,
                  grpc::Status(grpc::ServerContext*, const mp::VersionRequest*, grpc::ServerWriter<mp::VersionReply>*));
-    MOCK_METHOD3(create,
-                 grpc::Status(grpc::ServerContext*, const mp::CreateRequest*, grpc::ServerWriter<mp::CreateReply>*));
 };
 
 struct StubNameGenerator : public mp::NameGenerator
@@ -228,6 +228,7 @@ TEST_F(Daemon, receives_commands)
 {
     MockDaemon daemon{config_builder.build()};
 
+    EXPECT_CALL(daemon, create(_, _, _));
     EXPECT_CALL(daemon, launch(_, _, _));
     EXPECT_CALL(daemon, purge(_, _, _));
     EXPECT_CALL(daemon, find(_, _, _));
@@ -243,9 +244,9 @@ TEST_F(Daemon, receives_commands)
     EXPECT_CALL(daemon, version(_, _, _));
     EXPECT_CALL(daemon, mount(_, _, _));
     EXPECT_CALL(daemon, umount(_, _, _));
-    EXPECT_CALL(daemon, create(_, _, _));
 
-    send_commands({{"launch", "foo"},
+    send_commands({{"test_create", "foo"},
+                   {"launch", "foo"},
                    {"delete", "foo"},
                    {"exec", "foo", "--", "cmd"},
                    {"info", "foo"},
@@ -259,8 +260,7 @@ TEST_F(Daemon, receives_commands)
                    {"version"},
                    {"find", "something"},
                    {"mount", ".", "target"},
-                   {"umount", "instance"},
-                   {"test_create", "foo"}});
+                   {"umount", "instance"}});
 }
 
 TEST_F(Daemon, launches_virtual_machines)

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -46,6 +46,7 @@
 #include <QCoreApplication>
 
 #include <memory>
+#include <ostream>
 #include <sstream>
 #include <string>
 
@@ -109,7 +110,10 @@ public:
     {
         auto on_success = [](mp::CreateReply& /*reply*/) { return mp::ReturnCode::Ok; };
         auto on_failure = [](grpc::Status& /*status*/) { return mp::ReturnCode::CommandFail; };
-        auto streaming_callback = [](mp::CreateReply& /*reply*/) { /*pass*/ };
+        auto streaming_callback = [this](mp::CreateReply& reply)
+        {
+            cout << reply.create_message() << std::endl;
+        };
 
         return dispatch(&mp::Rpc::Stub::create, request, on_success, on_failure, streaming_callback);
     }

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -283,6 +283,14 @@ struct DaemonCreateLaunchTestSuite : public Daemon, public WithParamInterface<st
 {
 };
 
+struct MinSpaceRespectedSuite : public Daemon, public WithParamInterface<std::tuple<std::string, std::string>>
+{
+};
+
+struct MinSpaceViolatedSuite : public Daemon, public WithParamInterface<std::tuple<std::string, std::string>>
+{
+};
+
 TEST_P(DaemonCreateLaunchTestSuite, creates_virtual_machines)
 {
     auto mock_factory = use_a_mock_vm_factory();
@@ -458,16 +466,6 @@ TEST_P(DaemonCreateLaunchTestSuite, adds_ssh_keys_to_cloud_init_config)
     send_command({GetParam()});
 }
 
-INSTANTIATE_TEST_SUITE_P(Daemon, DaemonCreateLaunchTestSuite, Values("launch", "test_create"));
-
-struct MinSpaceRespectedSuite : public Daemon, public WithParamInterface<std::tuple<std::string, std::string>>
-{
-};
-
-struct MinSpaceViolatedSuite : public Daemon, public WithParamInterface<std::tuple<std::string, std::string>>
-{
-};
-
 TEST_P(MinSpaceRespectedSuite, accepts_launch_with_enough_explicit_memory)
 {
     auto mock_factory = use_a_mock_vm_factory();
@@ -497,6 +495,7 @@ TEST_P(MinSpaceViolatedSuite, refuses_launch_with_memory_below_threshold)
                 AllOf(HasSubstr("fail"), AnyOf(HasSubstr("memory"), HasSubstr("disk")), HasSubstr("minimum")));
 }
 
+INSTANTIATE_TEST_SUITE_P(Daemon, DaemonCreateLaunchTestSuite, Values("launch", "test_create"));
 INSTANTIATE_TEST_SUITE_P(Daemon, MinSpaceRespectedSuite,
                          Combine(Values("--mem", "--disk"), Values("1024m", "2Gb", "987654321")));
 INSTANTIATE_TEST_SUITE_P(Daemon, MinSpaceViolatedSuite,


### PR DESCRIPTION
Place instance creation in a separate method, to prepare the way to create without launching.