### PR TITLE
Warn unused param

### DIFF
--- a/3rd-party/CMakeLists.txt
+++ b/3rd-party/CMakeLists.txt
@@ -63,6 +63,8 @@ target_link_libraries(gRPC INTERFACE
   libprotobuf
   zlibstatic)
 
+target_compile_options(gRPC INTERFACE "-Wno-unused-parameter")
+
 # YAML C++
 # Disable tests here to avoid double-including gtest
 option(YAML_CPP_BUILD_TOOLS OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_compile_options(-Werror -Wall -pedantic -Wextra -Wno-unused-parameter -Wempty-body -Wformat-security -Winit-self -Warray-bounds -fPIC)
+add_compile_options(-Werror -Wall -pedantic -Wextra -Wempty-body -Wformat-security -Winit-self -Warray-bounds -fPIC)
 
 if(NOT ${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "^arm")
   add_compile_options(-Wcast-align)

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -30,6 +30,7 @@
 #include <QDir>
 #include <QString>
 #include <QStringList>
+#include <QVariant>
 
 namespace multipass
 {
@@ -92,6 +93,21 @@ void try_action_for(OnTimeoutCallable&& on_timeout, std::chrono::milliseconds ti
     }
     on_timeout();
 }
+
+// TODO @ricab separate declaration from implementation
+template <typename RegisteredQtEnum>
+QString qenum_to_qstring(RegisteredQtEnum val)
+{
+    return QVariant::fromValue(val).toString();
 }
+
+template <typename RegisteredQtEnum>
+std::string qenum_to_string(RegisteredQtEnum val)
+{
+    return qenum_to_qstring(val).toStdString();
 }
+
+} // namespace utils
+} // namespace multipass
+
 #endif // MULTIPASS_UTILS_H

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -38,10 +38,17 @@ class VirtualMachine;
 
 namespace utils
 {
+
 enum class QuoteType
 {
     no_quotes,
     quote_every_arg
+};
+
+enum class TimeoutAction
+{
+    retry,
+    done
 };
 
 QDir base_dir(const QString& path);
@@ -67,14 +74,20 @@ bool is_running(const VirtualMachine::State& state);
 void wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
                        std::function<void()> const& process_vm_events = []() { });
 
-enum class TimeoutAction
-{
-    retry,
-    done
-};
 template <typename OnTimeoutCallable, typename TryAction, typename... Args>
 void try_action_for(OnTimeoutCallable&& on_timeout, std::chrono::milliseconds timeout, TryAction&& try_action,
-                    Args&&... args)
+                    Args&&... args);
+template <typename RegisteredQtEnum>
+QString qenum_to_qstring(RegisteredQtEnum val);
+template <typename RegisteredQtEnum>
+std::string qenum_to_string(RegisteredQtEnum val);
+
+} // namespace utils
+} // namespace multipass
+
+template <typename OnTimeoutCallable, typename TryAction, typename... Args>
+void multipass::utils::try_action_for(OnTimeoutCallable&& on_timeout, std::chrono::milliseconds timeout,
+                                      TryAction&& try_action, Args&&... args)
 {
 
     static_assert(std::is_same<decltype(try_action(std::forward<Args>(args)...)), TimeoutAction>::value, "");
@@ -94,20 +107,16 @@ void try_action_for(OnTimeoutCallable&& on_timeout, std::chrono::milliseconds ti
     on_timeout();
 }
 
-// TODO @ricab separate declaration from implementation
 template <typename RegisteredQtEnum>
-QString qenum_to_qstring(RegisteredQtEnum val)
+QString multipass::utils::qenum_to_qstring(RegisteredQtEnum val)
 {
     return QVariant::fromValue(val).toString();
 }
 
 template <typename RegisteredQtEnum>
-std::string qenum_to_string(RegisteredQtEnum val)
+std::string multipass::utils::qenum_to_string(RegisteredQtEnum val)
 {
     return qenum_to_qstring(val).toStdString();
 }
-
-} // namespace utils
-} // namespace multipass
 
 #endif // MULTIPASS_UTILS_H

--- a/src/network/url_downloader.cpp
+++ b/src/network/url_downloader.cpp
@@ -152,7 +152,7 @@ QByteArray mp::URLDownloader::download(const QUrl& url)
 
     // This will connect to the QNetworkReply::readReady signal and when emitted,
     // reset the timer.
-    auto on_download = [](QNetworkReply* reply, QTimer& download_timeout) { download_timeout.start(); };
+    auto on_download = [](QNetworkReply*, QTimer& download_timeout) { download_timeout.start(); };
 
     return ::download(manager.get(), timeout, url, [](QNetworkReply*, qint64, qint64) {}, on_download, [] {});
 }

--- a/src/platform/backends/libvirt/libvirt_virtual_machine.cpp
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine.cpp
@@ -40,7 +40,7 @@ namespace
 {
 virErrorPtr libvirt_error;
 
-void libvirt_error_handler(void* opaque, virErrorPtr error)
+void libvirt_error_handler(void* /*opaque*/, virErrorPtr /*error*/)
 {
     virFreeError(libvirt_error);
     libvirt_error = virSaveLastError();

--- a/src/platform/backends/libvirt/libvirt_virtual_machine_factory.cpp
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine_factory.cpp
@@ -131,8 +131,8 @@ void mp::LibVirtVirtualMachineFactory::prepare_instance_image(const VMImage& ins
     mp::backend::resize_instance_image(process_factory, desc.disk_space, instance_image.image_path);
 }
 
-void mp::LibVirtVirtualMachineFactory::configure(const std::string& name, YAML::Node& meta_config,
-                                                 YAML::Node& user_config)
+void mp::LibVirtVirtualMachineFactory::configure(const std::string& /*name*/, YAML::Node& /*meta_config*/,
+                                                 YAML::Node& /*user_config*/)
 {
 }
 

--- a/src/platform/backends/qemu/dnsmasq_server.cpp
+++ b/src/platform/backends/qemu/dnsmasq_server.cpp
@@ -87,7 +87,8 @@ void mp::DNSMasqServer::release_mac(const std::string& hw_addr)
     QProcess dhcp_release;
     QObject::connect(&dhcp_release, &QProcess::errorOccurred, [&ip, &hw_addr](QProcess::ProcessError error) {
         mpl::log(mpl::Level::warning, "dnsmasq",
-                 fmt::format("failed to release ip addr {} with mac {}", ip.value().as_string(), hw_addr));
+                 fmt::format("failed to release ip addr {} with mac {}: {}", ip.value().as_string(), hw_addr,
+                             utils::qenum_to_string(error)));
     });
 
     auto log_exit_status = [&ip, &hw_addr](int exit_code, QProcess::ExitStatus exit_status) {

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -37,7 +37,6 @@
 #include <QHash>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QMetaEnum>
 #include <QObject>
 #include <QProcess>
 #include <QString>
@@ -213,8 +212,8 @@ mp::QemuVirtualMachine::QemuVirtualMachine(const ProcessFactory* process_factory
     });
 
     QObject::connect(vm_process.get(), &QProcess::stateChanged, [this](QProcess::ProcessState newState) {
-        auto meta = QMetaEnum::fromType<QProcess::ProcessState>();
-        mpl::log(mpl::Level::info, vm_name, fmt::format("process state changed to {}", meta.valueToKey(newState)));
+        mpl::log(mpl::Level::info, vm_name,
+                 fmt::format("process state changed to {}", utils::qenum_to_string(newState)));
     });
 
     QObject::connect(vm_process.get(), &QProcess::errorOccurred, [this](QProcess::ProcessError error) {
@@ -222,8 +221,8 @@ mp::QemuVirtualMachine::QemuVirtualMachine(const ProcessFactory* process_factory
         // out any scary error messages for this state
         if (update_shutdown_status)
         {
-            auto meta = QMetaEnum::fromType<QProcess::ProcessError>(); // TODO @ricab homogenize such uses
-            mpl::log(mpl::Level::error, vm_name, fmt::format("process error occurred {}", meta.valueToKey(error)));
+            mpl::log(mpl::Level::error, vm_name,
+                     fmt::format("process error occurred {}", utils::qenum_to_string(error)));
             on_error();
         }
     });

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -222,7 +222,7 @@ mp::QemuVirtualMachine::QemuVirtualMachine(const ProcessFactory* process_factory
         // out any scary error messages for this state
         if (update_shutdown_status)
         {
-            auto meta = QMetaEnum::fromType<QProcess::ProcessError>();
+            auto meta = QMetaEnum::fromType<QProcess::ProcessError>(); // TODO @ricab homogenize such uses
             mpl::log(mpl::Level::error, vm_name, fmt::format("process error occurred {}", meta.valueToKey(error)));
             on_error();
         }
@@ -231,7 +231,8 @@ mp::QemuVirtualMachine::QemuVirtualMachine(const ProcessFactory* process_factory
     QObject::connect(vm_process.get(), static_cast<void (QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished),
                      [this](int exitCode, QProcess::ExitStatus exitStatus) {
                          mpl::log(mpl::Level::info, vm_name,
-                                  fmt::format("process finished with exit code {}", exitCode));
+                                  fmt::format("process finished with exit code {} ({})", exitCode,
+                                              utils::qenum_to_string(exitStatus)));
                          if (update_shutdown_status || state == State::starting)
                          {
                              on_shutdown();

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
@@ -270,7 +270,8 @@ void mp::QemuVirtualMachineFactory::prepare_instance_image(const mp::VMImage& in
     mp::backend::resize_instance_image(process_factory, desc.disk_space, instance_image.image_path);
 }
 
-void mp::QemuVirtualMachineFactory::configure(const std::string& name, YAML::Node& meta_config, YAML::Node& user_config)
+void mp::QemuVirtualMachineFactory::configure(const std::string& /*name*/, YAML::Node& /*meta_config*/,
+                                              YAML::Node& /*user_config*/)
 {
 }
 

--- a/tests/mock_dnsmasq_server.cpp
+++ b/tests/mock_dnsmasq_server.cpp
@@ -15,7 +15,7 @@
  *
  */
 
-int main(int argc, char* argv[])
+int main()
 {
     return 0;
 }

--- a/tests/mock_qemu_system.cpp
+++ b/tests/mock_qemu_system.cpp
@@ -25,7 +25,7 @@ int main(int argc, char* argv[])
 {
     std::string input;
 
-    if (strcmp(argv[2], "-dump-vmstate") == 0)
+    if (argc > 2 && strcmp(argv[2], "-dump-vmstate") == 0)
         return 0;
 
     while (true)


### PR DESCRIPTION
Activates unused parameter warnings. Fixes all such cases, homogenizing implicated code.

Fixes #697 