### PR TITLE
[experiment] Add DaemonKiller interface

### DIFF
--- a/include/multipass/cli/command.h
+++ b/include/multipass/cli/command.h
@@ -20,6 +20,7 @@
 
 #include <multipass/callable_traits.h>
 #include <multipass/cli/return_codes.h>
+#include <multipass/daemon_killer.h>
 #include <multipass/format.h>
 #include <multipass/rpc/multipass.grpc.pb.h>
 #include <multipass/terminal.h>
@@ -40,13 +41,19 @@ class Command
 {
 public:
     using UPtr = std::unique_ptr<Command>;
-    Command(grpc::Channel& channel, Rpc::Stub& stub, std::ostream& cout, std::ostream& cerr)
-        : rpc_channel{&channel}, stub{&stub}, cout{cout}, cerr{cerr}
+    Command(grpc::Channel& channel, Rpc::Stub& stub, DaemonKiller* daemon_killer, std::ostream& cout,
+            std::ostream& cerr)
+        : rpc_channel{&channel}, stub{&stub}, daemon_killer{daemon_killer}, cout{cout}, cerr{cerr}
     {
     }
 
-    Command(grpc::Channel& channel, Rpc::Stub& stub, Terminal* term)
-        : rpc_channel{&channel}, stub{&stub}, term{term}, cout{term->cout()}, cerr{term->cerr()}
+    Command(grpc::Channel& channel, Rpc::Stub& stub, DaemonKiller* daemon_killer, Terminal* term)
+        : rpc_channel{&channel},
+          stub{&stub},
+          daemon_killer{daemon_killer},
+          term{term},
+          cout{term->cout()},
+          cerr{term->cerr()}
     {
     }
     virtual ~Command() = default;
@@ -136,6 +143,7 @@ protected:
 
     grpc::Channel* rpc_channel;
     Rpc::Stub* stub;
+    DaemonKiller* daemon_killer;
     Terminal* term;
     std::ostream& cout;
     std::ostream& cerr;

--- a/include/multipass/daemon_killer.h
+++ b/include/multipass/daemon_killer.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_DAEMON_KILLER_H
+#define MULTIPASS_DAEMON_KILLER_H
+
+#include <memory>
+
+namespace multipass
+{
+struct DaemonKiller
+{
+    virtual bool kill_daemon() const = 0;
+
+    using UPtr = std::unique_ptr<DaemonKiller>;
+    static UPtr make();
+};
+} // namespace multipass
+
+inline auto multipass::DaemonKiller::make() -> UPtr // FIXME move to platform
+{
+    class FIXMEDaemonKiller : public DaemonKiller
+    {
+        bool kill_daemon() const override
+        {
+            return false;
+        }
+    };
+
+    return std::make_unique<FIXMEDaemonKiller>();
+}
+
+#endif // MULTIPASS_DAEMON_KILLER_H

--- a/src/client/cli/client.cpp
+++ b/src/client/cli/client.cpp
@@ -53,6 +53,7 @@ mp::Client::Client(ClientConfig& config)
     : cert_provider{std::move(config.cert_provider)},
       rpc_channel{mp::client::make_channel(config.server_address, config.conn_type, *cert_provider)},
       stub{mp::Rpc::NewStub(rpc_channel)},
+      daemon_killer{std::move(config.daemon_killer)},
       term{config.term}
 {
     add_command<cmd::Launch>();

--- a/src/client/cli/client.h
+++ b/src/client/cli/client.h
@@ -35,6 +35,7 @@ struct ClientConfig
     const std::string server_address;
     const RpcConnectionType conn_type;
     std::unique_ptr<CertProvider> cert_provider;
+    DaemonKiller* daemon_killer;
     Terminal *term;
 };
 
@@ -57,6 +58,7 @@ private:
 
     std::vector<cmd::Command::UPtr> commands;
 
+    DaemonKiller* daemon_killer;
     Terminal* term;
 };
 } // namespace multipass
@@ -64,7 +66,7 @@ private:
 template <typename T>
 void multipass::Client::add_command()
 {
-    auto cmd = std::make_unique<T>(*rpc_channel, *stub, term);
+    auto cmd = std::make_unique<T>(*rpc_channel, *stub, daemon_killer, term);
     commands.push_back(std::move(cmd));
 }
 

--- a/src/client/cli/cmd/set.cpp
+++ b/src/client/cli/cmd/set.cpp
@@ -40,6 +40,9 @@ mp::ReturnCode cmd::Set::run(mp::ArgParser* parser)
             cerr << e.what() << "\n";
             ret = ReturnCode::CommandLineError;
         }
+
+        if (key.startsWith("local"))      // FIXME
+            daemon_killer->kill_daemon(); // FIXME check result
     }
 
     return ret;

--- a/src/client/cli/main.cpp
+++ b/src/client/cli/main.cpp
@@ -32,9 +32,10 @@ int main(int argc, char* argv[])
 
     mp::Console::setup_environment();
     auto term = mp::Terminal::make_terminal();
+    auto killer = mp::DaemonKiller::make();
 
     mp::ClientConfig config{mp::client::get_server_address(), mp::RpcConnectionType::ssl,
-                            mp::client::get_cert_provider(), term.get()};
+                            mp::client::get_cert_provider(), killer.get(), term.get()};
     mp::Client client{config};
 
     return client.run(QCoreApplication::arguments());

--- a/src/client/gui/client_gui.cpp
+++ b/src/client/gui/client_gui.cpp
@@ -29,7 +29,8 @@ mp::ClientGui::ClientGui(ClientConfig& config)
     : cert_provider{std::move(config.cert_provider)},
       rpc_channel{mp::client::make_channel(config.server_address, config.conn_type, *cert_provider)},
       stub{mp::Rpc::NewStub(rpc_channel)},
-      gui_cmd{std::make_unique<cmd::GuiCmd>(*rpc_channel, *stub, null_stream, null_stream)}
+      gui_cmd{std::make_unique<cmd::GuiCmd>(*rpc_channel, *stub, /*daemon_killer=*/nullptr /*FIXME*/, null_stream,
+                                            null_stream)}
 {
 }
 

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -249,7 +249,8 @@ struct Daemon : public Test
         mp::AutoJoinThread t([this, &commands, &cout, &cerr, &cin] {
             mpt::StubTerminal term(cout, cerr, cin);
             mp::ClientConfig client_config{server_address, mp::RpcConnectionType::insecure,
-                                           std::make_unique<mpt::StubCertProvider>(), &term};
+                                           std::make_unique<mpt::StubCertProvider>(),
+                                           /*daemon_killer=*/nullptr /*FIXME*/, &term};
             TestClient client{client_config};
             for (const auto& command : commands)
             {


### PR DESCRIPTION
With only fake and mock implementations ATM. Pass it along from where
the client is constructed to the `set` command where it will ultimately
be employed, cascading impacts.