### PR TITLE
launch/find: Allow using and searching for unsupported cloud images

### DIFF
--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -61,7 +61,7 @@ _multipass_complete()
             opts="${opts} --all --purge"
         ;;
         "launch")
-            opts="${opts} --cpus --disk --mem --name --cloud-init --allow-unsupported"
+            opts="${opts} --cpus --disk --mem --name --cloud-init"
         ;;
         "mount")
             opts="${opts} --gid-map --uid-map"
@@ -70,7 +70,7 @@ _multipass_complete()
             opts="${opts} --all"
         ;;
         "find")
-            opts="${opts} --allow-unsupported"
+            opts="${opts} --show-unsupported"
         ;;
     esac
 

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -61,13 +61,16 @@ _multipass_complete()
             opts="${opts} --all --purge"
         ;;
         "launch")
-            opts="${opts} --cpus --disk --mem --name --cloud-init"
+            opts="${opts} --cpus --disk --mem --name --cloud-init --allow-unsupported"
         ;;
         "mount")
             opts="${opts} --gid-map --uid-map"
         ;;
         "recover"|"start"|"stop"|"suspend"|"restart")
             opts="${opts} --all"
+        ;;
+        "find")
+            opts="${opts} --allow-unsupported"
         ;;
     esac
 

--- a/include/multipass/query.h
+++ b/include/multipass/query.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,8 +12,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
  *
  */
 
@@ -39,6 +37,7 @@ public:
     bool persistent;
     std::string remote_name;
     Type query_type;
+    bool allow_unsupported{false};
 };
 }
 #endif // MULTIPASS_QUERY_H

--- a/include/multipass/vm_image_host.h
+++ b/include/multipass/vm_image_host.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,7 +38,7 @@ public:
     virtual optional<VMImageInfo> info_for(const Query& query) = 0;
     virtual std::vector<VMImageInfo> all_info_for(const Query& query) = 0;
     virtual VMImageInfo info_for_full_hash(const std::string& full_hash) = 0;
-    virtual std::vector<VMImageInfo> all_images_for(const std::string& remote_name) = 0;
+    virtual std::vector<VMImageInfo> all_images_for(const std::string& remote_name, const bool allow_unsupported) = 0;
     virtual void for_each_entry_do(const Action& action) = 0;
     virtual std::vector<std::string> supported_remotes() = 0;
 

--- a/src/client/cmd/find.cpp
+++ b/src/client/cmd/find.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -131,6 +131,8 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
                                   "then search ‘daily‘. <string> can be a partial image hash or an "
                                   "Ubuntu release version, codename or alias.",
                                   "[<remote:>][<string>]");
+    QCommandLineOption unsupportedOption("unsupported", "Allow searching for unsupported cloud images");
+    parser->addOptions({unsupportedOption});
 
     auto status = parser->commandParse(this);
 
@@ -163,6 +165,11 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
         {
             request.set_search_string(search_string.toStdString());
         }
+    }
+
+    if (parser->isSet(unsupportedOption))
+    {
+        request.set_allow_unsupported(true);
     }
 
     return status;

--- a/src/client/cmd/find.cpp
+++ b/src/client/cmd/find.cpp
@@ -131,7 +131,7 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
                                   "then search ‘daily‘. <string> can be a partial image hash or an "
                                   "Ubuntu release version, codename or alias.",
                                   "[<remote:>][<string>]");
-    QCommandLineOption unsupportedOption("allow-unsupported", "Allow searching for unsupported cloud images");
+    QCommandLineOption unsupportedOption("show-unsupported", "Show unsupported cloud images as well");
     parser->addOptions({unsupportedOption});
 
     auto status = parser->commandParse(this);

--- a/src/client/cmd/find.cpp
+++ b/src/client/cmd/find.cpp
@@ -131,7 +131,7 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
                                   "then search ‘daily‘. <string> can be a partial image hash or an "
                                   "Ubuntu release version, codename or alias.",
                                   "[<remote:>][<string>]");
-    QCommandLineOption unsupportedOption("unsupported", "Allow searching for unsupported cloud images");
+    QCommandLineOption unsupportedOption("allow-unsupported", "Allow searching for unsupported cloud images");
     parser->addOptions({unsupportedOption});
 
     auto status = parser->commandParse(this);

--- a/src/client/cmd/launch.cpp
+++ b/src/client/cmd/launch.cpp
@@ -99,8 +99,7 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
     QCommandLineOption nameOption({"n", "name"}, "Name for the instance", "name");
     QCommandLineOption cloudInitOption("cloud-init", "Path to a user-data cloud-init configuration, or '-' for stdin",
                                        "file");
-    QCommandLineOption unsupportedOption("allow-unsupported", "Allow launching unsupported cloud images");
-    parser->addOptions({cpusOption, diskOption, memOption, nameOption, cloudInitOption, unsupportedOption});
+    parser->addOptions({cpusOption, diskOption, memOption, nameOption, cloudInitOption});
 
     auto status = parser->commandParse(this);
 
@@ -186,11 +185,6 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
             cerr << "error loading cloud-init config: " << e.what() << "\n";
             return ParseCode::CommandLineError;
         }
-    }
-
-    if (parser->isSet(unsupportedOption))
-    {
-        request.set_allow_unsupported(true);
     }
 
     request.set_verbosity_level(parser->verbosityLevel());

--- a/src/client/cmd/launch.cpp
+++ b/src/client/cmd/launch.cpp
@@ -99,7 +99,8 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
     QCommandLineOption nameOption({"n", "name"}, "Name for the instance", "name");
     QCommandLineOption cloudInitOption("cloud-init", "Path to a user-data cloud-init configuration, or '-' for stdin",
                                        "file");
-    parser->addOptions({cpusOption, diskOption, memOption, nameOption, cloudInitOption});
+    QCommandLineOption unsupportedOption("unsupported", "Allow launching unsupported cloud images");
+    parser->addOptions({cpusOption, diskOption, memOption, nameOption, cloudInitOption, unsupportedOption});
 
     auto status = parser->commandParse(this);
 
@@ -185,6 +186,11 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
             cerr << "error loading cloud-init config: " << e.what() << "\n";
             return ParseCode::CommandLineError;
         }
+    }
+
+    if (parser->isSet(unsupportedOption))
+    {
+        request.set_allow_unsupported(true);
     }
 
     request.set_verbosity_level(parser->verbosityLevel());

--- a/src/client/cmd/launch.cpp
+++ b/src/client/cmd/launch.cpp
@@ -99,7 +99,7 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
     QCommandLineOption nameOption({"n", "name"}, "Name for the instance", "name");
     QCommandLineOption cloudInitOption("cloud-init", "Path to a user-data cloud-init configuration, or '-' for stdin",
                                        "file");
-    QCommandLineOption unsupportedOption("unsupported", "Allow launching unsupported cloud images");
+    QCommandLineOption unsupportedOption("allow-unsupported", "Allow launching unsupported cloud images");
     parser->addOptions({cpusOption, diskOption, memOption, nameOption, cloudInitOption, unsupportedOption});
 
     auto status = parser->commandParse(this);

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -200,7 +200,8 @@ mp::VMImageInfo mp::CustomVMImageHost::info_for_full_hash_impl(const std::string
     return {};
 }
 
-std::vector<mp::VMImageInfo> mp::CustomVMImageHost::all_images_for(const std::string& remote_name)
+std::vector<mp::VMImageInfo> mp::CustomVMImageHost::all_images_for(const std::string& remote_name,
+                                                                   const bool allow_unsupported)
 {
     std::vector<mp::VMImageInfo> images;
     auto custom_manifest = manifest_from(remote_name);

--- a/src/daemon/custom_image_host.h
+++ b/src/daemon/custom_image_host.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -46,7 +46,7 @@ public:
 
     optional<VMImageInfo> info_for(const Query& query) override;
     std::vector<VMImageInfo> all_info_for(const Query& query) override;
-    std::vector<VMImageInfo> all_images_for(const std::string& remote_name) override;
+    std::vector<VMImageInfo> all_images_for(const std::string& remote_name, const bool allow_unsupported) override;
     std::vector<std::string> supported_remotes() override;
 
 protected:

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -92,7 +92,7 @@ mp::Query query_from(const mp::LaunchRequest* request, const std::string& name)
     else if (QString::fromStdString(image).startsWith("http"))
         query_type = mp::Query::Type::HttpDownload;
 
-    return {name, image, false, request->remote_name(), query_type};
+    return {name, image, false, request->remote_name(), query_type, request->allow_unsupported()};
 }
 
 auto make_cloud_init_vendor_config(const mp::SSHKeyProvider& key_provider, const std::string& time_zone,
@@ -762,8 +762,8 @@ try // clang-format on
                 throw std::runtime_error(fmt::format(
                     "{} is not a supported remote. Please use `multipass find` for list of supported images.", remote));
 
-            auto images_info =
-                it->second->all_info_for({"", request->search_string(), false, remote, Query::Type::Alias});
+            auto images_info = it->second->all_info_for(
+                {"", request->search_string(), false, remote, Query::Type::Alias, request->allow_unsupported()});
 
             if (!images_info.empty())
             {
@@ -774,8 +774,8 @@ try // clang-format on
         {
             for (const auto& image_host : config->image_hosts)
             {
-                auto images_info =
-                    image_host->all_info_for({"", request->search_string(), false, remote, Query::Type::Alias});
+                auto images_info = image_host->all_info_for(
+                    {"", request->search_string(), false, remote, Query::Type::Alias, request->allow_unsupported()});
 
                 if (!images_info.empty())
                 {
@@ -827,7 +827,7 @@ try // clang-format on
         if (it == remote_image_host_map.end())
             throw std::runtime_error(fmt::format("Remote \"{}\" is unknown.", remote));
 
-        auto vm_images_info = it->second->all_images_for(remote);
+        auto vm_images_info = it->second->all_images_for(remote, request->allow_unsupported());
         for (const auto& info : vm_images_info)
         {
             if (!info.aliases.empty())
@@ -855,12 +855,12 @@ try // clang-format on
         {
             std::unordered_set<std::string> image_found;
             const auto default_remote{"release"};
-            auto action = [&response, &image_found, default_remote](const std::string& remote,
-                                                                    const mp::VMImageInfo& info) {
+            auto action = [&response, &image_found, default_remote, request](const std::string& remote,
+                                                                             const mp::VMImageInfo& info) {
                 if (!mp::platform::is_remote_supported(remote))
                     return;
 
-                if (info.supported)
+                if (info.supported || request->allow_unsupported())
                 {
                     if (image_found.find(info.release_title.toStdString()) == image_found.end())
                     {

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -92,7 +92,7 @@ mp::Query query_from(const mp::LaunchRequest* request, const std::string& name)
     else if (QString::fromStdString(image).startsWith("http"))
         query_type = mp::Query::Type::HttpDownload;
 
-    return {name, image, false, request->remote_name(), query_type, request->allow_unsupported()};
+    return {name, image, false, request->remote_name(), query_type, true};
 }
 
 auto make_cloud_init_vendor_config(const mp::SSHKeyProvider& key_provider, const std::string& time_zone,

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,8 +12,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
  *
  */
 
@@ -108,7 +106,7 @@ mp::optional<mp::VMImageInfo> mp::UbuntuVMImageHost::info_for(const Query& query
 
     if (info)
     {
-        if (!info->supported)
+        if (!info->supported && !query.allow_unsupported)
             throw std::runtime_error(fmt::format("The {} release is no longer supported.", query.release));
 
         return with_location_fully_resolved(QString::fromStdString(remote_url_from(remote_name)), *info);
@@ -132,7 +130,7 @@ std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_info_for(const Query& qu
 
     if (info)
     {
-        if (!info->supported)
+        if (!info->supported && !query.allow_unsupported)
             throw std::runtime_error(fmt::format("The {} release is no longer supported.", query.release));
 
         images.push_back(*info);
@@ -143,7 +141,7 @@ std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_info_for(const Query& qu
 
         for (const auto& entry : manifest->products)
         {
-            if (entry.id.startsWith(key) && entry.supported &&
+            if (entry.id.startsWith(key) && (entry.supported || query.allow_unsupported) &&
                 found_hashes.find(entry.id.toStdString()) == found_hashes.end())
             {
                 images.push_back(
@@ -177,14 +175,15 @@ mp::VMImageInfo mp::UbuntuVMImageHost::info_for_full_hash_impl(const std::string
     return mp::VMImageInfo{{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, -1};
 }
 
-std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_images_for(const std::string& remote_name)
+std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_images_for(const std::string& remote_name,
+                                                                   const bool allow_unsupported)
 {
     std::vector<mp::VMImageInfo> images;
     auto manifest = manifest_from(remote_name);
 
     for (const auto& entry : manifest->products)
     {
-        if (entry.supported)
+        if (entry.supported || allow_unsupported)
         {
             images.push_back(with_location_fully_resolved(QString::fromStdString(remote_url_from(remote_name)), entry));
         }

--- a/src/daemon/ubuntu_image_host.h
+++ b/src/daemon/ubuntu_image_host.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -40,7 +40,7 @@ public:
 
     optional<VMImageInfo> info_for(const Query& query) override;
     std::vector<VMImageInfo> all_info_for(const Query& query) override;
-    std::vector<VMImageInfo> all_images_for(const std::string& remote_name) override;
+    std::vector<VMImageInfo> all_images_for(const std::string& remote_name, const bool allow_unsupported) override;
     std::vector<std::string> supported_remotes() override;
 
 protected:

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -59,7 +59,6 @@ message LaunchRequest {
     string remote_name = 9;
     OptInStatus opt_in_reply = 10;
     int32 verbosity_level = 11;
-    bool allow_unsupported = 12;
 }
 
 message LaunchError {

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -59,6 +59,7 @@ message LaunchRequest {
     string remote_name = 9;
     OptInStatus opt_in_reply = 10;
     int32 verbosity_level = 11;
+    bool allow_unsupported = 12;
 }
 
 message LaunchError {
@@ -127,6 +128,7 @@ message FindRequest {
     string search_string = 1;
     string remote_name = 2;
     int32 verbosity_level = 3;
+    bool allow_unsupported = 4;
 }
 
 message FindReply {

--- a/tests/stub_image_host.h
+++ b/tests/stub_image_host.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,7 +41,8 @@ struct StubVMImageHost final : public multipass::VMImageHost
         return {{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, -1};
     };
 
-    std::vector<multipass::VMImageInfo> all_images_for(const std::string& remote_name) override
+    std::vector<multipass::VMImageInfo> all_images_for(const std::string& remote_name,
+                                                       const bool allow_unsupported) override
     {
         return {};
     };

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -410,7 +410,7 @@ TEST_F(Client, launch_cmd_cloudinit_option_reads_stdin_ok)
 TEST_F(Client, launch_cmd_unsupported_option_ok)
 {
     EXPECT_CALL(mock_daemon, launch(_, _, _));
-    EXPECT_THAT(send_command({"launch", "--unsupported"}), Eq(mp::ReturnCode::Ok));
+    EXPECT_THAT(send_command({"launch", "--allow-unsupported"}), Eq(mp::ReturnCode::Ok));
 }
 
 // purge cli tests
@@ -1167,7 +1167,7 @@ TEST_F(Client, delete_cmd_accepts_purge_option)
 TEST_F(Client, find_cmd_unsupported_option_ok)
 {
     EXPECT_CALL(mock_daemon, find(_, _, _));
-    EXPECT_THAT(send_command({"find", "--unsupported"}), Eq(mp::ReturnCode::Ok));
+    EXPECT_THAT(send_command({"find", "--allow-unsupported"}), Eq(mp::ReturnCode::Ok));
 }
 
 TEST_F(Client, help_returns_ok_return_code)

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -407,6 +407,12 @@ TEST_F(Client, launch_cmd_cloudinit_option_reads_stdin_ok)
     EXPECT_THAT(send_command({"launch", "--cloud-init", "-"}, trash_stream, trash_stream, ss), Eq(mp::ReturnCode::Ok));
 }
 
+TEST_F(Client, launch_cmd_unsupported_option_ok)
+{
+    EXPECT_CALL(mock_daemon, launch(_, _, _));
+    EXPECT_THAT(send_command({"launch", "--unsupported"}), Eq(mp::ReturnCode::Ok));
+}
+
 // purge cli tests
 TEST_F(Client, purge_cmd_ok_no_args)
 {
@@ -1155,6 +1161,13 @@ TEST_F(Client, delete_cmd_accepts_purge_option)
     EXPECT_CALL(mock_daemon, delet(_, _, _)).Times(2);
     EXPECT_THAT(send_command({"delete", "--purge", "foo"}), Eq(mp::ReturnCode::Ok));
     EXPECT_THAT(send_command({"delete", "-p", "bar"}), Eq(mp::ReturnCode::Ok));
+}
+
+// find cli tests
+TEST_F(Client, find_cmd_unsupported_option_ok)
+{
+    EXPECT_CALL(mock_daemon, find(_, _, _));
+    EXPECT_THAT(send_command({"find", "--unsupported"}), Eq(mp::ReturnCode::Ok));
 }
 
 TEST_F(Client, help_returns_ok_return_code)

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -407,12 +407,6 @@ TEST_F(Client, launch_cmd_cloudinit_option_reads_stdin_ok)
     EXPECT_THAT(send_command({"launch", "--cloud-init", "-"}, trash_stream, trash_stream, ss), Eq(mp::ReturnCode::Ok));
 }
 
-TEST_F(Client, launch_cmd_unsupported_option_ok)
-{
-    EXPECT_CALL(mock_daemon, launch(_, _, _));
-    EXPECT_THAT(send_command({"launch", "--allow-unsupported"}), Eq(mp::ReturnCode::Ok));
-}
-
 // purge cli tests
 TEST_F(Client, purge_cmd_ok_no_args)
 {
@@ -1167,7 +1161,7 @@ TEST_F(Client, delete_cmd_accepts_purge_option)
 TEST_F(Client, find_cmd_unsupported_option_ok)
 {
     EXPECT_CALL(mock_daemon, find(_, _, _));
-    EXPECT_THAT(send_command({"find", "--allow-unsupported"}), Eq(mp::ReturnCode::Ok));
+    EXPECT_THAT(send_command({"find", "--show-unsupported"}), Eq(mp::ReturnCode::Ok));
 }
 
 TEST_F(Client, help_returns_ok_return_code)

--- a/tests/test_custom_image_host.cpp
+++ b/tests/test_custom_image_host.cpp
@@ -116,7 +116,7 @@ TEST_F(CustomImageHost, all_images_for_snapcraft_returns_two_matches)
 {
     mp::CustomVMImageHost host{&url_downloader, default_ttl, test_path};
 
-    auto images = host.all_images_for("snapcraft");
+    auto images = host.all_images_for("snapcraft", false);
 
     const size_t expected_matches{2};
     EXPECT_THAT(images.size(), Eq(expected_matches));

--- a/tests/test_data/releases/multiple_versions_manifest.json
+++ b/tests/test_data/releases/multiple_versions_manifest.json
@@ -105,6 +105,40 @@
           "pubname": "ubuntu-zesty-17.04-amd64-server-20170619.1"
         }
       }
+    },
+    "com.ubuntu.cloud:server:17.10:amd64": {
+      "aliases": "17.10,a,artful",
+      "arch": "amd64",
+      "os": "ubuntu",
+      "release": "artful",
+      "release_codename": "Artful Aardvark",
+      "release_title": "17.10",
+      "support_eol": "2018-07-19",
+      "supported": false,
+      "version": "17.10",
+      "versions": {
+        "20171017": {
+          "items": {
+            "disk1.img": {
+              "ftype": "disk1.img",
+              "md5": "2d011144148d71d2745d0c5be6e785ab",
+              "path": "server/releases/artful/release-20171017/ubuntu-17.10-server-cloudimg-amd64.img",
+              "sha256": "520224efaaf49b15a976b49c7ce7f2bd2e5b161470d684b37a838933595c0520",
+              "size": 317849600
+            },
+            "lxd.tar.xz": {
+              "combined_squashfs_sha256": "d6b33e50f42d129cdd0d3ef0b267d79012e382380deb30f6e22b5f9910a1e8ec",
+              "ftype": "lxd.tar.xz",
+              "md5": "15241f00869ffebbeff53bc020b562c7",
+              "path": "server/releases/artful/release-20171017/ubuntu-17.10-server-cloudimg-amd64-lxd.tar.xz",
+              "sha256": "d421060416078ea4ec3a25953dd66b87efc937ef5edb16e64f9cb7ba9b8fad0a",
+              "size": 776
+            }
+          },
+          "label": "release",
+          "pubname": "ubuntu-artful-17.10-amd64-server-20171017"
+        }
+      }
     }
   },
   "updated": "Thu, 18 May 2017 09:18:01 +0000"

--- a/tests/test_image_vault.cpp
+++ b/tests/test_image_vault.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -72,7 +72,7 @@ struct ImageHost : public mp::VMImageHost
         return {{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, -1};
     }
 
-    std::vector<mp::VMImageInfo> all_images_for(const std::string& remote_name) override
+    std::vector<mp::VMImageInfo> all_images_for(const std::string& remote_name, const bool allow_unsupported) override
     {
         return {};
     }

--- a/tests/test_ubuntu_image_host.cpp
+++ b/tests/test_ubuntu_image_host.cpp
@@ -86,13 +86,14 @@ TEST_F(UbuntuImageHost, iterates_over_all_entries)
     auto action = [&ids](const std::string& remote, const mp::VMImageInfo& info) { ids.insert(info.id.toStdString()); };
     host.for_each_entry_do(action);
 
-    const size_t expected_entries{4};
+    const size_t expected_entries{5};
     EXPECT_THAT(ids.size(), Eq(expected_entries));
 
     EXPECT_THAT(ids.count("1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac"), Eq(1u));
     EXPECT_THAT(ids.count("8842e7a8adb01c7a30cc702b01a5330a1951b12042816e87efd24b61c5e2239f"), Eq(1u));
     EXPECT_THAT(ids.count("1507bd2b3288ef4bacd3e699fe71b827b7ccf321ec4487e168a30d7089d3c8e4"), Eq(1u));
     EXPECT_THAT(ids.count("ab115b83e7a8bebf3d3a02bf55ad0cb75a0ed515fcbc65fb0c9abe76c752921c"), Eq(1u));
+    EXPECT_THAT(ids.count("520224efaaf49b15a976b49c7ce7f2bd2e5b161470d684b37a838933595c0520"), Eq(1u));
 }
 
 TEST_F(UbuntuImageHost, can_query_by_hash)
@@ -184,9 +185,19 @@ TEST_F(UbuntuImageHost, all_images_for_release_returns_four_matches)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
 
-    auto images = host.all_images_for(release_remote_spec.first);
+    auto images = host.all_images_for(release_remote_spec.first, false);
 
     const size_t expected_matches{4};
+    EXPECT_THAT(images.size(), Eq(expected_matches));
+}
+
+TEST_F(UbuntuImageHost, all_images_for_release_unsupported_returns_five_matches)
+{
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+
+    auto images = host.all_images_for(release_remote_spec.first, true);
+
+    const size_t expected_matches{5};
     EXPECT_THAT(images.size(), Eq(expected_matches));
 }
 
@@ -194,7 +205,7 @@ TEST_F(UbuntuImageHost, all_images_for_daily_returns_two_matches)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
 
-    auto images = host.all_images_for(daily_remote_spec.first);
+    auto images = host.all_images_for(daily_remote_spec.first, false);
 
     const size_t expected_matches{2};
     EXPECT_THAT(images.size(), Eq(expected_matches));


### PR DESCRIPTION
This uses an `--allow-unsupported` option for `launch` and `find`.

Fixes #736