### PR TITLE
[cmake] rework version detection (Fixes #713)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,20 +48,26 @@ find_package(Qt5Core REQUIRED)
 find_package(Qt5Network REQUIRED)
 
 function(determine_version OUTPUT_VARIABLE)
+  execute_process(COMMAND git describe --exact
+                  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                  OUTPUT_VARIABLE GIT_RELEASE
+                  OUTPUT_STRIP_TRAILING_WHITESPACE
+                  ERROR_QUIET)
+
   execute_process(COMMAND git describe
                   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                   OUTPUT_VARIABLE GIT_VERSION
                   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-  execute_process(COMMAND git describe --tags --abbrev=0
+  execute_process(COMMAND git describe --tags --match *-dev --match *-rc --abbrev=0
                   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                   OUTPUT_VARIABLE GIT_TAG
                   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
   string(REGEX MATCH "^v.+-([0-9]+)-(g.+)$" GIT_VERSION_MATCH ${GIT_VERSION})
 
-  if(${GIT_VERSION} STREQUAL ${GIT_TAG})
-    set(NEW_VERSION ${GIT_TAG})
+  if(GIT_RELEASE)
+    set(NEW_VERSION ${GIT_RELEASE})
   elseif(GIT_VERSION_MATCH)
     set(NEW_VERSION ${GIT_TAG}.${CMAKE_MATCH_1}+${CMAKE_MATCH_2})
   else()


### PR DESCRIPTION
Be explicit about using *-dev and *-rc tags for interim builds and rely
on `git describe --exact` for releases.