### PR TITLE
rpc: Unify virtual machine state values via the rpc enum

### DIFF
--- a/include/multipass/cli/format_utils.h
+++ b/include/multipass/cli/format_utils.h
@@ -33,7 +33,7 @@ class Formatter;
 
 namespace format
 {
-std::string status_string_for(const InstanceStatus& status);
+std::string state_string_for(const InstanceState& state);
 std::string image_string_for(const multipass::FindReply_AliasInfo& alias);
 Formatter* formatter_for(const std::string& format);
 

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -71,7 +71,7 @@ std::string escape_char(const std::string& s, char c);
 std::vector<std::string> split(const std::string& string, const std::string& delimiter);
 std::string generate_mac_address();
 std::string timestamp();
-bool is_running(const VirtualMachine::State& state);
+bool is_running(const InstanceState& state);
 void wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
                        std::function<void()> const& ensure_vm_is_running = []() {});
 void wait_for_cloud_init(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -18,6 +18,8 @@
 #ifndef MULTIPASS_VIRTUAL_MACHINE_H
 #define MULTIPASS_VIRTUAL_MACHINE_H
 
+#include <multipass/rpc/multipass.grpc.pb.h>
+
 #include <chrono>
 #include <condition_variable>
 #include <memory>
@@ -26,24 +28,9 @@
 
 namespace multipass
 {
-class SSHKeyProvider;
-
 class VirtualMachine
 {
 public:
-    enum class State
-    {
-        off,
-        stopped,
-        starting,
-        restarting,
-        running,
-        delayed_shutdown,
-        suspending,
-        suspended,
-        unknown
-    };
-
     using UPtr = std::unique_ptr<VirtualMachine>;
     using ShPtr = std::shared_ptr<VirtualMachine>;
 
@@ -52,7 +39,7 @@ public:
     virtual void start() = 0;
     virtual void shutdown() = 0;
     virtual void suspend() = 0;
-    virtual State current_state() = 0;
+    virtual InstanceState current_state() = 0;
     virtual int ssh_port() = 0;
     virtual std::string ssh_hostname() = 0;
     virtual std::string ssh_username() = 0;
@@ -62,14 +49,14 @@ public:
     virtual void ensure_vm_is_running() = 0;
     virtual void update_state() = 0;
 
-    VirtualMachine::State state;
+    InstanceState state;
     const std::string vm_name;
     std::condition_variable state_wait;
     std::mutex state_mutex;
 
 protected:
-    VirtualMachine(VirtualMachine::State state, const std::string& vm_name) : state{state}, vm_name{vm_name} {};
-    VirtualMachine(const std::string& vm_name) : VirtualMachine(State::off, vm_name){};
+    VirtualMachine(InstanceState state, const std::string& vm_name) : state{state}, vm_name{vm_name} {};
+    VirtualMachine(const std::string& vm_name) : VirtualMachine(InstanceState::OFF, vm_name){};
     VirtualMachine(const VirtualMachine&) = delete;
     VirtualMachine& operator=(const VirtualMachine&) = delete;
 };

--- a/include/multipass/vm_status_monitor.h
+++ b/include/multipass/vm_status_monitor.h
@@ -35,7 +35,7 @@ public:
     virtual void on_shutdown() = 0;
     virtual void on_suspend() = 0;
     virtual void on_restart(const std::string& name) = 0;
-    virtual void persist_state_for(const std::string& name, const VirtualMachine::State& state) = 0;
+    virtual void persist_state_for(const std::string& name, const InstanceState& state) = 0;
     virtual void update_metadata_for(const std::string& name, const QJsonObject& metadata) = 0;
     virtual QJsonObject retrieve_metadata_for(const std::string& name) = 0;
 

--- a/src/client/cli/formatter/csv_formatter.cpp
+++ b/src/client/cli/formatter/csv_formatter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,7 +33,7 @@ std::string mp::CSVFormatter::format(const InfoReply& reply) const
     for (const auto& info : format::sorted(reply.info()))
     {
         fmt::format_to(buf, "{},{},{},{},{},{},{},{},{},{},{},{},", info.name(),
-                       mp::format::status_string_for(info.instance_status()), info.ipv4(), info.ipv6(),
+                       mp::format::state_string_for(info.instance_status().state()), info.ipv4(), info.ipv6(),
                        info.current_release(), info.id(), info.image_release(), info.load(), info.disk_usage(),
                        info.disk_total(), info.memory_usage(), info.memory_total());
 
@@ -57,8 +57,8 @@ std::string mp::CSVFormatter::format(const ListReply& reply) const
     for (const auto& instance : format::sorted(reply.instances()))
     {
         fmt::format_to(buf, "{},{},{},{},{}\n", instance.name(),
-                       mp::format::status_string_for(instance.instance_status()), instance.ipv4(), instance.ipv6(),
-                       instance.current_release());
+                       mp::format::state_string_for(instance.instance_status().state()), instance.ipv4(),
+                       instance.ipv6(), instance.current_release());
     }
 
     return fmt::to_string(buf);

--- a/src/client/cli/formatter/format_utils.cpp
+++ b/src/client/cli/formatter/format_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -48,34 +48,34 @@ const std::set<std::string> unwanted_aliases{"ubuntu", "default"};
 
 } // namespace
 
-std::string mp::format::status_string_for(const mp::InstanceStatus& status)
+std::string mp::format::state_string_for(const mp::InstanceState& state)
 {
     std::string status_val;
 
-    switch (status.status())
+    switch (state)
     {
-    case mp::InstanceStatus::RUNNING:
+    case mp::InstanceState::RUNNING:
         status_val = "Running";
         break;
-    case mp::InstanceStatus::STOPPED:
+    case mp::InstanceState::STOPPED:
         status_val = "Stopped";
         break;
-    case mp::InstanceStatus::DELETED:
+    case mp::InstanceState::DELETED:
         status_val = "Deleted";
         break;
-    case mp::InstanceStatus::STARTING:
+    case mp::InstanceState::STARTING:
         status_val = "Starting";
         break;
-    case mp::InstanceStatus::RESTARTING:
+    case mp::InstanceState::RESTARTING:
         status_val = "Restarting";
         break;
-    case mp::InstanceStatus::DELAYED_SHUTDOWN:
+    case mp::InstanceState::DELAYED_SHUTDOWN:
         status_val = "Delayed Shutdown";
         break;
-    case mp::InstanceStatus::SUSPENDING:
+    case mp::InstanceState::SUSPENDING:
         status_val = "Suspending";
         break;
-    case mp::InstanceStatus::SUSPENDED:
+    case mp::InstanceState::SUSPENDED:
         status_val = "Suspended";
         break;
     default:

--- a/src/client/cli/formatter/json_formatter.cpp
+++ b/src/client/cli/formatter/json_formatter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -36,7 +36,8 @@ std::string mp::JsonFormatter::format(const InfoReply& reply) const
     for (const auto& info : reply.info())
     {
         QJsonObject instance_info;
-        instance_info.insert("state", QString::fromStdString(mp::format::status_string_for(info.instance_status())));
+        instance_info.insert("state",
+                             QString::fromStdString(mp::format::state_string_for(info.instance_status().state())));
         instance_info.insert("image_hash", QString::fromStdString(info.id()));
         instance_info.insert("image_release", QString::fromStdString(info.image_release()));
         instance_info.insert("release", QString::fromStdString(info.current_release()));
@@ -119,7 +120,8 @@ std::string mp::JsonFormatter::format(const ListReply& reply) const
     {
         QJsonObject instance_obj;
         instance_obj.insert("name", QString::fromStdString(instance.name()));
-        instance_obj.insert("state", QString::fromStdString(mp::format::status_string_for(instance.instance_status())));
+        instance_obj.insert("state",
+                            QString::fromStdString(mp::format::state_string_for(instance.instance_status().state())));
 
         QJsonArray ipv4_addrs;
         if (!instance.ipv4().empty())

--- a/src/client/cli/formatter/table_formatter.cpp
+++ b/src/client/cli/formatter/table_formatter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -57,7 +57,7 @@ std::string mp::TableFormatter::format(const InfoReply& reply) const
     for (const auto& info : format::sorted(reply.info()))
     {
         fmt::format_to(buf, "{:<16}{}\n", "Name:", info.name());
-        fmt::format_to(buf, "{:<16}{}\n", "State:", mp::format::status_string_for(info.instance_status()));
+        fmt::format_to(buf, "{:<16}{}\n", "State:", mp::format::state_string_for(info.instance_status().state()));
         fmt::format_to(buf, "{:<16}{}\n", "IPv4:", info.ipv4().empty() ? "--" : info.ipv4());
 
         if (!info.ipv6().empty())
@@ -128,7 +128,7 @@ std::string mp::TableFormatter::format(const ListReply& reply) const
     for (const auto& instance : format::sorted(reply.instances()))
     {
         fmt::format_to(buf, "{:<24}{:<18}{:<17}{:<}\n", instance.name(),
-                       mp::format::status_string_for(instance.instance_status()),
+                       mp::format::state_string_for(instance.instance_status().state()),
                        instance.ipv4().empty() ? "--" : instance.ipv4(),
                        instance.current_release().empty() ? "Not Available"
                                                           : fmt::format("Ubuntu {}", instance.current_release()));

--- a/src/client/cli/formatter/yaml_formatter.cpp
+++ b/src/client/cli/formatter/yaml_formatter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -51,7 +51,7 @@ std::string mp::YamlFormatter::format(const InfoReply& reply) const
     {
         YAML::Node instance_node;
 
-        instance_node["state"] = mp::format::status_string_for(info.instance_status());
+        instance_node["state"] = mp::format::state_string_for(info.instance_status().state());
         instance_node["image_hash"] = info.id();
         instance_node["image_release"] = info.image_release();
         if (info.current_release().empty())
@@ -131,7 +131,7 @@ std::string mp::YamlFormatter::format(const ListReply& reply) const
     for (const auto& instance : format::sorted(reply.instances()))
     {
         YAML::Node instance_node;
-        instance_node["state"] = mp::format::status_string_for(instance.instance_status());
+        instance_node["state"] = mp::format::state_string_for(instance.instance_status().state());
 
         instance_node["ipv4"].push_back(instance.ipv4());
         instance_node["release"] = instance.current_release();

--- a/src/client/gui/gui_cmd.h
+++ b/src/client/gui/gui_cmd.h
@@ -72,7 +72,7 @@ private:
     void initiate_menu_layout();
     void initiate_about_menu_layout();
     ListReply retrieve_all_instances();
-    void set_menu_actions_for(const std::string& instance_name, const InstanceStatus& state);
+    void set_menu_actions_for(const std::string& instance_name, const InstanceState& state);
     void start_instance_for(const std::string& instance_name);
     void stop_instance_for(const std::string& instance_name);
     void suspend_instance_for(const std::string& instance_name);
@@ -93,7 +93,7 @@ private:
 
     struct InstanceEntry
     {
-        InstanceStatus state;
+        InstanceState state;
         std::unique_ptr<QMenu> menu;
     };
     std::unordered_map<std::string, InstanceEntry> instances_entries;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -53,7 +53,7 @@ struct VMSpecs
     MemorySize disk_space;
     std::string mac_addr;
     std::string ssh_username;
-    VirtualMachine::State state;
+    InstanceState state;
     std::unordered_map<std::string, VMMount> mounts;
     bool deleted;
     QJsonObject metadata;
@@ -80,7 +80,7 @@ protected:
     void on_shutdown() override;
     void on_suspend() override;
     void on_restart(const std::string& name) override;
-    void persist_state_for(const std::string& name, const VirtualMachine::State& state) override;
+    void persist_state_for(const std::string& name, const InstanceState& state) override;
     void update_metadata_for(const std::string& name, const QJsonObject& metadata) override;
     QJsonObject retrieve_metadata_for(const std::string& name) override;
 

--- a/src/daemon/delayed_shutdown_timer.cpp
+++ b/src/daemon/delayed_shutdown_timer.cpp
@@ -60,14 +60,13 @@ mp::DelayedShutdownTimer::~DelayedShutdownTimer()
             ssh_session->exec("wall The system shutdown has been cancelled").exit_code();
         }
         mpl::log(mpl::Level::info, virtual_machine->vm_name, fmt::format("Cancelling delayed shutdown"));
-        virtual_machine->state = VirtualMachine::State::running;
+        virtual_machine->state = InstanceState::RUNNING;
     }
 }
 
 void mp::DelayedShutdownTimer::start(const std::chrono::milliseconds delay)
 {
-    if (virtual_machine->state == VirtualMachine::State::stopped ||
-        virtual_machine->state == VirtualMachine::State::off)
+    if (virtual_machine->state == InstanceState::STOPPED || virtual_machine->state == InstanceState::OFF)
         return;
 
     if (delay > decltype(delay)(0))
@@ -102,7 +101,7 @@ void mp::DelayedShutdownTimer::start(const std::chrono::milliseconds delay)
             }
         });
 
-        virtual_machine->state = VirtualMachine::State::delayed_shutdown;
+        virtual_machine->state = InstanceState::DELAYED_SHUTDOWN;
 
         shutdown_timer.start(delay < std::chrono::minutes(1) ? delay : std::chrono::minutes(1));
     }

--- a/src/metrics/CMakeLists.txt
+++ b/src/metrics/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Copyright © 2018 Canonical Ltd.
-# 
+# Copyright © 2018-2019 Canonical Ltd.
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
 # published by the Free Software Foundation.
@@ -17,5 +17,6 @@ add_library(metrics STATIC
 
 target_link_libraries(metrics
   fmt
+  rpc
   Qt5::Core
   Qt5::Network)

--- a/src/platform/backends/libvirt/libvirt_virtual_machine.h
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine.h
@@ -43,7 +43,7 @@ public:
     void stop() override;
     void shutdown() override;
     void suspend() override;
-    State current_state() override;
+    InstanceState current_state() override;
     int ssh_port() override;
     std::string ssh_hostname() override;
     std::string ssh_username() override;

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -43,7 +43,7 @@ public:
     void stop() override;
     void shutdown() override;
     void suspend() override;
-    State current_state() override;
+    InstanceState current_state() override;
     int ssh_port() override;
     std::string ssh_hostname() override;
     std::string ssh_username() override;

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -170,19 +170,21 @@ message MountInfo {
     repeated MountPaths mount_paths = 2;
 }
 
+enum InstanceState {
+    UNKNOWN = 0;
+    OFF = 1;
+    STOPPED = 2;
+    STARTING = 3;
+    RESTARTING = 4;
+    RUNNING = 5;
+    DELETED = 6;
+    DELAYED_SHUTDOWN = 7;
+    SUSPENDING = 8;
+    SUSPENDED = 9;
+}
+
 message InstanceStatus {
-    enum Status {
-        RUNNING = 0;
-        STARTING = 1;
-        RESTARTING = 2;
-        STOPPED = 3;
-        DELETED = 4;
-        DELAYED_SHUTDOWN = 5;
-        SUSPENDING = 6;
-        SUSPENDED = 7;
-        UNKNOWN = 8;
-    }
-    Status status = 1;
+    InstanceState state = 1;
 }
 
 message InfoReply {

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -19,5 +19,6 @@ add_library(utils STATIC
 
 target_link_libraries(utils
   fmt
+  rpc
   ssh
   Qt5::Core)

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -146,7 +146,7 @@ void mp::utils::wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::
             mp::SSHSession session{virtual_machine->ssh_hostname(), virtual_machine->ssh_port()};
 
             std::lock_guard<decltype(virtual_machine->state_mutex)> lock{virtual_machine->state_mutex};
-            virtual_machine->state = VirtualMachine::State::running;
+            virtual_machine->state = InstanceState::RUNNING;
             virtual_machine->update_state();
             return mp::utils::TimeoutAction::done;
         }
@@ -157,7 +157,7 @@ void mp::utils::wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::
     };
     auto on_timeout = [virtual_machine] {
         std::lock_guard<decltype(virtual_machine->state_mutex)> lock{virtual_machine->state_mutex};
-        virtual_machine->state = VirtualMachine::State::unknown;
+        virtual_machine->state = InstanceState::UNKNOWN;
         virtual_machine->update_state();
         throw std::runtime_error(fmt::format("{}: timed out waiting for response", virtual_machine->vm_name));
     };
@@ -269,7 +269,7 @@ std::string mp::utils::timestamp()
     return time.toString(Qt::ISODateWithMs).toStdString();
 }
 
-bool mp::utils::is_running(const VirtualMachine::State& state)
+bool mp::utils::is_running(const mp::InstanceState& state)
 {
-    return state == VirtualMachine::State::running || state == VirtualMachine::State::delayed_shutdown;
+    return state == InstanceState::RUNNING || state == InstanceState::DELAYED_SHUTDOWN;
 }

--- a/tests/mock_status_monitor.h
+++ b/tests/mock_status_monitor.h
@@ -32,7 +32,7 @@ struct MockVMStatusMonitor : public VMStatusMonitor
     MOCK_METHOD0(on_shutdown, void());
     MOCK_METHOD0(on_suspend, void());
     MOCK_METHOD1(on_restart, void(const std::string&));
-    MOCK_METHOD2(persist_state_for, void(const std::string&, const VirtualMachine::State&));
+    MOCK_METHOD2(persist_state_for, void(const std::string&, const InstanceState&));
     MOCK_METHOD2(update_metadata_for, void(const std::string&, const QJsonObject&));
     MOCK_METHOD1(retrieve_metadata_for, QJsonObject(const std::string&));
 };

--- a/tests/stub_status_monitor.h
+++ b/tests/stub_status_monitor.h
@@ -31,7 +31,7 @@ struct StubVMStatusMonitor : public multipass::VMStatusMonitor
     void on_shutdown() override{};
     void on_suspend() override{};
     void on_restart(const std::string& name) override{};
-    void persist_state_for(const std::string& name, const VirtualMachine::State& state) override{};
+    void persist_state_for(const std::string& name, const InstanceState& state) override{};
     void update_metadata_for(const std::string& name, const QJsonObject& metadata) override{};
     QJsonObject retrieve_metadata_for(const std::string& name) override
     {

--- a/tests/stub_virtual_machine.h
+++ b/tests/stub_virtual_machine.h
@@ -46,9 +46,9 @@ struct StubVirtualMachine final : public multipass::VirtualMachine
     {
     }
 
-    multipass::VirtualMachine::State current_state() override
+    InstanceState current_state() override
     {
-        return multipass::VirtualMachine::State::off;
+        return InstanceState::OFF;
     }
 
     int ssh_port() override

--- a/tests/test_delayed_shutdown.cpp
+++ b/tests/test_delayed_shutdown.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -43,7 +43,7 @@ struct DelayedShutdown : public Test
         request_exec.returnValue(SSH_OK);
 
         vm = std::make_unique<mpt::StubVirtualMachine>();
-        vm->state = mp::VirtualMachine::State::running;
+        vm->state = mp::InstanceState::RUNNING;
     }
 
     decltype(MOCK(ssh_connect)) connect{MOCK(ssh_connect)};
@@ -102,11 +102,11 @@ TEST_F(DelayedShutdown, vm_state_delayed_shutdown_when_timer_running)
     };
     REPLACE(ssh_event_dopoll, event_dopoll);
 
-    EXPECT_TRUE(vm->state == mp::VirtualMachine::State::running);
+    EXPECT_TRUE(vm->state == mp::InstanceState::RUNNING);
     mp::DelayedShutdownTimer delayed_shutdown_timer{vm.get(), std::move(session)};
     delayed_shutdown_timer.start(std::chrono::milliseconds(1));
 
-    EXPECT_TRUE(vm->state == mp::VirtualMachine::State::delayed_shutdown);
+    EXPECT_TRUE(vm->state == mp::InstanceState::DELAYED_SHUTDOWN);
 }
 
 TEST_F(DelayedShutdown, vm_state_running_after_cancel)
@@ -128,8 +128,8 @@ TEST_F(DelayedShutdown, vm_state_running_after_cancel)
     {
         mp::DelayedShutdownTimer delayed_shutdown_timer{vm.get(), std::move(session)};
         delayed_shutdown_timer.start(std::chrono::milliseconds(1));
-        EXPECT_TRUE(vm->state == mp::VirtualMachine::State::delayed_shutdown);
+        EXPECT_TRUE(vm->state == mp::InstanceState::DELAYED_SHUTDOWN);
     }
 
-    EXPECT_TRUE(vm->state == mp::VirtualMachine::State::running);
+    EXPECT_TRUE(vm->state == mp::InstanceState::RUNNING);
 }

--- a/tests/test_format_utils.cpp
+++ b/tests/test_format_utils.cpp
@@ -26,8 +26,8 @@ using namespace testing;
 TEST(InstanceStatusString, running_status_returns_RUNNING)
 {
     mp::InstanceStatus status;
-    status.set_status(mp::InstanceStatus::RUNNING);
-    auto status_string = mp::format::status_string_for(status);
+    status.set_state(mp::InstanceState::RUNNING);
+    auto status_string = mp::format::state_string_for(status.state());
 
     EXPECT_THAT(status_string, Eq("Running"));
 }
@@ -35,8 +35,8 @@ TEST(InstanceStatusString, running_status_returns_RUNNING)
 TEST(InstanceStatusString, stopped_status_returns_STOPPED)
 {
     mp::InstanceStatus status;
-    status.set_status(mp::InstanceStatus::STOPPED);
-    auto status_string = mp::format::status_string_for(status);
+    status.set_state(mp::InstanceState::STOPPED);
+    auto status_string = mp::format::state_string_for(status.state());
 
     EXPECT_THAT(status_string, Eq("Stopped"));
 }
@@ -44,8 +44,8 @@ TEST(InstanceStatusString, stopped_status_returns_STOPPED)
 TEST(InstanceStatusString, deleted_status_returns_DELETED)
 {
     mp::InstanceStatus status;
-    status.set_status(mp::InstanceStatus::DELETED);
-    auto status_string = mp::format::status_string_for(status);
+    status.set_state(mp::InstanceState::DELETED);
+    auto status_string = mp::format::state_string_for(status.state());
 
     EXPECT_THAT(status_string, Eq("Deleted"));
 }
@@ -53,8 +53,8 @@ TEST(InstanceStatusString, deleted_status_returns_DELETED)
 TEST(InstanceStatusString, suspending_status_returns_SUSPENDING)
 {
     mp::InstanceStatus status;
-    status.set_status(mp::InstanceStatus::SUSPENDING);
-    auto status_string = mp::format::status_string_for(status);
+    status.set_state(mp::InstanceState::SUSPENDING);
+    auto status_string = mp::format::state_string_for(status.state());
 
     EXPECT_THAT(status_string, Eq("Suspending"));
 }
@@ -62,8 +62,8 @@ TEST(InstanceStatusString, suspending_status_returns_SUSPENDING)
 TEST(InstanceStatusString, suspended_status_returns_SUSPENDED)
 {
     mp::InstanceStatus status;
-    status.set_status(mp::InstanceStatus::SUSPENDED);
-    auto status_string = mp::format::status_string_for(status);
+    status.set_state(mp::InstanceState::SUSPENDED);
+    auto status_string = mp::format::state_string_for(status.state());
 
     EXPECT_THAT(status_string, Eq("Suspended"));
 }
@@ -71,8 +71,8 @@ TEST(InstanceStatusString, suspended_status_returns_SUSPENDED)
 TEST(InstanceStatusString, running_status_returns_RESTARTING)
 {
     mp::InstanceStatus status;
-    status.set_status(mp::InstanceStatus::RESTARTING);
-    auto status_string = mp::format::status_string_for(status);
+    status.set_state(mp::InstanceState::RESTARTING);
+    auto status_string = mp::format::state_string_for(status.state());
 
     EXPECT_THAT(status_string, Eq("Restarting"));
 }
@@ -80,8 +80,8 @@ TEST(InstanceStatusString, running_status_returns_RESTARTING)
 TEST(InstanceStatusString, bogus_status_returns_UNKNOWN)
 {
     mp::InstanceStatus status;
-    status.set_status(static_cast<mp::InstanceStatus_Status>(10));
-    auto status_string = mp::format::status_string_for(status);
+    status.set_state(mp::InstanceState::UNKNOWN);
+    auto status_string = mp::format::state_string_for(status.state());
 
     EXPECT_THAT(status_string, Eq("Unknown"));
 }

--- a/tests/test_format_utils.cpp
+++ b/tests/test_format_utils.cpp
@@ -23,67 +23,85 @@
 namespace mp = multipass;
 using namespace testing;
 
-TEST(InstanceStatusString, running_status_returns_RUNNING)
+TEST(InstanceStateString, RUNNING_state_returns_Running)
 {
     mp::InstanceStatus status;
     status.set_state(mp::InstanceState::RUNNING);
-    auto status_string = mp::format::state_string_for(status.state());
+    auto state_string = mp::format::state_string_for(status.state());
 
-    EXPECT_THAT(status_string, Eq("Running"));
+    EXPECT_THAT(state_string, Eq("Running"));
 }
 
-TEST(InstanceStatusString, stopped_status_returns_STOPPED)
+TEST(InstanceStateString, STOPPED_state_returns_Stopped)
 {
     mp::InstanceStatus status;
     status.set_state(mp::InstanceState::STOPPED);
-    auto status_string = mp::format::state_string_for(status.state());
+    auto state_string = mp::format::state_string_for(status.state());
 
-    EXPECT_THAT(status_string, Eq("Stopped"));
+    EXPECT_THAT(state_string, Eq("Stopped"));
 }
 
-TEST(InstanceStatusString, deleted_status_returns_DELETED)
+TEST(InstanceStateString, DELETED_state_returns_Deleted)
 {
     mp::InstanceStatus status;
     status.set_state(mp::InstanceState::DELETED);
-    auto status_string = mp::format::state_string_for(status.state());
+    auto state_string = mp::format::state_string_for(status.state());
 
-    EXPECT_THAT(status_string, Eq("Deleted"));
+    EXPECT_THAT(state_string, Eq("Deleted"));
 }
 
-TEST(InstanceStatusString, suspending_status_returns_SUSPENDING)
+TEST(InstanceStateString, SUSPENDING_status_returns_Suspending)
 {
     mp::InstanceStatus status;
     status.set_state(mp::InstanceState::SUSPENDING);
-    auto status_string = mp::format::state_string_for(status.state());
+    auto state_string = mp::format::state_string_for(status.state());
 
-    EXPECT_THAT(status_string, Eq("Suspending"));
+    EXPECT_THAT(state_string, Eq("Suspending"));
 }
 
-TEST(InstanceStatusString, suspended_status_returns_SUSPENDED)
+TEST(InstanceStateString, SUSPENDED_state_returns_Suspended)
 {
     mp::InstanceStatus status;
     status.set_state(mp::InstanceState::SUSPENDED);
-    auto status_string = mp::format::state_string_for(status.state());
+    auto state_string = mp::format::state_string_for(status.state());
 
-    EXPECT_THAT(status_string, Eq("Suspended"));
+    EXPECT_THAT(state_string, Eq("Suspended"));
 }
 
-TEST(InstanceStatusString, running_status_returns_RESTARTING)
+TEST(InstanceStateString, RESTARTING_state_returns_Restarting)
 {
     mp::InstanceStatus status;
     status.set_state(mp::InstanceState::RESTARTING);
-    auto status_string = mp::format::state_string_for(status.state());
+    auto state_string = mp::format::state_string_for(status.state());
 
-    EXPECT_THAT(status_string, Eq("Restarting"));
+    EXPECT_THAT(state_string, Eq("Restarting"));
 }
 
-TEST(InstanceStatusString, bogus_status_returns_UNKNOWN)
+TEST(InstanceStateString, UNKNOWN_state_returns_Unknown)
 {
     mp::InstanceStatus status;
     status.set_state(mp::InstanceState::UNKNOWN);
-    auto status_string = mp::format::state_string_for(status.state());
+    auto state_string = mp::format::state_string_for(status.state());
 
-    EXPECT_THAT(status_string, Eq("Unknown"));
+    EXPECT_THAT(state_string, Eq("Unknown"));
+}
+
+TEST(InstanceStateString, STARTING_state_returns_Starting)
+{
+    mp::InstanceStatus status;
+    status.set_state(mp::InstanceState::STARTING);
+    auto state_string = mp::format::state_string_for(status.state());
+
+    EXPECT_THAT(state_string, Eq("Starting"));
+}
+
+TEST(InstanceStateString, DELAYED_SHUTDOWN_state_returns_Delayed_Shutdown)
+{
+    mp::InstanceStatus status;
+    status.set_state(mp::InstanceState::DELAYED_SHUTDOWN);
+    auto state_string = mp::format::state_string_for(status.state());
+
+    EXPECT_THAT(state_string, Eq("Delayed Shutdown"));
 }
 
 TEST(AliasFilter, unwanted_aliases_filtered_out)

--- a/tests/test_libvirt_backend.cpp
+++ b/tests/test_libvirt_backend.cpp
@@ -104,7 +104,7 @@ TEST_F(LibVirtBackend, creates_in_off_state)
     mpt::StubVMStatusMonitor stub_monitor;
     auto machine = backend.create_virtual_machine(default_description, stub_monitor);
 
-    EXPECT_THAT(machine->current_state(), Eq(mp::VirtualMachine::State::off));
+    EXPECT_THAT(machine->current_state(), Eq(mp::InstanceState::OFF));
 }
 
 TEST_F(LibVirtBackend, creates_in_suspended_state_with_managed_save)
@@ -128,7 +128,7 @@ TEST_F(LibVirtBackend, creates_in_suspended_state_with_managed_save)
     mpt::StubVMStatusMonitor stub_monitor;
     auto machine = backend.create_virtual_machine(default_description, stub_monitor);
 
-    EXPECT_THAT(machine->current_state(), Eq(mp::VirtualMachine::State::suspended));
+    EXPECT_THAT(machine->current_state(), Eq(mp::InstanceState::SUSPENDED));
 }
 
 TEST_F(LibVirtBackend, machine_sends_monitoring_events)
@@ -158,11 +158,11 @@ TEST_F(LibVirtBackend, machine_sends_monitoring_events)
     EXPECT_CALL(mock_monitor, on_resume());
     machine->start();
 
-    machine->state = mp::VirtualMachine::State::running;
+    machine->state = mp::InstanceState::RUNNING;
     EXPECT_CALL(mock_monitor, on_shutdown());
     machine->shutdown();
 
-    machine->state = mp::VirtualMachine::State::running;
+    machine->state = mp::InstanceState::RUNNING;
     EXPECT_CALL(mock_monitor, on_suspend());
     machine->suspend();
 }
@@ -194,7 +194,7 @@ TEST_F(LibVirtBackend, machine_persists_and_sets_state_on_start)
     EXPECT_CALL(mock_monitor, persist_state_for(_, _));
     machine->start();
 
-    EXPECT_THAT(machine->current_state(), Eq(mp::VirtualMachine::State::starting));
+    EXPECT_THAT(machine->current_state(), Eq(mp::InstanceState::STARTING));
 }
 
 TEST_F(LibVirtBackend, machine_persists_and_sets_state_on_shutdown)
@@ -221,11 +221,11 @@ TEST_F(LibVirtBackend, machine_persists_and_sets_state_on_shutdown)
     NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
     auto machine = backend.create_virtual_machine(default_description, mock_monitor);
 
-    machine->state = mp::VirtualMachine::State::running;
+    machine->state = mp::InstanceState::RUNNING;
     EXPECT_CALL(mock_monitor, persist_state_for(_, _));
     machine->shutdown();
 
-    EXPECT_THAT(machine->current_state(), Eq(mp::VirtualMachine::State::off));
+    EXPECT_THAT(machine->current_state(), Eq(mp::InstanceState::OFF));
 }
 
 TEST_F(LibVirtBackend, machine_persists_and_sets_state_on_suspend)
@@ -252,11 +252,11 @@ TEST_F(LibVirtBackend, machine_persists_and_sets_state_on_suspend)
     NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
     auto machine = backend.create_virtual_machine(default_description, mock_monitor);
 
-    machine->state = mp::VirtualMachine::State::running;
+    machine->state = mp::InstanceState::RUNNING;
     EXPECT_CALL(mock_monitor, persist_state_for(_, _));
     machine->suspend();
 
-    EXPECT_THAT(machine->current_state(), Eq(mp::VirtualMachine::State::suspended));
+    EXPECT_THAT(machine->current_state(), Eq(mp::InstanceState::SUSPENDED));
 }
 
 TEST_F(LibVirtBackend, machine_unknown_state_properly_shuts_down)
@@ -283,9 +283,9 @@ TEST_F(LibVirtBackend, machine_unknown_state_properly_shuts_down)
     NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
     auto machine = backend.create_virtual_machine(default_description, mock_monitor);
 
-    machine->state = mp::VirtualMachine::State::unknown;
+    machine->state = mp::InstanceState::UNKNOWN;
     EXPECT_CALL(mock_monitor, persist_state_for(_, _));
     machine->shutdown();
 
-    EXPECT_THAT(machine->current_state(), Eq(mp::VirtualMachine::State::off));
+    EXPECT_THAT(machine->current_state(), Eq(mp::InstanceState::OFF));
 }

--- a/tests/test_output_formatter.cpp
+++ b/tests/test_output_formatter.cpp
@@ -48,7 +48,7 @@ auto construct_single_instance_list_reply()
 
     auto list_entry = list_reply.add_instances();
     list_entry->set_name("foo");
-    list_entry->mutable_instance_status()->set_status(mp::InstanceStatus::RUNNING);
+    list_entry->mutable_instance_status()->set_state(mp::InstanceState::RUNNING);
     list_entry->set_current_release("16.04 LTS");
     list_entry->set_ipv4("10.168.32.2");
 
@@ -61,13 +61,13 @@ auto construct_multiple_instances_list_reply()
 
     auto list_entry = list_reply.add_instances();
     list_entry->set_name("bogus-instance");
-    list_entry->mutable_instance_status()->set_status(mp::InstanceStatus::RUNNING);
+    list_entry->mutable_instance_status()->set_state(mp::InstanceState::RUNNING);
     list_entry->set_current_release("16.04 LTS");
     list_entry->set_ipv4("10.21.124.56");
 
     list_entry = list_reply.add_instances();
     list_entry->set_name("bombastic");
-    list_entry->mutable_instance_status()->set_status(mp::InstanceStatus::STOPPED);
+    list_entry->mutable_instance_status()->set_state(mp::InstanceState::STOPPED);
     list_entry->set_current_release("18.04 LTS");
 
     return list_reply;
@@ -79,7 +79,7 @@ auto construct_multiple_instances_including_petenv_list_reply()
 
     auto instance = reply.add_instances();
     instance->set_name(petenv_name());
-    instance->mutable_instance_status()->set_status(mp::InstanceStatus::DELETED);
+    instance->mutable_instance_status()->set_state(mp::InstanceState::DELETED);
     instance->set_current_release("Not Available");
 
     return reply;
@@ -91,7 +91,7 @@ auto construct_single_instance_info_reply()
 
     auto info_entry = info_reply.add_info();
     info_entry->set_name("foo");
-    info_entry->mutable_instance_status()->set_status(mp::InstanceStatus::RUNNING);
+    info_entry->mutable_instance_status()->set_state(mp::InstanceState::RUNNING);
     info_entry->set_image_release("16.04 LTS");
     info_entry->set_id("1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac");
 
@@ -127,7 +127,7 @@ auto construct_multiple_instances_info_reply()
 
     auto info_entry = info_reply.add_info();
     info_entry->set_name("bogus-instance");
-    info_entry->mutable_instance_status()->set_status(mp::InstanceStatus::RUNNING);
+    info_entry->mutable_instance_status()->set_state(mp::InstanceState::RUNNING);
     info_entry->set_image_release("16.04 LTS");
     info_entry->set_id("1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac");
 
@@ -150,7 +150,7 @@ auto construct_multiple_instances_info_reply()
 
     info_entry = info_reply.add_info();
     info_entry->set_name("bombastic");
-    info_entry->mutable_instance_status()->set_status(mp::InstanceStatus::STOPPED);
+    info_entry->mutable_instance_status()->set_state(mp::InstanceState::STOPPED);
     info_entry->set_image_release("18.04 LTS");
     info_entry->set_id("ab5191cc172564e7cc0eafd397312a32598823e645279c820f0935393aead509");
 
@@ -163,7 +163,7 @@ auto construct_multiple_instances_including_petenv_info_reply()
 
     auto entry = reply.add_info();
     entry->set_name(petenv_name());
-    entry->mutable_instance_status()->set_status(mp::InstanceStatus::SUSPENDED);
+    entry->mutable_instance_status()->set_state(mp::InstanceState::SUSPENDED);
     entry->set_image_release("18.10");
     entry->set_id("1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd");
 

--- a/tests/test_qemu_backend.cpp
+++ b/tests/test_qemu_backend.cpp
@@ -57,7 +57,7 @@ TEST_F(QemuBackend, creates_in_off_state)
     mp::QemuVirtualMachineFactory backend{&process_factory, data_dir.path()};
 
     auto machine = backend.create_virtual_machine(default_description, stub_monitor);
-    EXPECT_THAT(machine->current_state(), Eq(mp::VirtualMachine::State::off));
+    EXPECT_THAT(machine->current_state(), Eq(mp::InstanceState::OFF));
 }
 
 TEST_F(QemuBackend, machine_start_shutdown_sends_monitoring_events)
@@ -71,7 +71,7 @@ TEST_F(QemuBackend, machine_start_shutdown_sends_monitoring_events)
     EXPECT_CALL(mock_monitor, on_resume());
     machine->start();
 
-    machine->state = mp::VirtualMachine::State::running;
+    machine->state = mp::InstanceState::RUNNING;
 
     EXPECT_CALL(mock_monitor, persist_state_for(_, _));
     EXPECT_CALL(mock_monitor, on_shutdown());
@@ -89,7 +89,7 @@ TEST_F(QemuBackend, machine_start_suspend_sends_monitoring_event)
     EXPECT_CALL(mock_monitor, on_resume());
     machine->start();
 
-    machine->state = mp::VirtualMachine::State::running;
+    machine->state = mp::InstanceState::RUNNING;
 
     EXPECT_CALL(mock_monitor, on_suspend());
     EXPECT_CALL(mock_monitor, persist_state_for(_, _));
@@ -103,7 +103,7 @@ TEST_F(QemuBackend, throws_when_starting_while_suspending)
 
     auto machine = backend.create_virtual_machine(default_description, mock_monitor);
 
-    machine->state = mp::VirtualMachine::State::suspending;
+    machine->state = mp::InstanceState::SUSPENDING;
 
     EXPECT_THROW(machine->start(), std::runtime_error);
 }
@@ -119,13 +119,13 @@ TEST_F(QemuBackend, machine_unknown_state_properly_shuts_down)
     EXPECT_CALL(mock_monitor, on_resume());
     machine->start();
 
-    machine->state = mp::VirtualMachine::State::unknown;
+    machine->state = mp::InstanceState::UNKNOWN;
 
     EXPECT_CALL(mock_monitor, persist_state_for(_, _));
     EXPECT_CALL(mock_monitor, on_shutdown());
     machine->shutdown();
 
-    EXPECT_THAT(machine->current_state(), Eq(mp::VirtualMachine::State::off));
+    EXPECT_THAT(machine->current_state(), Eq(mp::InstanceState::OFF));
 }
 
 TEST_F(QemuBackend, verify_dnsmasq_and_qemu_processes_created)

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -352,21 +352,21 @@ TEST(Utils, subdirectory_returns_new_path)
 
 TEST(Utils, vm_running_returns_true)
 {
-    mp::VirtualMachine::State state = mp::VirtualMachine::State::running;
+    mp::InstanceState state = mp::InstanceState::RUNNING;
 
     EXPECT_TRUE(mp::utils::is_running(state));
 }
 
 TEST(Utils, vm_delayed_shutdown_returns_true)
 {
-    mp::VirtualMachine::State state = mp::VirtualMachine::State::delayed_shutdown;
+    mp::InstanceState state = mp::InstanceState::DELAYED_SHUTDOWN;
 
     EXPECT_TRUE(mp::utils::is_running(state));
 }
 
 TEST(Utils, vm_stopped_returns_false)
 {
-    mp::VirtualMachine::State state = mp::VirtualMachine::State::stopped;
+    mp::InstanceState state = mp::InstanceState::STOPPED;
 
     EXPECT_FALSE(mp::utils::is_running(state));
 }


### PR DESCRIPTION
Previously, possible virtual state values were kept in two different places, so
a "translation" was necessary to switch back and forth between the two. Now, just
use the InstanceState enum in the rpc everywhere.