### PR TITLE
[release] use semantic versioning format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ function(determine_version OUTPUT_VARIABLE)
 endfunction()
 
 determine_version(MULTIPASS_VERSION)
-set(MULTIPASS_VERSION ${MULTIPASS_VERSION} CACHE STRING "Multipass version string" FORCE)
+set(MULTIPASS_VERSION ${MULTIPASS_VERSION})
 message(STATUS "Setting version to: ${MULTIPASS_VERSION}")
 
 set(CMAKE_CXX_STANDARD 14)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,39 @@ add_subdirectory(3rd-party)
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Network REQUIRED)
 
-execute_process(COMMAND git describe
-                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-                OUTPUT_VARIABLE MULTIPASS_VERSION
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
+function(determine_version OUTPUT_VARIABLE)
+  execute_process(COMMAND git describe
+                  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                  OUTPUT_VARIABLE GIT_VERSION
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  execute_process(COMMAND git describe --tags --abbrev=0
+                  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                  OUTPUT_VARIABLE GIT_TAG
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  string(REGEX MATCH "^v.+-([0-9]+)-(g.+)$" GIT_VERSION_MATCH ${GIT_VERSION})
+
+  if(${GIT_VERSION} STREQUAL ${GIT_TAG})
+    set(NEW_VERSION ${GIT_TAG})
+  elseif(GIT_VERSION_MATCH)
+    set(NEW_VERSION ${GIT_TAG}.${CMAKE_MATCH_1}+${CMAKE_MATCH_2})
+  else()
+    message(FATAL_ERROR "Failed to parse version number: ${GIT_VERSION}")
+  endif()
+
+  string(REGEX MATCH "^v(.+)" VERSION_MATCH ${NEW_VERSION})
+
+  if(VERSION_MATCH)
+    set(${OUTPUT_VARIABLE} ${CMAKE_MATCH_1} PARENT_SCOPE)
+  else()
+    message(FATAL_ERROR "Invalid tag detected: ${NEW_VERSION}")
+  endif()
+endfunction()
+
+determine_version(MULTIPASS_VERSION)
+set(MULTIPASS_VERSION ${MULTIPASS_VERSION} CACHE STRING "Multipass version string" FORCE)
+message(STATUS "Setting version to: ${MULTIPASS_VERSION}")
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -151,7 +151,7 @@ parts:
       mkdir -p ${SNAPCRAFT_PART_INSTALL}/etc/bash_completion.d/
       echo 'export PATH="${PATH}:/snap/bin:/var/lib/snapd/snap/bin"' > ${SNAPCRAFT_PART_INSTALL}/etc/bash_completion.d/snap.multipass
       cat ../src/completions/bash/multipass >> ${SNAPCRAFT_PART_INSTALL}/etc/bash_completion.d/snap.multipass
-      snapcraftctl set-version $( cmake -L . | awk -F= '/^MULTIPASS_VERSION/ { print $2 }' )
+      snapcraftctl set-version $( awk -F\" '/version_string/ { print $2 }' gen/multipass/version.h )
 
   qemu:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,5 @@
 name: multipass
-version: 'git'
-version-script: |
-  git describe
+adopt-info: multipass
 summary: Ubuntu at your fingertips
 description: |
   Multipass gives you Ubuntu VMs in seconds. Just run `multipass launch`
@@ -153,6 +151,7 @@ parts:
       mkdir -p ${SNAPCRAFT_PART_INSTALL}/etc/bash_completion.d/
       echo 'export PATH="${PATH}:/snap/bin:/var/lib/snapd/snap/bin"' > ${SNAPCRAFT_PART_INSTALL}/etc/bash_completion.d/snap.multipass
       cat ../src/completions/bash/multipass >> ${SNAPCRAFT_PART_INSTALL}/etc/bash_completion.d/snap.multipass
+      snapcraftctl set-version $( cmake -L . | awk -F= '/^MULTIPASS_VERSION/ { print $2 }' )
 
   qemu:
     plugin: nil


### PR DESCRIPTION
Adhere to https://semver.org/, using the latest tag, number of commits since
latest annotated tag and commit abbreviation as version, pre-release
identifier and build metadata, respectively.