### PR TITLE
Create VMInstance class

### DIFF
--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -25,7 +25,8 @@ add_library(daemon STATIC
   daemon_rpc.cpp
   default_vm_image_vault.cpp
   json_writer.cpp
-  ubuntu_image_host.cpp)
+  ubuntu_image_host.cpp
+  vm_instance.cpp)
 
 add_library(delayed_shutdown STATIC
   delayed_shutdown_timer.cpp

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -20,6 +20,7 @@
 
 #include "daemon_config.h"
 #include "daemon_rpc.h"
+#include "vm_instance.h"
 
 #include <multipass/delayed_shutdown_timer.h>
 #include <multipass/memory_size.h>
@@ -135,7 +136,7 @@ public slots:
 
 private:
     void persist_instances();
-    void start_mount(VirtualMachine *vm, const std::string& name, const std::string& source_path,
+    void start_mount(VirtualMachine* vm, const std::string& name, const std::string& source_path,
                      const std::string& target_path, const std::unordered_map<int, int>& gid_map,
                      const std::unordered_map<int, int>& uid_map);
     void stop_mounts_for_instance(const std::string& instance);
@@ -148,7 +149,7 @@ private:
     grpc::Status shutdown_vm(VirtualMachine& vm, const std::chrono::milliseconds delay);
     grpc::Status cancel_vm_shutdown(const VirtualMachine& vm);
     grpc::Status cmd_vms(const std::vector<std::string>& tgts, std::function<grpc::Status(VirtualMachine&)> cmd);
-    void install_sshfs(VirtualMachine *vm, const std::string& name);
+    void install_sshfs(VirtualMachine* vm, const std::string& name);
 
     struct AsyncOperationStatus
     {
@@ -167,8 +168,8 @@ private:
 
     std::unique_ptr<const DaemonConfig> config;
     std::unordered_map<std::string, VMSpecs> vm_instance_specs;
-    std::unordered_map<std::string, VirtualMachine::ShPtr> vm_instances;
-    std::unordered_map<std::string, VirtualMachine::ShPtr> deleted_instances;
+    std::unordered_map<std::string, VMInstance::UPtr> vm_instances;
+    std::unordered_map<std::string, VMInstance::UPtr> deleted_instances;
     std::unordered_map<std::string, std::unordered_map<std::string, std::unique_ptr<SshfsMount>>> mount_threads;
     std::unordered_map<std::string, std::unique_ptr<DelayedShutdownTimer>> delayed_shutdown_instances;
     std::unordered_set<std::string> allocated_mac_addrs;

--- a/src/daemon/vm_instance.cpp
+++ b/src/daemon/vm_instance.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "vm_instance.h"
+
+#include <multipass/format.h>
+#include <multipass/logging/log.h>
+#include <multipass/ssh/ssh_session.h>
+#include <multipass/utils.h>
+
+namespace mp = multipass;
+namespace mpl = multipass::logging;
+
+namespace
+{
+constexpr auto category = "daemon";
+} // namespace
+
+mp::VMInstance::VMInstance(const VirtualMachine::ShPtr vm, const SSHKeyProvider& key_provider)
+    : vm_shptr(vm), key_provider(key_provider)
+{
+}
+
+const multipass::VirtualMachine::ShPtr mp::VMInstance::vm() const
+{
+    return vm_shptr;
+}
+
+std::string mp::VMInstance::run_command(const std::string& cmd)
+{
+    mp::SSHSession session(vm_shptr->ssh_hostname(), vm_shptr->ssh_port(), vm_shptr->ssh_username(), key_provider);
+
+    auto proc = session.exec(cmd);
+    if (proc.exit_code() != 0)
+    {
+        auto error_msg = proc.read_std_error();
+        mpl::log(mpl::Level::warning, category,
+                 fmt::format("failed to run '{}', error message: '{}'", cmd, mp::utils::trim_end(error_msg)));
+        return std::string{};
+    }
+
+    auto output = proc.read_std_output();
+    if (output.empty())
+    {
+        mpl::log(mpl::Level::warning, category, fmt::format("no output after running '{}'", cmd));
+        return std::string{};
+    }
+
+    return mp::utils::trim_end(output);
+}

--- a/src/daemon/vm_instance.h
+++ b/src/daemon/vm_instance.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_VM_INSTANCE_H
+#define MULTIPASS_VM_INSTANCE_H
+
+#include <multipass/virtual_machine.h>
+#include <multipass/ssh/ssh_key_provider.h>
+
+namespace multipass
+{
+
+class VMInstance
+{
+public:
+    using UPtr = std::unique_ptr<VMInstance>;
+
+    VMInstance(const VirtualMachine::ShPtr vm, const SSHKeyProvider &key_provider);
+
+    const VirtualMachine::ShPtr vm() const;
+
+    std::string run_command(const std::string& cmd);
+
+private:
+    VMInstance(const VMInstance&) = delete;
+    VMInstance& operator=(const VMInstance&) = delete;
+    VMInstance(VirtualMachine::ShPtr vm, const SSHKeyProvider &&) = delete; // avoid accidentally accepting temporary
+
+    const VirtualMachine::ShPtr vm_shptr;
+    const SSHKeyProvider &key_provider;
+};
+
+} // namespace multipass
+#endif // MULTIPASS_VM_INSTANCE_H


### PR DESCRIPTION
I want to share my thinking into a refactor.

We currently keep a lot of state and operations code related to VMs in the Daemon. For instance state, i.e. preparing a VM, VM being deleted, VM shutdown delay, we track that state by moving the instance name between different sets/maps. Operations code are mostly platform-independent VM-control methods (start/shutdown/reboot/install_sshfs/mounts).

I'm in a situation where I want to add another per-VM operation (a maintenance operation which will fire on a timer while VM running). It is a platform independent op, so doesn't belong in the VirtualMachine implementations themselves. Right now, platform independent VM ops are private methods in Daemon itself. So adding this new op means I'll have to add another list to Daemon, and carefully add/remove from the list in sync with the VM state - clunky.

My thinking is to introduce a "VMInstance" class, which will hold per-VM state and platform independent operations (i.e. start/shutdown/reboot/install_sshfs/mounts). 

I hope to replace the state sets/maps in Daemon with VMInstance::state() which for example would return Prepared/Exists/Deleted/ - I've to decide out of the actual VM state should be included too.

And I also want to move the ops like start/shutdown/reboot/install_sshfs/mounts our of Daemon and create as members of this.

This PR is the first step on this journey, and make it easier to add my per-VM operation.

What do you folks think? Right direction or no?