### PR TITLE
Handle errors in reading/writting from/to persistent setttings

### DIFF
--- a/include/multipass/exceptions/settings_exceptions.h
+++ b/include/multipass/exceptions/settings_exceptions.h
@@ -15,29 +15,49 @@
  *
  */
 
-#ifndef MULTIPASS_INVALID_SETTINGS_EXCEPTION_H
-#define MULTIPASS_INVALID_SETTINGS_EXCEPTION_H
+#ifndef MULTIPASS_SETTINGS_EXCEPTIONS_H
+#define MULTIPASS_SETTINGS_EXCEPTIONS_H
 
 #include <multipass/format.h>
 
 #include <QString>
 
 #include <stdexcept>
+#include <string>
 
 namespace multipass
 {
-class InvalidSettingsException : public std::runtime_error
+class SettingsException : public std::runtime_error
 {
 public:
-    InvalidSettingsException(const QString& key) : runtime_error{fmt::format("Unrecognized settings key: '{}'", key)}
+    SettingsException(const std::string& msg) : runtime_error{msg}
+    {
+    }
+};
+
+class PersistentSettingsException : public SettingsException
+{
+public:
+    PersistentSettingsException(const QString& attempted_operation, const QString& failure)
+        : SettingsException{fmt::format("Could not {} settings: {} error", attempted_operation, failure)}
+    {
+    }
+};
+
+class InvalidSettingsException : public SettingsException
+{
+public:
+    InvalidSettingsException(const QString& key)
+        : SettingsException{fmt::format("Unrecognized settings key: '{}'", key)}
     {
     }
 
     InvalidSettingsException(const QString& key, const QString& val, const QString& why)
-        : runtime_error{fmt::format("Invalid setting '{}={}': {}", key, val, why)}
+        : SettingsException{fmt::format("Invalid setting '{}={}': {}", key, val, why)}
     {
     }
 };
+
 } // namespace multipass
 
-#endif // MULTIPASS_INVALID_SETTINGS_EXCEPTION_H
+#endif // MULTIPASS_SETTINGS_EXCEPTIONS_H

--- a/src/client/cli/cmd/common_cli.cpp
+++ b/src/client/cli/cmd/common_cli.cpp
@@ -20,6 +20,7 @@
 
 #include <multipass/cli/argparser.h>
 #include <multipass/cli/format_utils.h>
+#include <multipass/exceptions/settings_exceptions.h>
 
 #include <fmt/ostream.h>
 #include <sstream>
@@ -154,4 +155,9 @@ mp::ReturnCode cmd::run_cmd_and_retry(const QStringList& args, const mp::ArgPars
                                       std::ostream& cerr)
 {
     return ok2retry(run_cmd(args, parser, cout, cerr));
+}
+
+auto cmd::return_code_from(const SettingsException& e) -> ReturnCode
+{
+    return dynamic_cast<const InvalidSettingsException*>(&e) ? ReturnCode::CommandLineError : ReturnCode::CommandFail;
 }

--- a/src/client/cli/cmd/common_cli.h
+++ b/src/client/cli/cmd/common_cli.h
@@ -31,6 +31,7 @@ namespace multipass
 {
 class ArgParser;
 class Formatter;
+class SettingsException;
 
 namespace cmd
 {
@@ -44,6 +45,7 @@ ParseCode handle_format_option(const ArgParser* parser, Formatter** chosen_forma
 std::string instance_action_message_for(const InstanceNames& instance_names, const std::string& action_name);
 ReturnCode run_cmd(const QStringList& args, const ArgParser* parser, std::ostream& cout, std::ostream& cerr);
 ReturnCode run_cmd_and_retry(const QStringList& args, const ArgParser* parser, std::ostream& cout, std::ostream& cerr);
+ReturnCode return_code_from(const SettingsException& e);
 
 // helpers for update handling
 bool update_available(const multipass::UpdateInfo& update_info);

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "get.h"
+#include "common_cli.h"
 
 #include <multipass/cli/argparser.h>
 #include <multipass/constants.h>
@@ -40,8 +41,7 @@ mp::ReturnCode cmd::Get::run(mp::ArgParser* parser)
         catch (const SettingsException& e)
         {
             cerr << e.what() << "\n";
-            ret = dynamic_cast<const InvalidSettingsException*>(&e) ? ReturnCode::CommandLineError
-                                                                    : ReturnCode::CommandFail;
+            ret = return_code_from(e);
         }
     }
 

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -19,7 +19,7 @@
 
 #include <multipass/cli/argparser.h>
 #include <multipass/constants.h>
-#include <multipass/exceptions/invalid_settings_exception.h>
+#include <multipass/exceptions/settings_exceptions.h>
 #include <multipass/settings.h>
 
 #include <QtGlobal>
@@ -37,10 +37,11 @@ mp::ReturnCode cmd::Get::run(mp::ArgParser* parser)
         {
             cout << qPrintable(Settings::instance().get(key)) << "\n";
         }
-        catch (const InvalidSettingsException& e)
+        catch (const SettingsException& e)
         {
             cerr << e.what() << "\n";
-            ret = ReturnCode::CommandLineError;
+            ret = dynamic_cast<const InvalidSettingsException*>(&e) ? ReturnCode::CommandLineError
+                                                                    : ReturnCode::CommandFail;
         }
     }
 

--- a/src/client/cli/cmd/set.cpp
+++ b/src/client/cli/cmd/set.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "set.h"
+#include "common_cli.h"
 
 #include <multipass/cli/argparser.h>
 #include <multipass/constants.h>
@@ -38,8 +39,7 @@ mp::ReturnCode cmd::Set::run(mp::ArgParser* parser)
         catch (const SettingsException& e)
         {
             cerr << e.what() << "\n";
-            ret = dynamic_cast<const InvalidSettingsException*>(&e) ? ReturnCode::CommandLineError
-                                                                    : ReturnCode::CommandFail;
+            ret = return_code_from(e);
         }
     }
 

--- a/src/client/cli/cmd/set.cpp
+++ b/src/client/cli/cmd/set.cpp
@@ -19,7 +19,7 @@
 
 #include <multipass/cli/argparser.h>
 #include <multipass/constants.h>
-#include <multipass/exceptions/invalid_settings_exception.h>
+#include <multipass/exceptions/settings_exceptions.h>
 #include <multipass/settings.h>
 
 namespace mp = multipass;
@@ -35,10 +35,11 @@ mp::ReturnCode cmd::Set::run(mp::ArgParser* parser)
         {
             Settings::instance().set(key, val);
         }
-        catch (const InvalidSettingsException& e)
+        catch (const SettingsException& e)
         {
             cerr << e.what() << "\n";
-            ret = ReturnCode::CommandLineError;
+            ret = dynamic_cast<const InvalidSettingsException*>(&e) ? ReturnCode::CommandLineError
+                                                                    : ReturnCode::CommandFail;
         }
     }
 

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -25,6 +25,7 @@
 #include <QStandardPaths>
 
 #include <memory>
+#include <stdexcept>
 
 namespace mp = multipass;
 
@@ -48,6 +49,31 @@ std::unique_ptr<QSettings> persistent_settings()
     return std::make_unique<QSettings>(file_path, format); /* unique_ptr to circumvent absent copy-ctor and no RVO
                                                               guarantee (until C++17) */
 }
+
+void check_status(const QSettings& settings, const QString& attempted_operation)
+{
+    auto status = settings.status();
+    if (status)
+        throw std::runtime_error{fmt::format("Could not {} settings: {} error", attempted_operation,
+                                             status == QSettings::AccessError ? "access" : "format")};
+}
+
+QString checked_get(QSettings& settings, const QString& key, const QString& fallback)
+{
+    auto ret = settings.value(key, fallback).toString();
+
+    check_status(settings, "read");
+    return ret;
+}
+
+void checked_set(QSettings& settings, const QString& key, const QString& val)
+{
+    settings.setValue(key, val);
+
+    settings.sync(); // flush to confirm we can write
+    check_status(settings, "write");
+}
+
 } // namespace
 
 mp::Settings::Settings(const Singleton<Settings>::PrivatePass& pass)
@@ -59,7 +85,7 @@ mp::Settings::Settings(const Singleton<Settings>::PrivatePass& pass)
 QString mp::Settings::get(const QString& key) const
 {
     const auto& default_ret = get_default(key); // make sure the key is valid before reading from disk
-    return persistent_settings()->value(key, default_ret).toString();
+    return checked_get(*persistent_settings(), key, default_ret);
 }
 
 void mp::Settings::set(const QString& key, const QString& val)
@@ -67,7 +93,7 @@ void mp::Settings::set(const QString& key, const QString& val)
     get_default(key); // make sure the key is valid before setting
     if (key == petenv_key && !mp::utils::valid_hostname(val.toStdString()))
         throw InvalidSettingsException{key, val, "Invalid hostname"}; // TODO move checking logic out
-    persistent_settings()->setValue(key, val);
+    checked_set(*persistent_settings(), key, val);
 }
 
 const QString& mp::Settings::get_default(const QString& key) const

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -16,7 +16,7 @@
  */
 
 #include <multipass/constants.h>
-#include <multipass/exceptions/invalid_settings_exception.h> // TODO move out
+#include <multipass/exceptions/settings_exceptions.h>
 #include <multipass/settings.h>
 #include <multipass/utils.h> // TODO move out
 
@@ -54,15 +54,16 @@ void check_status(const QSettings& settings, const QString& attempted_operation)
 {
     auto status = settings.status();
     if (status)
-        throw std::runtime_error{fmt::format("Could not {} settings: {} error", attempted_operation,
-                                             status == QSettings::AccessError ? "access" : "format")};
+        throw mp::PersistentSettingsException{attempted_operation, status == QSettings::AccessError
+                                                                       ? QStringLiteral("access")
+                                                                       : QStringLiteral("format")};
 }
 
 QString checked_get(QSettings& settings, const QString& key, const QString& fallback)
 {
     auto ret = settings.value(key, fallback).toString();
 
-    check_status(settings, "read");
+    check_status(settings, QStringLiteral("read"));
     return ret;
 }
 
@@ -71,7 +72,7 @@ void checked_set(QSettings& settings, const QString& key, const QString& val)
     settings.setValue(key, val);
 
     settings.sync(); // flush to confirm we can write
-    check_status(settings, "write");
+    check_status(settings, QStringLiteral("write"));
 }
 
 } // namespace

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -1296,6 +1296,21 @@ TEST_F(Client, set_cmd_fails_with_unknown_key)
     EXPECT_THAT(send_command({"set", key, val}), Eq(mp::ReturnCode::CommandLineError));
 }
 
+TEST_F(Client, get_handles_persistent_settings_errors)
+{
+    const auto key = mp::petenv_key;
+    EXPECT_CALL(mock_settings, get(Eq(key))).WillOnce(Throw(mp::PersistentSettingsException{"op", "test"}));
+    EXPECT_THAT(send_command({"get", key}), Eq(mp::ReturnCode::CommandFail));
+}
+
+TEST_F(Client, set_handles_persistent_settings_errors)
+{
+    const auto key = mp::petenv_key;
+    const auto val = "asdasdasd";
+    EXPECT_CALL(mock_settings, set(Eq(key), Eq(val))).WillOnce(Throw(mp::PersistentSettingsException{"op", "test"}));
+    EXPECT_THAT(send_command({"set", key, val}), Eq(mp::ReturnCode::CommandFail));
+}
+
 TEST_F(Client, get_and_set_can_read_and_write_primary_name)
 {
     const auto name = "xyz";

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -23,7 +23,7 @@
 #include "stub_terminal.h"
 
 #include <multipass/constants.h>
-#include <multipass/exceptions/invalid_settings_exception.h>
+#include <multipass/exceptions/settings_exceptions.h>
 #include <multipass/logging/log.h>
 #include <src/client/cli/client.h>
 #include <src/daemon/daemon_rpc.h>


### PR DESCRIPTION
This improves upon the code that was merged in #805 for #766 . I missed error handling and noticed when working on #776 .