### PR TITLE
utils: Re-add wait_for_cloud_init()

### DIFF
--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -34,6 +34,7 @@
 
 namespace multipass
 {
+class SSHKeyProvider;
 class VirtualMachine;
 
 namespace utils
@@ -71,9 +72,10 @@ std::vector<std::string> split(const std::string& string, const std::string& del
 std::string generate_mac_address();
 std::string timestamp();
 bool is_running(const VirtualMachine::State& state);
-// TODO: Rename process_vm_events to something more meaningful
 void wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
-                       std::function<void()> const& process_vm_events = []() { });
+                       std::function<void()> const& ensure_vm_is_running = []() {});
+void wait_for_cloud_init(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
+                         const SSHKeyProvider& key_provider);
 
 template <typename OnTimeoutCallable, typename TryAction, typename... Args>
 void try_action_for(OnTimeoutCallable&& on_timeout, std::chrono::milliseconds timeout, TryAction&& try_action,

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -59,7 +59,7 @@ public:
     virtual std::string ipv4() = 0;
     virtual std::string ipv6() = 0;
     virtual void wait_until_ssh_up(std::chrono::milliseconds timeout) = 0;
-    virtual void ensure_vm_is_running(){};
+    virtual void ensure_vm_is_running() = 0;
     virtual void update_state() = 0;
 
     VirtualMachine::State state;

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -59,6 +59,7 @@ public:
     virtual std::string ipv4() = 0;
     virtual std::string ipv6() = 0;
     virtual void wait_until_ssh_up(std::chrono::milliseconds timeout) = 0;
+    virtual void ensure_vm_is_running(){};
     virtual void update_state() = 0;
 
     VirtualMachine::State state;

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -315,6 +315,11 @@ mp::ReturnCode cmd::Launch::request_launch()
             spinner.stop();
             spinner.start(reply.create_message());
         }
+        else if (!reply.reply_message().empty())
+        {
+            spinner.stop();
+            spinner.start(reply.reply_message());
+        }
     };
 
     return dispatch(&RpcMethod::launch, request, on_success, on_failure, streaming_callback);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -74,6 +74,7 @@ constexpr auto uuid_file_name = "multipass-unique-id";
 constexpr auto metrics_opt_in_file = "multipassd-send-metrics.yaml";
 constexpr auto reboot_cmd = "sudo reboot";
 constexpr auto up_timeout = 2min; // This may be tweaked as appropriate and used in places that wait for ssh to be up
+constexpr auto cloud_init_timeout = 5min;
 constexpr auto stop_ssh_cmd = "sudo systemctl stop ssh";
 constexpr auto max_install_sshfs_retries = 3;
 constexpr auto default_mem = "1G";
@@ -1911,11 +1912,12 @@ void mp::Daemon::create_vm(const CreateRequest* request, grpc::ServerWriter<Crea
                     auto& vm = vm_instances[name];
                     vm->start();
 
-                    reply.set_vm_instance_name(name);
-                    config->update_prompt->populate_if_time_to_show(reply.mutable_update_info());
-                    server->Write(reply);
-
-                    auto future_watcher = create_future_watcher();
+                    auto future_watcher = create_future_watcher([this, server, name] {
+                        LaunchReply reply;
+                        reply.set_vm_instance_name(name);
+                        config->update_prompt->populate_if_time_to_show(reply.mutable_update_info());
+                        server->Write(reply);
+                    });
                     future_watcher->setFuture(QtConcurrent::run(this, &Daemon::async_wait_for_ready_all<LaunchReply>,
                                                                 server, std::vector<std::string>{name},
                                                                 status_promise));
@@ -2112,13 +2114,17 @@ void mp::Daemon::install_sshfs(VirtualMachine* vm, const std::string& name)
         throw mp::SSHFSMissingError();
 }
 
-QFutureWatcher<mp::Daemon::AsyncOperationStatus>* mp::Daemon::create_future_watcher()
+QFutureWatcher<mp::Daemon::AsyncOperationStatus>*
+mp::Daemon::create_future_watcher(std::function<void()> const& finished_operation)
 {
     async_future_watchers.emplace_back(std::make_unique<QFutureWatcher<AsyncOperationStatus>>());
 
     auto future_watcher = async_future_watchers.back().get();
     QObject::connect(future_watcher, &QFutureWatcher<AsyncOperationStatus>::finished,
-                     [this, future_watcher]() { finish_async_operation(future_watcher->future()); });
+                     [this, future_watcher, finished_operation] {
+                         finished_operation();
+                         finish_async_operation(future_watcher->future());
+                     });
 
     return future_watcher;
 }
@@ -2133,6 +2139,15 @@ error_string mp::Daemon::async_wait_for_ssh_and_start_mounts_for(const std::stri
         auto it = vm_instances.find(name);
         auto vm = it->second;
         vm->wait_until_ssh_up(up_timeout);
+
+        if (server)
+        {
+            Reply reply;
+            reply.set_reply_message("Waiting for initialization to complete");
+            server->Write(reply);
+        }
+
+        mp::utils::wait_for_cloud_init(vm.get(), cloud_init_timeout, *config->ssh_key_provider);
 
         std::vector<std::string> invalid_mounts;
         auto& mounts = vm_instance_specs[name].mounts;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -163,8 +163,7 @@ private:
                                                   const std::vector<std::string>& vms,
                                                   std::promise<grpc::Status>* status_promise);
     void finish_async_operation(QFuture<AsyncOperationStatus> async_future);
-    QFutureWatcher<AsyncOperationStatus>* create_future_watcher(std::function<void()> const& finished_operation = []() {
-    });
+    QFutureWatcher<AsyncOperationStatus>* create_future_watcher(std::function<void()> const& finished_op = []() {});
 
     std::unique_ptr<const DaemonConfig> config;
     std::unordered_map<std::string, VMSpecs> vm_instance_specs;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -163,7 +163,8 @@ private:
                                                   const std::vector<std::string>& vms,
                                                   std::promise<grpc::Status>* status_promise);
     void finish_async_operation(QFuture<AsyncOperationStatus> async_future);
-    QFutureWatcher<AsyncOperationStatus>* create_future_watcher();
+    QFutureWatcher<AsyncOperationStatus>* create_future_watcher(std::function<void()> const& finished_operation = []() {
+    });
 
     std::unique_ptr<const DaemonConfig> config;
     std::unordered_map<std::string, VMSpecs> vm_instance_specs;

--- a/src/platform/backends/libvirt/libvirt_virtual_machine.h
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine.h
@@ -50,10 +50,10 @@ public:
     std::string ipv4() override;
     std::string ipv6() override;
     void wait_until_ssh_up(std::chrono::milliseconds timeout) override;
+    void ensure_vm_is_running() override;
     void update_state() override;
 
 private:
-    void ensure_vm_is_running();
 
     virConnectPtr connection;
     DomainUPtr domain;

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -50,6 +50,7 @@ public:
     std::string ssh_username() override;
     std::string ipv4() override;
     std::string ipv6() override;
+    void ensure_vm_is_running() override;
     void wait_until_ssh_up(std::chrono::milliseconds timeout) override;
     void update_state() override;
 
@@ -59,7 +60,6 @@ private:
     void on_shutdown();
     void on_suspend();
     void on_restart();
-    void ensure_vm_is_running();
     multipass::optional<IPAddress> ip;
     const std::string tap_device_name;
     const std::string mac_addr;

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -137,10 +137,10 @@ std::string mp::utils::generate_mac_address()
 }
 
 void mp::utils::wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
-                                  std::function<void()> const& process_vm_events)
+                                  std::function<void()> const& ensure_vm_is_running)
 {
-    auto action = [virtual_machine, &process_vm_events] {
-        process_vm_events();
+    auto action = [virtual_machine, &ensure_vm_is_running] {
+        ensure_vm_is_running();
         try
         {
             mp::SSHSession session{virtual_machine->ssh_hostname(), virtual_machine->ssh_port()};
@@ -162,6 +162,29 @@ void mp::utils::wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::
         throw std::runtime_error(fmt::format("{}: timed out waiting for response", virtual_machine->vm_name));
     };
 
+    mp::utils::try_action_for(on_timeout, timeout, action);
+}
+
+void mp::utils::wait_for_cloud_init(mp::VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
+                                    const mp::SSHKeyProvider& key_provider)
+{
+    auto action = [virtual_machine, &key_provider] {
+        virtual_machine->ensure_vm_is_running();
+        try
+        {
+            std::lock_guard<decltype(virtual_machine->state_mutex)> lock{virtual_machine->state_mutex};
+            mp::SSHSession session{virtual_machine->ssh_hostname(), virtual_machine->ssh_port(),
+                                   virtual_machine->ssh_username(), key_provider};
+            auto ssh_process = session.exec({"[ -e /var/lib/cloud/instance/boot-finished ]"});
+            return ssh_process.exit_code() == 0 ? mp::utils::TimeoutAction::done : mp::utils::TimeoutAction::retry;
+        }
+        catch (const std::exception& e)
+        {
+            mpl::log(mpl::Level::warning, virtual_machine->vm_name, e.what());
+            return mp::utils::TimeoutAction::retry;
+        }
+    };
+    auto on_timeout = [] { throw std::runtime_error("timed out waiting for initialization to complete"); };
     mp::utils::try_action_for(on_timeout, timeout, action);
 }
 

--- a/tests/stub_virtual_machine.h
+++ b/tests/stub_virtual_machine.h
@@ -76,6 +76,11 @@ struct StubVirtualMachine final : public multipass::VirtualMachine
         return {};
     }
 
+    void ensure_vm_is_running() override
+    {
+        throw std::runtime_error("Not running");
+    }
+
     void wait_until_ssh_up(std::chrono::milliseconds) override
     {
     }


### PR DESCRIPTION
This allows launch to wait for a long running custom cloud-init.

Fixes #696