### PR TITLE
image_vault: Allow for simultaneous launching of new images

### DIFF
--- a/include/multipass/vm_image_info.h
+++ b/include/multipass/vm_image_info.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,17 +26,18 @@ namespace multipass
 class VMImageInfo
 {
 public:
-    const QStringList aliases;
-    const QString os;
-    const QString release;
-    const QString release_title;
-    const bool supported;
-    const QString image_location;
-    const QString kernel_location;
-    const QString initrd_location;
-    const QString id;
-    const QString version;
-    const int64_t size;
+    QStringList aliases;
+    QString os;
+    QString release;
+    QString release_title;
+    bool supported;
+    QString image_location;
+    QString kernel_location;
+    QString initrd_location;
+    QString id;
+    QString version;
+    int64_t size;
+    bool verify;
 };
 }
 #endif // MULTIPASS_VM_IMAGE_INFO_H

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -292,7 +292,8 @@ mp::ReturnCode cmd::Launch::request_launch()
             {LaunchProgress_ProgressTypes_KERNEL, "Retrieving kernel image: "},
             {LaunchProgress_ProgressTypes_INITRD, "Retrieving initrd image: "},
             {LaunchProgress_ProgressTypes_EXTRACT, "Extracting image: "},
-            {LaunchProgress_ProgressTypes_VERIFY, "Verifying image: "}};
+            {LaunchProgress_ProgressTypes_VERIFY, "Verifying image: "},
+            {LaunchProgress_ProgressTypes_WAITING, "Waiting for in progress image preparation"}};
 
         if (reply.create_oneof_case() == mp::LaunchReply::CreateOneofCase::kLaunchProgress)
         {
@@ -305,6 +306,7 @@ mp::ReturnCode cmd::Launch::request_launch()
             }
             else
             {
+                spinner.stop();
                 spinner.start(progress_message);
             }
         }

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -293,7 +293,7 @@ mp::ReturnCode cmd::Launch::request_launch()
             {LaunchProgress_ProgressTypes_INITRD, "Retrieving initrd image: "},
             {LaunchProgress_ProgressTypes_EXTRACT, "Extracting image: "},
             {LaunchProgress_ProgressTypes_VERIFY, "Verifying image: "},
-            {LaunchProgress_ProgressTypes_WAITING, "Waiting for in-progress image preparation: "}};
+            {LaunchProgress_ProgressTypes_WAITING, "Preparing image: "}};
 
         if (reply.create_oneof_case() == mp::LaunchReply::CreateOneofCase::kLaunchProgress)
         {

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -293,7 +293,7 @@ mp::ReturnCode cmd::Launch::request_launch()
             {LaunchProgress_ProgressTypes_INITRD, "Retrieving initrd image: "},
             {LaunchProgress_ProgressTypes_EXTRACT, "Extracting image: "},
             {LaunchProgress_ProgressTypes_VERIFY, "Verifying image: "},
-            {LaunchProgress_ProgressTypes_WAITING, "Waiting for in progress image preparation"}};
+            {LaunchProgress_ProgressTypes_WAITING, "Waiting for in-progress image preparation: "}};
 
         if (reply.create_oneof_case() == mp::LaunchReply::CreateOneofCase::kLaunchProgress)
         {

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -153,7 +153,8 @@ auto full_image_info_for(const QMap<QString, CustomImageInfo>& custom_image_info
                                         image_info.second.initrd_location,
                                         base_image_info.hash,
                                         base_image_info.last_modified,
-                                        0};
+                                        0,
+                                        true};
 
         default_images.push_back(full_image_info);
     }

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -32,6 +32,7 @@
 #include <memory>
 #include <mutex>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <QFutureWatcher>
@@ -179,6 +180,7 @@ private:
     std::vector<std::unique_ptr<QFutureWatcher<AsyncOperationStatus>>> async_future_watchers;
     std::unordered_map<std::string, QFuture<std::string>> async_running_futures;
     std::mutex start_mutex;
+    std::unordered_set<std::string> preparing_instances;
 };
 } // namespace multipass
 #endif // MULTIPASS_DAEMON_H

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -268,235 +268,187 @@ mp::DefaultVMImageVault::DefaultVMImageVault(std::vector<VMImageHost*> image_hos
 mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type, const Query& query,
                                                  const PrepareAction& prepare, const ProgressMonitor& monitor)
 {
-    auto name_entry = instance_image_records.find(query.name);
-    if (name_entry != instance_image_records.end())
     {
-        const auto& record = name_entry->second;
+        std::lock_guard<decltype(fetch_mutex)> lock{fetch_mutex};
+        auto name_entry = instance_image_records.find(query.name);
+        if (name_entry != instance_image_records.end())
+        {
+            const auto& record = name_entry->second;
 
-        return record.image;
+            return record.image;
+        }
     }
 
-    if (query.query_type != Query::Type::Alias)
-    {
-        if (!mp::platform::is_image_url_supported())
-            throw std::runtime_error(fmt::format("http and file based images are not supported"));
+    if (query.query_type != Query::Type::Alias && !mp::platform::is_image_url_supported())
+        throw std::runtime_error(fmt::format("http and file based images are not supported"));
 
+    if (query.query_type == Query::Type::LocalFile)
+    {
         QUrl image_url(QString::fromStdString(query.release));
         VMImage source_image, vm_image;
 
-        if (image_url.isLocalFile())
+        if (!QFile::exists(image_url.path()))
+            throw std::runtime_error(fmt::format("Custom image `{}` does not exist.", image_url.path().toStdString()));
+
+        source_image.image_path = image_url.path();
+
+        if (source_image.image_path.endsWith(".xz"))
         {
-            if (!QFile::exists(image_url.path()))
-                throw std::runtime_error(
-                    fmt::format("Custom image `{}` does not exist.", image_url.path().toStdString()));
-            source_image.image_path = image_url.path();
-
-            if (source_image.image_path.endsWith(".xz"))
-            {
-                source_image = extract_image_from(query.name, source_image, monitor);
-            }
-            else
-            {
-                source_image = image_instance_from(query.name, source_image);
-            }
-
-            if (fetch_type == FetchType::ImageKernelAndInitrd)
-            {
-                Query kernel_query{query.name, "default", false, "", Query::Type::Alias};
-                auto info = info_for(kernel_query);
-
-                source_image = fetch_kernel_and_initrd(info, source_image,
-                                                       QFileInfo(source_image.image_path).absoluteDir(), monitor);
-            }
-
-            vm_image = prepare(source_image);
-            remove_source_images(source_image, vm_image);
+            source_image = extract_image_from(query.name, source_image, monitor);
         }
         else
         {
+            source_image = image_instance_from(query.name, source_image);
+        }
+
+        if (fetch_type == FetchType::ImageKernelAndInitrd)
+        {
+            auto info = get_kernel_query_info(query.name);
+
+            source_image =
+                fetch_kernel_and_initrd(info, source_image, QFileInfo(source_image.image_path).absoluteDir(), monitor);
+        }
+
+        vm_image = prepare(source_image);
+        remove_source_images(source_image, vm_image);
+
+        {
+            std::lock_guard<decltype(fetch_mutex)> lock{fetch_mutex};
+            instance_image_records[query.name] = {vm_image, query, std::chrono::system_clock::now()};
+            persist_instance_records();
+        }
+
+        return vm_image;
+    }
+    else
+    {
+        std::string id;
+        optional<VMImage> source_image{nullopt};
+        VMImageInfo info;
+        QDir image_dir;
+
+        if (query.query_type == Query::Type::HttpDownload)
+        {
+            QUrl image_url(QString::fromStdString(query.release));
+
             // Generate a sha256 hash based on the URL and use that for the id
-            auto hash =
-                QCryptographicHash::hash(query.release.c_str(), QCryptographicHash::Sha256).toHex().toStdString();
+            id = QCryptographicHash::hash(query.release.c_str(), QCryptographicHash::Sha256).toHex().toStdString();
             auto last_modified = url_downloader->last_modified(image_url);
 
-            auto entry = prepared_image_records.find(hash);
+            std::lock_guard<decltype(fetch_mutex)> lock{fetch_mutex};
+            auto entry = prepared_image_records.find(id);
             if (entry != prepared_image_records.end())
             {
                 auto& record = entry->second;
 
                 if (last_modified.isValid() && (last_modified.toString().toStdString() == record.image.release_date))
                 {
-                    record.last_accessed = std::chrono::system_clock::now();
-                    auto vm_image = finalize_image_records(query, record.image);
-                    return vm_image;
+                    return finalize_image_records(query, record.image, id);
                 }
                 else
                 {
-                    source_image = record.image;
+                    *source_image = record.image;
                 }
             }
             else
             {
+                auto kernel_info = get_kernel_query_info(query.name);
+                info = static_cast<const VMImageInfo>(VMImageInfo{{},
+                                                                  {},
+                                                                  {},
+                                                                  {},
+                                                                  true,
+                                                                  image_url.url(),
+                                                                  kernel_info.kernel_location,
+                                                                  kernel_info.initrd_location,
+                                                                  QString::fromStdString(id),
+                                                                  {},
+                                                                  0,
+                                                                  false});
                 const auto image_filename = filename_for(image_url.path());
                 // Attempt to make a sane directory name based on the filename of the image
+
                 const auto image_dir_name = QString("%1-%2")
                                           .arg(image_filename.section(".", 0, image_filename.endsWith(".xz") ? -3 : -2))
                                           .arg(last_modified.toString("yyyyMMdd"));
-                const QDir image_dir{mp::utils::make_dir(images_dir, image_dir_name)};
-
-                source_image.id = hash;
-                source_image.image_path = image_dir.filePath(image_filename);
+                image_dir = mp::utils::make_dir(images_dir, image_dir_name);
             }
+        }
+        else
+        {
+            info = static_cast<const VMImageInfo>(info_for(query));
 
-            DeleteOnException image_file{source_image.image_path};
-            url_downloader->download_to(image_url, source_image.image_path, 0, LaunchProgress::IMAGE, monitor);
+            if (!mp::platform::is_remote_supported(query.remote_name))
+                throw std::runtime_error(
+                    fmt::format("{} is not a supported remote. Please use `multipass find` for supported images.",
+                                query.remote_name));
 
-            if (fetch_type == FetchType::ImageKernelAndInitrd)
+            if (!mp::platform::is_alias_supported(query.release, query.remote_name))
+                throw std::runtime_error(
+                    fmt::format("{} is not a supported alias. Please use `multipass find` for supported image aliases.",
+                                query.release));
+
+            id = info.id.toStdString();
+
+            if (!query.name.empty())
             {
-                Query kernel_query{query.name, "default", false, "", Query::Type::Alias};
-                auto info = info_for(kernel_query);
+                std::lock_guard<decltype(fetch_mutex)> lock{fetch_mutex};
+                for (auto& record : prepared_image_records)
+                {
+                    if (record.second.query.remote_name != query.remote_name)
+                        continue;
 
-                source_image = fetch_kernel_and_initrd(info, source_image,
-                                                       QFileInfo(source_image.image_path).absoluteDir(), monitor);
+                    const auto aliases = record.second.image.aliases;
+                    if (id == record.first ||
+                        std::find(aliases.cbegin(), aliases.cend(), query.release) != aliases.cend())
+                    {
+                        const auto prepared_image = record.second.image;
+                        try
+                        {
+                            return finalize_image_records(query, prepared_image, id);
+                        }
+                        catch (const std::exception& e)
+                        {
+                            mpl::log(mpl::Level::warning, category,
+                                     fmt::format("Cannot create instance image: {}", e.what()));
+
+                            break;
+                        }
+                    }
+                }
             }
 
-            if (source_image.image_path.endsWith(".xz"))
-            {
-                source_image = extract_downloaded_image(source_image, monitor);
-            }
-
-            vm_image = prepare(source_image);
-            vm_image.release_date = last_modified.toString().toStdString();
-            prepared_image_records[hash] = {vm_image, query, std::chrono::system_clock::now()};
-            remove_source_images(source_image, vm_image);
-            persist_image_records();
-            vm_image = image_instance_from(query.name, vm_image);
+            image_dir = mp::utils::make_dir(images_dir, QString("%1-%2").arg(info.release).arg(info.version));
         }
 
-        instance_image_records[query.name] = {vm_image, query, std::chrono::system_clock::now()};
-        persist_instance_records();
-
-        return vm_image;
-    }
-    else
-    {
-        auto info = info_for(query);
-
-        if (!mp::platform::is_remote_supported(query.remote_name))
-            throw std::runtime_error(fmt::format(
-                "{} is not a supported remote. Please use `multipass find` for supported images.", query.remote_name));
-
-        if (!mp::platform::is_alias_supported(query.release, query.remote_name))
-            throw std::runtime_error(
-                fmt::format("{} is not a supported alias. Please use `multipass find` for supported image aliases.",
-                            query.release));
-
-        auto id = info.id.toStdString();
-
-        std::unique_lock<decltype(fetch_mutex)> lock{fetch_mutex};
-        auto it = in_progress_image_fetches.find(id);
-        if (it != in_progress_image_fetches.end())
+        auto running_future = get_image_future(id);
+        if (running_future)
         {
-            auto future = it->second;
             monitor(LaunchProgress::WAITING, -1);
-            lock.unlock();
+            auto prepared_image = (*running_future).result();
 
-            auto prepared_image = future.result();
-
-            lock.lock();
-            prepared_image_records[id].last_accessed = std::chrono::system_clock::now();
-            auto vm_image = finalize_image_records(query, prepared_image);
-            lock.unlock();
-
-            return vm_image;
+            {
+                std::lock_guard<decltype(fetch_mutex)> lock{fetch_mutex};
+                return finalize_image_records(query, prepared_image, id);
+            }
         }
 
-        if (!query.name.empty())
+        // Had to use std::bind here to workaround the 5 allowable function arguments constraint of QtConcurrent::run()
+        auto future = QtConcurrent::run(std::bind(&DefaultVMImageVault::download_and_prepare_source_image, this, info,
+                                                  source_image, image_dir, fetch_type, prepare, monitor));
+
         {
-            for (auto& record : prepared_image_records)
-            {
-                if (record.second.query.remote_name != query.remote_name)
-                    continue;
-
-                const auto aliases = record.second.image.aliases;
-                if (id == record.first || std::find(aliases.cbegin(), aliases.cend(), query.release) != aliases.cend())
-                {
-                    const auto prepared_image = record.second.image;
-                    try
-                    {
-                        record.second.last_accessed = std::chrono::system_clock::now();
-                        auto vm_image = finalize_image_records(query, prepared_image);
-                        lock.unlock();
-
-                        return vm_image;
-                    }
-                    catch (const std::exception& e)
-                    {
-                        mpl::log(mpl::Level::warning, category,
-                                 fmt::format("Cannot create instance image: {}", e.what()));
-
-                        break;
-                    }
-                }
-            }
+            std::lock_guard<decltype(fetch_mutex)> lock{fetch_mutex};
+            in_progress_image_fetches[id] = future;
         }
-
-        const auto image_dir_name = QString("%1-%2").arg(info.release).arg(info.version);
-        const QDir image_dir{mp::utils::make_dir(images_dir, image_dir_name)};
-
-        VMImage source_image;
-        source_image.id = id;
-        source_image.image_path = image_dir.filePath(filename_for(info.image_location));
-        source_image.original_release = info.release_title.toStdString();
-        for (const auto& alias : info.aliases)
-        {
-            source_image.aliases.push_back(alias.toStdString());
-        }
-        DeleteOnException image_file{source_image.image_path};
-
-        auto future = QtConcurrent::run([&]() -> VMImage {
-            try
-            {
-                url_downloader->download_to(info.image_location, source_image.image_path, info.size,
-                                            LaunchProgress::IMAGE, monitor);
-
-                monitor(LaunchProgress::VERIFY, -1);
-                verify_image_download(source_image.image_path, id);
-
-                if (fetch_type == FetchType::ImageKernelAndInitrd)
-                {
-                    source_image = fetch_kernel_and_initrd(info, source_image, image_dir, monitor);
-                }
-
-                if (source_image.image_path.endsWith(".xz"))
-                {
-                    source_image = extract_downloaded_image(source_image, monitor);
-                }
-
-                auto prepared_image = prepare(source_image);
-                remove_source_images(source_image, prepared_image);
-
-                return prepared_image;
-            }
-            catch (const std::exception& e)
-            {
-                throw CreateImageException(e.what());
-            }
-        });
-
-        in_progress_image_fetches[id] = future;
-        lock.unlock();
 
         auto prepared_image = future.result();
 
-        lock.lock();
-        prepared_image_records[id] = {prepared_image, query, std::chrono::system_clock::now()};
-        auto vm_image = finalize_image_records(query, prepared_image);
-
-        in_progress_image_fetches.erase(id);
-        lock.unlock();
-
-        return vm_image;
+        {
+            std::lock_guard<decltype(fetch_mutex)> lock{fetch_mutex};
+            in_progress_image_fetches.erase(id);
+            return finalize_image_records(query, prepared_image, id);
+        }
     }
 }
 
@@ -569,6 +521,63 @@ void mp::DefaultVMImageVault::update_images(const FetchType& fetch_type, const P
     }
 }
 
+mp::VMImage mp::DefaultVMImageVault::download_and_prepare_source_image(
+    const VMImageInfo& info, mp::optional<VMImage>& existing_source_image, const QDir& image_dir,
+    const FetchType& fetch_type, const PrepareAction& prepare, const ProgressMonitor& monitor)
+{
+    VMImage source_image;
+    auto id = info.id.toStdString();
+
+    if (existing_source_image)
+    {
+        source_image = *existing_source_image;
+    }
+    else
+    {
+        source_image.id = id;
+        source_image.image_path = image_dir.filePath(filename_for(info.image_location));
+        source_image.original_release = info.release_title.toStdString();
+
+        for (const auto& alias : info.aliases)
+        {
+            source_image.aliases.push_back(alias.toStdString());
+        }
+    }
+
+    DeleteOnException image_file{source_image.image_path};
+
+    try
+    {
+        url_downloader->download_to(info.image_location, source_image.image_path, info.size, LaunchProgress::IMAGE,
+                                    monitor);
+
+        if (info.verify)
+        {
+            monitor(LaunchProgress::VERIFY, -1);
+            verify_image_download(source_image.image_path, id);
+        }
+
+        if (fetch_type == FetchType::ImageKernelAndInitrd)
+        {
+            source_image = fetch_kernel_and_initrd(info, source_image, image_dir, monitor);
+        }
+
+        if (source_image.image_path.endsWith(".xz"))
+        {
+            source_image = extract_downloaded_image(source_image, monitor);
+        }
+
+        auto prepared_image = prepare(source_image);
+        remove_source_images(source_image, prepared_image);
+
+        return prepared_image;
+    }
+    catch (const std::exception& e)
+    {
+        throw CreateImageException(e.what());
+    }
+}
+
 mp::VMImage mp::DefaultVMImageVault::extract_image_from(const std::string& instance_name, const VMImage& source_image,
                                                         const ProgressMonitor& monitor)
 {
@@ -632,7 +641,20 @@ mp::VMImage mp::DefaultVMImageVault::fetch_kernel_and_initrd(const VMImageInfo& 
     return image;
 }
 
-mp::VMImage mp::DefaultVMImageVault::finalize_image_records(const Query& query, const VMImage& prepared_image)
+mp::optional<QFuture<mp::VMImage>> mp::DefaultVMImageVault::get_image_future(const std::string& id)
+{
+    std::lock_guard<decltype(fetch_mutex)> lock{fetch_mutex};
+    auto it = in_progress_image_fetches.find(id);
+    if (it != in_progress_image_fetches.end())
+    {
+        return it->second;
+    }
+
+    return mp::nullopt;
+}
+
+mp::VMImage mp::DefaultVMImageVault::finalize_image_records(const Query& query, const VMImage& prepared_image,
+                                                            const std::string& id)
 {
     VMImage vm_image;
 
@@ -640,6 +662,16 @@ mp::VMImage mp::DefaultVMImageVault::finalize_image_records(const Query& query, 
     {
         vm_image = image_instance_from(query.name, prepared_image);
         instance_image_records[query.name] = {vm_image, query, std::chrono::system_clock::now()};
+    }
+
+    try
+    {
+        auto record = prepared_image_records.at(id);
+        record.last_accessed = std::chrono::system_clock::now();
+    }
+    catch (const std::out_of_range&)
+    {
+        prepared_image_records[id] = {prepared_image, query, std::chrono::system_clock::now()};
     }
 
     persist_instance_records();
@@ -675,6 +707,13 @@ mp::VMImageInfo mp::DefaultVMImageVault::info_for(const mp::Query& query)
     }
 
     throw std::runtime_error(fmt::format("Unable to find an image matching \"{}\"", query.release));
+}
+
+mp::VMImageInfo mp::DefaultVMImageVault::get_kernel_query_info(const std::string& name)
+{
+
+    Query kernel_query{name, "default", false, "", Query::Type::Alias};
+    return info_for(kernel_query);
 }
 
 namespace

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -592,7 +592,6 @@ mp::VMImage mp::DefaultVMImageVault::download_and_prepare_source_image(
     }
     catch (const std::exception& e)
     {
-        fmt::print("The error is {}\n", e.what());
         throw CreateImageException(e.what());
     }
 }

--- a/src/daemon/default_vm_image_vault.h
+++ b/src/daemon/default_vm_image_vault.h
@@ -19,6 +19,7 @@
 #define MULTIPASS_DEFAULT_VM_IMAGE_VAULT_H
 
 #include <multipass/days.h>
+#include <multipass/optional.h>
 #include <multipass/path.h>
 #include <multipass/query.h>
 #include <multipass/vm_image.h>
@@ -58,13 +59,18 @@ public:
 
 private:
     VMImage image_instance_from(const std::string& name, const VMImage& prepared_image);
+    VMImage download_and_prepare_source_image(const VMImageInfo& info, optional<VMImage>& existing_source_image,
+                                              const QDir& image_dir, const FetchType& fetch_type,
+                                              const PrepareAction& prepare, const ProgressMonitor& monitor);
     VMImage extract_image_from(const std::string& instance_name, const VMImage& source_image,
                                const ProgressMonitor& monitor);
     VMImage extract_downloaded_image(const VMImage& source_image, const ProgressMonitor& monitor);
     VMImage fetch_kernel_and_initrd(const VMImageInfo& info, const VMImage& source_image, const QDir& image_dir,
                                     const ProgressMonitor& monitor);
-    VMImage finalize_image_records(const Query& query, const VMImage& prepared_image);
+    optional<QFuture<VMImage>> get_image_future(const std::string& id);
+    VMImage finalize_image_records(const Query& query, const VMImage& prepared_image, const std::string& id);
     VMImageInfo info_for(const Query& query);
+    VMImageInfo get_kernel_query_info(const std::string& name);
     void persist_image_records();
     void persist_instance_records();
 

--- a/src/daemon/default_vm_image_vault.h
+++ b/src/daemon/default_vm_image_vault.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,7 +26,10 @@
 #include <multipass/vm_image_vault.h>
 
 #include <QDir>
+#include <QFuture>
+
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 
 namespace multipass
@@ -60,6 +63,7 @@ private:
     VMImage extract_downloaded_image(const VMImage& source_image, const ProgressMonitor& monitor);
     VMImage fetch_kernel_and_initrd(const VMImageInfo& info, const VMImage& source_image, const QDir& image_dir,
                                     const ProgressMonitor& monitor);
+    VMImage finalize_image_records(const Query& query, const VMImage& prepared_image);
     VMImageInfo info_for(const Query& query);
     void persist_image_records();
     void persist_instance_records();
@@ -71,10 +75,12 @@ private:
     const QDir instances_dir;
     const QDir images_dir;
     const days days_to_expire;
+    std::mutex fetch_mutex;
 
     std::unordered_map<std::string, VaultRecord> prepared_image_records;
     std::unordered_map<std::string, VaultRecord> instance_image_records;
     std::unordered_map<std::string, VMImageHost*> remote_image_host_map;
+    std::unordered_map<std::string, QFuture<VMImage>> in_progress_image_fetches;
 };
 }
 #endif // MULTIPASS_DEFAULT_VM_IMAGE_VAULT_H

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -57,7 +57,8 @@ mp::VMImageInfo with_location_fully_resolved(const QString& host_url, const mp::
             host_url + info.initrd_location,
             info.id,
             info.version,
-            info.size};
+            info.size,
+            info.verify};
 }
 
 auto key_from(const std::string& search_string)
@@ -171,8 +172,6 @@ mp::VMImageInfo mp::UbuntuVMImageHost::info_for_full_hash_impl(const std::string
     }
 
     throw std::runtime_error(fmt::format("Unable to find an image matching hash \"{}\"", full_hash));
-
-    return mp::VMImageInfo{{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, -1};
 }
 
 std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_images_for(const std::string& remote_name,

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -79,6 +79,7 @@ message LaunchProgress {
         INITRD = 2;
         EXTRACT = 3;
         VERIFY = 4;
+        WAITING = 5;
     }
     ProgressTypes type = 1;
     string percent_complete = 2;

--- a/src/simplestreams/simple_streams_manifest.cpp
+++ b/src/simplestreams/simple_streams_manifest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,9 +12,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Authored by: Chris Townsend <christopher.townsend@canonical.com>
- *              Alberto Aguirre <alberto.aguirre@canonical.com>
  *
  */
 
@@ -130,7 +127,7 @@ std::unique_ptr<mp::SimpleStreamsManifest> mp::SimpleStreamsManifest::fromJson(c
             // Aliases always alias to the latest version
             const QStringList& aliases = version_string == latest_version ? product_aliases : QStringList();
             products.push_back({aliases, "Ubuntu", release, release_title, supported, image_location, kernel_location,
-                                initrd_location, sha256, version_string, size});
+                                initrd_location, sha256, version_string, size, true});
         }
     }
 

--- a/tests/stub_image_host.h
+++ b/tests/stub_image_host.h
@@ -28,7 +28,7 @@ struct StubVMImageHost final : public multipass::VMImageHost
 {
     multipass::optional<multipass::VMImageInfo> info_for(const multipass::Query& query) override
     {
-        return multipass::optional<multipass::VMImageInfo>{VMImageInfo{{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, -1}};
+        return multipass::optional<multipass::VMImageInfo>{VMImageInfo{{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, -1, {}}};
     };
 
     std::vector<multipass::VMImageInfo> all_info_for(const multipass::Query& query) override
@@ -38,7 +38,7 @@ struct StubVMImageHost final : public multipass::VMImageHost
 
     multipass::VMImageInfo info_for_full_hash(const std::string& full_hash) override
     {
-        return {{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, -1};
+        return {{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, -1, {}};
     };
 
     std::vector<multipass::VMImageInfo> all_images_for(const std::string& remote_name,

--- a/tests/test_image_vault.cpp
+++ b/tests/test_image_vault.cpp
@@ -60,7 +60,8 @@ struct ImageHost : public mp::VMImageHost
                                                              initrd.url(),
                                                              default_id,
                                                              default_version,
-                                                             1}};
+                                                             1,
+                                                             true}};
     }
 
     std::vector<mp::VMImageInfo> all_info_for(const mp::Query& query) override
@@ -70,7 +71,7 @@ struct ImageHost : public mp::VMImageHost
 
     mp::VMImageInfo info_for_full_hash(const std::string& full_hash) override
     {
-        return {{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, -1};
+        return {{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, -1, {}};
     }
 
     std::vector<mp::VMImageInfo> all_images_for(const std::string& remote_name, const bool allow_unsupported) override

--- a/tests/test_image_vault.cpp
+++ b/tests/test_image_vault.cpp
@@ -23,6 +23,7 @@
 #include "temp_dir.h"
 #include "temp_file.h"
 
+#include <multipass/exceptions/create_image_exception.h>
 #include <multipass/optional.h>
 #include <multipass/query.h>
 #include <multipass/url_downloader.h>
@@ -370,7 +371,7 @@ TEST_F(ImageVault, missing_downloaded_image_throws)
     mpt::StubURLDownloader stub_url_downloader;
     mp::DefaultVMImageVault vault{hosts, &stub_url_downloader, cache_dir.path(), data_dir.path(), mp::days{0}};
     EXPECT_THROW(vault.fetch_image(mp::FetchType::ImageOnly, default_query, stub_prepare, stub_monitor),
-                 std::runtime_error);
+                 mp::CreateImageException);
 }
 
 TEST_F(ImageVault, hash_mismatch_throws)
@@ -378,7 +379,7 @@ TEST_F(ImageVault, hash_mismatch_throws)
     BadURLDownloader bad_url_downloader;
     mp::DefaultVMImageVault vault{hosts, &bad_url_downloader, cache_dir.path(), data_dir.path(), mp::days{0}};
     EXPECT_THROW(vault.fetch_image(mp::FetchType::ImageOnly, default_query, stub_prepare, stub_monitor),
-                 std::runtime_error);
+                 mp::CreateImageException);
 }
 
 TEST_F(ImageVault, invalid_remote_throws)
@@ -400,7 +401,8 @@ TEST_F(ImageVault, invalid_image_alias_throw)
 
     query.release = "foo";
 
-    EXPECT_THROW(vault.fetch_image(mp::FetchType::ImageOnly, query, stub_prepare, stub_monitor), std::runtime_error);
+    EXPECT_THROW(vault.fetch_image(mp::FetchType::ImageOnly, query, stub_prepare, stub_monitor),
+                 mp::CreateImageException);
 }
 
 TEST_F(ImageVault, valid_remote_and_alias_returns_valid_image_info)


### PR DESCRIPTION
The first launch will download and prepare the image while other launches of the
same image will block until the download and prepare is complete.

Fixes #664