### PR TITLE
[readme] fix exec command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ multipass launch --name foo
 
 ## Run commands in an instance
 ```
-multipass exec foo lsb_release -a
+multipass exec foo lsb_release -- -a
 ```
 
 ## Pass a cloud-init file to an instance


### PR DESCRIPTION
According to [docs](https://discourse.ubuntu.com/t/multipass-exec-command/10851) and reality.

> The -- separator is required if you want to pass options to the command being run.


```
munit-258:~ develar$ multipass exec build-service lsb_release -a
Unknown option 'a'.
munit-258:~ develar$ multipass exec build-service lsb_release -- -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 18.04.2 LTS
Release:	18.04
Codename:	bionic
munit-258:~ develar$ 
```