### PR TITLE
Do not muck with PTY sizing when stdin is live (stdout irrelevant)

### DIFF
--- a/src/platform/console/unix_console.cpp
+++ b/src/platform/console/unix_console.cpp
@@ -86,7 +86,7 @@ mp::UnixConsole::UnixConsole(ssh_channel channel, UnixTerminal* term)
 {
     setup_console();
 
-    if (term->cout_is_live())
+    if (term->cin_is_live())
     {
         ssh_channel_request_pty(channel);
         change_ssh_pty_size(channel, term->cout_fd());


### PR DESCRIPTION
Fix #678 