### PR TITLE
[snap] snapcraft.yaml cleanup and improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,15 @@ if: |
 addons:
   snaps:
   - lxd
+  - name: snapcraft
+    classic: true
 
 env:
   global:
   - SNAPCRAFT_ENABLE_ERROR_REPORTING=0
 
 install:
-- sudo apt remove --assume-yes lxd
+- sudo apt remove --purge --assume-yes lxd lxd-client
 - sudo /snap/bin/lxd waitready
 - sudo /snap/bin/lxd init --auto
 - sudo adduser $USER lxd
@@ -28,16 +30,8 @@ install:
 before_script:
 - "[ ! -f tests/travis.patch ] || patch -p1 --no-backup-if-mismatch < tests/travis.patch"
 - "[ ! -f tests/travis-${BUILD_TYPE}.patch ] || patch -p1 < tests/travis-${BUILD_TYPE}.patch"
-- sg lxd -c 'lxc remote add --protocol simplestreams ubuntu-minimal https://cloud-images.ubuntu.com/minimal/releases/'
-- |
-    sg lxd -c "$( printf '/snap/bin/lxc launch ubuntu-minimal:16.04 snapcraft-multipass \
-      --config user.user-data="#cloud-config\npackages: [ccache]" \
-      --config environment.PATH="/usr/lib/ccache:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin" \
-      --config raw.idmap="uid %s 0\ngid %s 0"' $( id -u ) $( id -g ) )"
-- sg lxd -c "/snap/bin/lxc config device add snapcraft-multipass project disk source=$PWD path=/root/project"
-- sg lxd -c "/snap/bin/lxc config device add snapcraft-multipass ccache disk source=${HOME}/.ccache/ path=/root/.ccache"
-- while ! sg lxd -c '/snap/bin/lxc exec snapcraft-multipass -- cloud-init status' | grep 'done'; do sleep 5; done
-- while ! sg lxd -c '/snap/bin/lxc exec snapcraft-multipass -- snap install snapcraft --classic'; do sleep 5; done
+- sg lxd -c '/snap/bin/lxc profile device add default ccache disk source=${HOME}/.ccache/ path=/root/.ccache'
+- sg lxd -c '/snap/bin/lxc profile set default environment.PATH "/usr/lib/ccache:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"'
 - ccache --zero-stats
 
 after_failure:
@@ -52,25 +46,27 @@ jobs:
   include:
     - env: BUILD_TYPE=RelWithDebInfo
       script:
-      - sg lxd -c '/snap/bin/lxc exec snapcraft-multipass -- sh -c "cd project; snapcraft"'
+      - sg lxd -c '/snap/bin/snapcraft --use-lxd'
 
     - env: BUILD_TYPE=Debug
       script:
-      - sg lxd -c '/snap/bin/lxc exec snapcraft-multipass -- sh -c "cd project; snapcraft build multipass"'
+      - sg lxd -c '/snap/bin/snapcraft build --use-lxd multipass'
+      - sg lxd -c '/snap/bin/lxc start snapcraft-multipass'
       - sg lxd -c
           '/snap/bin/lxc exec snapcraft-multipass --
              env CTEST_OUTPUT_ON_FAILURE=1
-                 LD_LIBRARY_PATH=/root/project/stage/usr/lib/x86_64-linux-gnu/:/root/project/stage/lib/
-                 /root/project/parts/multipass/build/bin/multipass_tests'
+                 LD_LIBRARY_PATH=/root/stage/usr/lib/x86_64-linux-gnu/:/root/stage/lib/
+                 /root/parts/multipass/build/bin/multipass_tests'
 
     - env: BUILD_TYPE=Coverage
       script:
-      - sg lxd -c '/snap/bin/lxc exec snapcraft-multipass -- sh -c "cd project; snapcraft build multipass"'
+      - sg lxd -c '/snap/bin/snapcraft build --use-lxd multipass'
+      - sg lxd -c '/snap/bin/lxc start snapcraft-multipass'
       - sg lxd -c
           '/snap/bin/lxc exec snapcraft-multipass --
              env CTEST_OUTPUT_ON_FAILURE=1
-                 LD_LIBRARY_PATH=/root/project/stage/usr/lib/x86_64-linux-gnu/:/root/project/stage/lib/
-                 cmake --build /root/project/parts/multipass/build --target covreport'
+                 LD_LIBRARY_PATH=/root/stage/usr/lib/x86_64-linux-gnu/:/root/stage/lib/
+                 cmake --build /root/parts/multipass/build --target covreport'
       after_success:
       - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
     - if: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 
 before_script:
 - "[ ! -f tests/travis.patch ] || patch -p1 --no-backup-if-mismatch < tests/travis.patch"
-- "[ ! -f tests/travis-${BUILD_TYPE}.patch ] || patch -p1 < tests/travis-${BUILD_TYPE}.patch"
+- "[ ! -f tests/travis-${BUILD_TYPE}.patch ] || patch -p1 --no-backup-if-mismatch < tests/travis-${BUILD_TYPE}.patch"
 - sg lxd -c '/snap/bin/lxc profile device add default ccache disk source=${HOME}/.ccache/ path=/root/.ccache'
 - sg lxd -c '/snap/bin/lxc profile set default environment.PATH "/usr/lib/ccache:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"'
 - ccache --zero-stats

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,7 +12,6 @@ passthrough:
   license: GPL-3.0
 
 adopt-info: multipass
-grade: devel
 confinement: classic
 
 apps:
@@ -233,7 +232,9 @@ parts:
       mkdir -p ${SNAPCRAFT_PART_INSTALL}/etc/bash_completion.d/
       echo 'export PATH="${PATH}:/snap/bin:/var/lib/snapd/snap/bin"' > ${SNAPCRAFT_PART_INSTALL}/etc/bash_completion.d/snap.multipass
       cat ../src/completions/bash/multipass >> ${SNAPCRAFT_PART_INSTALL}/etc/bash_completion.d/snap.multipass
-      snapcraftctl set-version $( awk -F\" '/version_string/ { print $2 }' gen/multipass/version.h )
+      VERSION=$( awk -F\" '/version_string/ { print $2 }' gen/multipass/version.h )
+      snapcraftctl set-version ${VERSION}
+      snapcraftctl set-grade $( echo ${VERSION} | grep -qe '^[0-9]\+\.[0-9]\+\.[0-9]\+$' && echo stable || echo devel )
 
   qemu:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,11 +1,17 @@
 name: multipass
-adopt-info: multipass
-summary: Ubuntu at your fingertips
+icon: snap/gui/multipass-gui.svg
+summary: Instant Ubuntu VMs
 description: |
-  Multipass gives you Ubuntu VMs in seconds. Just run `multipass launch`
-  and it'll do all the setup for you. Check out `multipass find` for a list
-  of available images. More details you can find under `multipass help`.
+  Multipass is a tool to launch and manage VMs on Windows, Mac and Linux that
+  simulates a cloud environment with support for cloud-init. Get Ubuntu
+  on-demand with clean integration to your IDE and version control on your
+  native platform.
 
+passthrough:
+  title: Multipass
+  license: GPL-3.0
+
+adopt-info: multipass
 grade: devel
 confinement: classic
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,5 @@
 name: multipass
+title: Multipass
 icon: snap/gui/multipass-gui.svg
 summary: Instant Ubuntu VMs
 description: |
@@ -6,10 +7,7 @@ description: |
   simulates a cloud environment with support for cloud-init. Get Ubuntu
   on-demand with clean integration to your IDE and version control on your
   native platform.
-
-passthrough:
-  title: Multipass
-  license: GPL-3.0
+license: GPL-3.0
 
 adopt-info: multipass
 confinement: classic
@@ -25,8 +23,7 @@ apps:
       XDG_DATA_HOME: $SNAP_COMMON/data
       XDG_CACHE_HOME: $SNAP_COMMON/cache
     daemon: simple
-    passthrough:
-      after: [libvirt-bin]
+    after: [libvirt-bin]
   multipass:
     environment:
       LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -287,6 +287,7 @@ parts:
     - try: [libnuma1]
     - libcurl3-gnutls
     - libpciaccess0
+    - pm-utils
     configflags:
     - --with-qemu
     - --without-bhyve

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,7 @@ passthrough:
 
 adopt-info: multipass
 confinement: classic
+base: core
 
 apps:
   multipassd:
@@ -157,7 +158,7 @@ parts:
     - on arm64: http://ports.ubuntu.com/ubuntu-ports/pool/main/i/icu/libicu60_60.2-3ubuntu3_arm64.deb
     source-type: deb
 
-  libssl1.1:
+  libssl11:
     plugin: dump
     source:
     - on amd64: http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4.3_amd64.deb
@@ -260,6 +261,7 @@ parts:
     - try: [msr-tools]
 
   libvirt:
+    source: snap
     source-subdir: libvirt-1.3.1
     plugin: autotools
     build-packages:

--- a/tests/travis.patch
+++ b/tests/travis.patch
@@ -1,6 +1,14 @@
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
-@@ -220,6 +220,7 @@ parts:
+@@ -212,6 +212,7 @@ parts:
+     - on arm64: [libgles2-mesa-dev]
+     - on armhf: [libgles2-mesa-dev]
+     - build-essential
++    - ccache
+     - cmake-extras
+     - git
+     - golang
+@@ -228,6 +229,7 @@ parts:
      - -DCMAKE_INSTALL_PREFIX=/
      - -DMULTIPASS_ENABLE_TESTS=off
      override-build: |
@@ -8,9 +16,17 @@
        snapcraftctl build
        set -e
        mkdir -p ${SNAPCRAFT_PART_INSTALL}/etc/bash_completion.d/
-@@ -315,6 +316,9 @@ parts:
-       wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.25.debian.tar.xz
-       wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.25.dsc
+@@ -265,6 +267,7 @@ parts:
+     source-subdir: libvirt-1.3.1
+     plugin: autotools
+     build-packages:
++    - ccache
+     - libxml2-dev
+     - libxml-libxml-perl
+     - libcurl4-gnutls-dev
+@@ -327,6 +330,9 @@ parts:
+       wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.26.debian.tar.xz
+       wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.26.dsc
        dpkg-source -x libvirt*.dsc
 +    override-build: |
 +      update-ccache-symlinks


### PR DESCRIPTION
- move to `base:`-enabled `snapcraft.yaml`
- improve snap metadata
- use `snapcraft --use-lxd` on travis
- add missing package