### PR TITLE
daemon: Remove timer that waits for the suspend operation to finish

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1574,7 +1574,7 @@ try // clang-format on
         }
 
         status = cmd_vms(instances_to_suspend, [this](auto& vm) {
-            stop_mounts_for_instance(vm.vm_name);
+            this->stop_mounts_for_instance(vm.vm_name);
             vm.suspend();
             return grpc::Status::OK;
         });

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1573,13 +1573,11 @@ try // clang-format on
                 instances_to_suspend.push_back(pair.first);
         }
 
-        for (const auto& name : instances_to_suspend)
-        {
-            stop_mounts_for_instance(name);
-
-            auto it = vm_instances.find(name);
-            it->second->suspend();
-        }
+        status = cmd_vms(instances_to_suspend, [this](auto& vm) {
+            stop_mounts_for_instance(vm.vm_name);
+            vm.suspend();
+            return grpc::Status::OK;
+        });
     }
 
     return status;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1577,18 +1577,8 @@ try // clang-format on
         {
             stop_mounts_for_instance(name);
 
-            QTimer timer;
-            QEventLoop event_loop;
-
-            QObject::connect(this, &Daemon::suspend_finished, &event_loop, &QEventLoop::quit, Qt::QueuedConnection);
-            QObject::connect(&timer, &QTimer::timeout, &event_loop, &QEventLoop::quit);
-
             auto it = vm_instances.find(name);
             it->second->suspend();
-
-            timer.setSingleShot(true);
-            timer.start(std::chrono::seconds(30));
-            event_loop.exec();
         }
     }
 
@@ -1792,7 +1782,6 @@ void mp::Daemon::on_stop()
 
 void mp::Daemon::on_suspend()
 {
-    emit suspend_finished();
 }
 
 void mp::Daemon::on_restart(const std::string& name)

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -123,9 +123,6 @@ public slots:
     grpc::Status version(grpc::ServerContext* context, const VersionRequest* request,
                          grpc::ServerWriter<VersionReply>* response) override;
 
-signals:
-    void suspend_finished();
-
 private:
     void persist_instances();
     void start_mount(const VirtualMachine::UPtr& vm, const std::string& name, const std::string& source_path,

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -370,6 +370,7 @@ void mp::QemuVirtualMachine::suspend()
             update_state();
 
             update_shutdown_status = false;
+            vm_process->waitForFinished();
         }
     }
     else if (state == State::off || state == State::suspended)


### PR DESCRIPTION
The EventLoop tied to the QTimer was causing unintended behavior.  Instead, just wait
on suspend to finish in the particular backend code.

Fixes #609