### PR TITLE
Locate socket in $SNAP_COMMON while snapped

### DIFF
--- a/include/multipass/snap_utils.h
+++ b/include/multipass/snap_utils.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_SNAP_UTILS_H
+#define MULTIPASS_SNAP_UTILS_H
+
+#include <QByteArray>
+
+namespace multipass
+{
+namespace utils
+{
+bool is_snap();
+QByteArray snap_dir();
+QByteArray snap_common_dir();
+} // namespace utils
+} // namespace multipass
+
+#endif // MULTIPASS_SNAP_UTILS_H

--- a/src/platform/backends/qemu/qemu_vm_process_spec.cpp
+++ b/src/platform/backends/qemu/qemu_vm_process_spec.cpp
@@ -19,10 +19,12 @@
 
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
+#include <multipass/snap_utils.h>
 #include <shared/linux/backend_utils.h>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;
+namespace mu = multipass::utils;
 
 namespace
 {
@@ -157,8 +159,7 @@ QStringList mp::QemuVMProcessSpec::arguments() const
 
 QString mp::QemuVMProcessSpec::working_directory() const
 {
-    auto snap = qgetenv("SNAP");
-    if (!snap.isEmpty())
-        return snap.append("/qemu");
+    if (mu::is_snap())
+        return mu::snap_dir().append("/qemu");
     return QString();
 }

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -19,6 +19,8 @@
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
 #include <multipass/platform.h>
+#include <multipass/settings.h>
+#include <multipass/snap_utils.h>
 #include <multipass/utils.h>
 #include <multipass/virtual_machine_factory.h>
 
@@ -29,10 +31,22 @@
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;
+namespace mu = multipass::utils;
 
 std::string mp::platform::default_server_address()
 {
-    return {"unix:/run/multipass_socket"};
+    std::string base_dir;
+
+    if (mu::is_snap())
+    {
+        // if Snap, client and daemon can both access $SNAP_COMMON so can put socket there
+        base_dir = mu::snap_common_dir().toStdString();
+    }
+    else
+    {
+        base_dir = "/run";
+    }
+    return "unix:" + base_dir + "/multipass_socket";
 }
 
 QString mp::platform::default_driver()

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_library(utils STATIC
   memory_size.cpp
   settings.cpp
+  snap_utils.cpp
   utils.cpp)
 
 target_link_libraries(utils

--- a/src/utils/snap_utils.cpp
+++ b/src/utils/snap_utils.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <multipass/snap_utils.h>
+
+namespace mu = multipass::utils;
+
+bool mu::is_snap()
+{
+    // Decide if Snap based on if $SNAP env var is set.
+    // TODO: can this be better?
+    return !snap_dir().isEmpty();
+}
+
+QByteArray mu::snap_dir()
+{
+    return qgetenv("SNAP"); // Inside snap, this can be trusted.
+}
+
+QByteArray mu::snap_common_dir()
+{
+    return qgetenv("SNAP_COMMON"); // Inside snap, this can be trusted
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -107,6 +107,7 @@ add_executable(multipass_tests
   test_scp_client.cpp
   test_sftp_client.cpp
   test_sftpserver.cpp
+  test_snap_utils.cpp
   test_ssl_cert_provider.cpp
   test_sshfsmount.cpp
   test_ssh_client.cpp

--- a/tests/mock_environment_helpers.h
+++ b/tests/mock_environment_helpers.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_MOCK_ENVIRONMENT_HELPER_H
+#define MULTIPASS_MOCK_ENVIRONMENT_HELPER_H
+
+namespace multipass
+{
+namespace testing
+{
+
+class SetEnvScope
+{
+public:
+    explicit SetEnvScope(const QByteArray& name, const QByteArray& new_value) : name(name)
+    {
+        old_value = qgetenv(name.constData());
+        setenv(name.constData(), new_value.constData(), 1 /*overwrite*/);
+    }
+    ~SetEnvScope()
+    {
+        if (old_value.isNull())
+            unsetenv(name.constData());
+        else
+            setenv(name.constData(), old_value.constData(), 1 /*overwrite*/);
+    }
+
+private:
+    QByteArray name, old_value;
+};
+
+class UnsetEnvScope
+{
+public:
+    explicit UnsetEnvScope(const QByteArray& name) : name(name)
+    {
+        old_value = qgetenv(name.constData());
+        if (!old_value.isNull())
+            unsetenv(name.constData());
+    }
+    ~UnsetEnvScope()
+    {
+        if (!old_value.isNull())
+            setenv(name.constData(), old_value.constData(), 0 /*no-overwrite*/);
+    }
+
+private:
+    QByteArray name, old_value;
+};
+
+} // namespace testing
+} // namespace multipass
+
+#endif // MULTIPASS_MOCK_ENVIRONMENT_HELPER_H

--- a/tests/test_snap_utils.cpp
+++ b/tests/test_snap_utils.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <multipass/snap_utils.h>
+
+#include <QTemporaryDir>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "mock_environment_helpers.h"
+
+namespace mp = multipass;
+namespace mpt = multipass::testing;
+namespace mu = multipass::utils;
+
+using namespace testing;
+
+TEST(SnapUtils, test_is_confined_when_snap_dir_set)
+{
+    mpt::SetEnvScope env("SNAP", "/tmp");
+
+    EXPECT_TRUE(mu::is_snap());
+}
+
+TEST(SnapUtils, test_is_not_confined_when_snap_dir_not_set)
+{
+    mpt::UnsetEnvScope env("SNAP");
+
+    EXPECT_FALSE(mu::is_snap());
+}
+
+TEST(SnapUtils, test_snap_dir_read_ok)
+{
+    QTemporaryDir snap_dir;
+    mpt::SetEnvScope env("SNAP", snap_dir.path().toUtf8());
+
+    EXPECT_EQ(snap_dir.path(), mu::snap_dir());
+}
+
+TEST(SnapUtils, test_snap_dir_null_if_not_set)
+{
+    mpt::UnsetEnvScope env("SNAP");
+
+    EXPECT_EQ(QByteArray(), mu::snap_dir());
+}
+
+TEST(SnapUtils, test_snap_common_dir_read_ok)
+{
+    QTemporaryDir snap_dir;
+    mpt::SetEnvScope env("SNAP_COMMON", snap_dir.path().toUtf8());
+
+    EXPECT_EQ(snap_dir.path(), mu::snap_common_dir());
+}
+
+TEST(SnapUtils, test_snap_common_dir_null_if_not_set)
+{
+    mpt::UnsetEnvScope env("SNAP_COMMON");
+
+    EXPECT_EQ(QByteArray(), mu::snap_common_dir());
+}


### PR DESCRIPTION
The multipass socket can be located in $SNAP_COMMON while both the daemon and client are in the same snap.

While doing this, deduplicate reads of the SNAP env var by using a small utility.