### PR TITLE
backends/qemu: Use '-drive' option for already suspended instances

### DIFF
--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -145,6 +145,7 @@ auto get_metadata()
     QJsonObject metadata;
 
     metadata["machine_type"] = get_qemu_machine_type();
+    metadata["use_cdrom"] = true;
 
     return metadata;
 }
@@ -162,7 +163,8 @@ mp::QemuVirtualMachine::QemuVirtualMachine(const ProcessFactory* process_factory
       dnsmasq_server{&dnsmasq_server},
       monitor{&monitor},
       vm_process{make_qemu_process(process_factory, desc, tap_device_name, mac_addr)},
-      original_args{vm_process->arguments()}
+      original_args{vm_process->arguments()},
+      cloud_init_path{desc.cloud_init_iso}
 {
     QObject::connect(vm_process.get(), &QProcess::started, [this]() {
         mpl::log(mpl::Level::info, vm_name, "process started");
@@ -272,12 +274,26 @@ void mp::QemuVirtualMachine::start()
         auto args = vm_process->arguments();
         args << "-loadvm" << suspend_tag;
         args << "-machine" << machine_type;
+
+        if (metadata["use_cdrom"].toBool())
+        {
+            args << "-cdrom" << cloud_init_path;
+        }
+        else
+        {
+            args << "-drive" << QString("file=%1,if=virtio,format=raw,snapshot=off,read-only").arg(cloud_init_path);
+        }
+
         vm_process->setArguments(args);
         update_shutdown_status = true;
         delete_memory_snapshot = true;
     }
     else
     {
+        auto args = vm_process->arguments();
+        args << "-cdrom" << cloud_init_path;
+        vm_process->setArguments(args);
+
         monitor->update_metadata_for(vm_name, get_metadata());
     }
 

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -69,6 +69,7 @@ private:
     VMStatusMonitor* monitor;
     std::unique_ptr<QProcess> vm_process;
     const QStringList original_args;
+    const QString cloud_init_path;
     std::string saved_error_msg;
     bool update_shutdown_status{true};
     bool delete_memory_snapshot{false};

--- a/src/platform/backends/qemu/qemu_vm_process_spec.cpp
+++ b/src/platform/backends/qemu/qemu_vm_process_spec.cpp
@@ -40,8 +40,6 @@ QStringList mp::QemuVMProcessSpec::arguments() const
     QStringList args{"--enable-kvm"};
     // The VM image itself
     args << "-hda" << desc.image.image_path;
-    // For the cloud-init configuration
-    args << "-cdrom" << desc.cloud_init_iso;
     // Number of cpu cores
     args << "-smp" << QString::number(desc.num_cores);
     // Memory to use for VM


### PR DESCRIPTION
This fixes the case where an instance is suspended using '-drive' for the cloud-init
iso and then the newer version of the daemon is started that uses the '-cdrom' option
instead and qemu fails to load the saved memory snapshot.

Fixes #738