### PR TITLE
Make ProcessFactory a (testable) singleton

### DIFF
--- a/src/platform/backends/libvirt/libvirt_virtual_machine_factory.cpp
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine_factory.cpp
@@ -85,11 +85,8 @@ std::string enable_libvirt_network(virConnectPtr connection, const mp::Path& dat
 }
 } // namespace
 
-mp::LibVirtVirtualMachineFactory::LibVirtVirtualMachineFactory(const ProcessFactory* process_factory,
-                                                               const mp::Path& data_dir)
-    : process_factory{process_factory},
-      connection{connect_to_libvirt_daemon()},
-      bridge_name{enable_libvirt_network(connection.get(), data_dir)}
+mp::LibVirtVirtualMachineFactory::LibVirtVirtualMachineFactory(const mp::Path& data_dir)
+    : connection{connect_to_libvirt_daemon()}, bridge_name{enable_libvirt_network(connection.get(), data_dir)}
 {
 }
 
@@ -122,14 +119,14 @@ mp::FetchType mp::LibVirtVirtualMachineFactory::fetch_type()
 mp::VMImage mp::LibVirtVirtualMachineFactory::prepare_source_image(const VMImage& source_image)
 {
     VMImage image{source_image};
-    image.image_path = mp::backend::convert_to_qcow_if_necessary(process_factory, source_image.image_path);
+    image.image_path = mp::backend::convert_to_qcow_if_necessary(source_image.image_path);
     return image;
 }
 
 void mp::LibVirtVirtualMachineFactory::prepare_instance_image(const VMImage& instance_image,
                                                               const VirtualMachineDescription& desc)
 {
-    mp::backend::resize_instance_image(process_factory, desc.disk_space, instance_image.image_path);
+    mp::backend::resize_instance_image(desc.disk_space, instance_image.image_path);
 }
 
 void mp::LibVirtVirtualMachineFactory::configure(const std::string& /*name*/, YAML::Node& /*meta_config*/,

--- a/src/platform/backends/libvirt/libvirt_virtual_machine_factory.h
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine_factory.h
@@ -32,7 +32,7 @@ class LibVirtVirtualMachineFactory final : public VirtualMachineFactory
 public:
     using ConnectionUPtr = std::unique_ptr<virConnect, decltype(virConnectClose)*>;
 
-    explicit LibVirtVirtualMachineFactory(const ProcessFactory* process_factory, const Path& data_dir);
+    explicit LibVirtVirtualMachineFactory(const Path& data_dir);
     ~LibVirtVirtualMachineFactory();
 
     VirtualMachine::UPtr create_virtual_machine(const VirtualMachineDescription& desc,
@@ -49,7 +49,6 @@ public:
     };
 
 private:
-    const ProcessFactory* process_factory;
     ConnectionUPtr connection;
     const std::string bridge_name;
 };

--- a/src/platform/backends/qemu/dnsmasq_server.cpp
+++ b/src/platform/backends/qemu/dnsmasq_server.cpp
@@ -19,8 +19,8 @@
 
 #include "dnsmasq_process_spec.h"
 #include <multipass/logging/log.h>
-#include <multipass/utils.h>
 #include <multipass/process.h>
+#include <multipass/utils.h>
 #include <shared/linux/process_factory.h>
 
 #include <multipass/format.h>
@@ -31,20 +31,18 @@ namespace mpl = multipass::logging;
 
 namespace
 {
-auto make_dnsmasq_process(const mp::ProcessFactory* process_factory, const mp::Path& data_dir,
-                          const QString& bridge_name, const mp::IPAddress& bridge_addr, const mp::IPAddress& start,
-                          const mp::IPAddress& end)
+auto make_dnsmasq_process(const mp::Path& data_dir, const QString& bridge_name, const mp::IPAddress& bridge_addr,
+                          const mp::IPAddress& start, const mp::IPAddress& end)
 {
     auto process_spec = std::make_unique<mp::DNSMasqProcessSpec>(data_dir, bridge_name, bridge_addr, start, end);
-    return process_factory->create_process(std::move(process_spec));
+    return mp::ProcessFactory::instance().create_process(std::move(process_spec));
 }
 } // namespace
 
-mp::DNSMasqServer::DNSMasqServer(const ProcessFactory* process_factory, const Path& data_dir,
-                                 const QString& bridge_name, const IPAddress& bridge_addr, const IPAddress& start,
-                                 const IPAddress& end)
+mp::DNSMasqServer::DNSMasqServer(const Path& data_dir, const QString& bridge_name, const IPAddress& bridge_addr,
+                                 const IPAddress& start, const IPAddress& end)
     : data_dir{data_dir},
-      dnsmasq_cmd{make_dnsmasq_process(process_factory, data_dir, bridge_name, bridge_addr, start, end)},
+      dnsmasq_cmd{make_dnsmasq_process(data_dir, bridge_name, bridge_addr, start, end)},
       bridge_name{bridge_name}
 {
     dnsmasq_cmd->start();

--- a/src/platform/backends/qemu/dnsmasq_server.h
+++ b/src/platform/backends/qemu/dnsmasq_server.h
@@ -30,13 +30,11 @@
 
 namespace multipass
 {
-class ProcessFactory;
-
 class DNSMasqServer
 {
 public:
-    DNSMasqServer(const ProcessFactory* process_factory, const Path& data_dir, const QString& bridge_name,
-                  const IPAddress& bridge_addr, const IPAddress& start, const IPAddress& end);
+    DNSMasqServer(const Path& data_dir, const QString& bridge_name, const IPAddress& bridge_addr,
+                  const IPAddress& start, const IPAddress& end);
     DNSMasqServer(DNSMasqServer&& other) = default;
     ~DNSMasqServer();
 

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -28,15 +28,14 @@
 namespace multipass
 {
 class DNSMasqServer;
-class ProcessFactory;
 class VMStatusMonitor;
 class VirtualMachineDescription;
 
 class QemuVirtualMachine final : public VirtualMachine
 {
 public:
-    QemuVirtualMachine(const ProcessFactory* process_factory, const VirtualMachineDescription& desc,
-                       const std::string& tap_device_name, DNSMasqServer& dnsmasq_server, VMStatusMonitor& monitor);
+    QemuVirtualMachine(const VirtualMachineDescription& desc, const std::string& tap_device_name,
+                       DNSMasqServer& dnsmasq_server, VMStatusMonitor& monitor);
     ~QemuVirtualMachine();
 
     void start() override;

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
@@ -24,7 +24,6 @@
 #include <multipass/virtual_machine_description.h>
 
 #include <shared/linux/backend_utils.h>
-#include <shared/linux/process_factory.h>
 
 #include <multipass/format.h>
 #include <yaml-cpp/yaml.h>
@@ -201,8 +200,7 @@ void set_nat_iptables(const std::string& subnet, const QString& bridge_name)
             "iptables", {"-I", "FORWARD", "-o", bridge_name, "-j", "REJECT", "--reject-with icmp-port-unreachable"});
 }
 
-mp::DNSMasqServer create_dnsmasq_server(const mp::ProcessFactory* process_factory, const mp::Path& data_dir,
-                                        const QString& bridge_name)
+mp::DNSMasqServer create_dnsmasq_server(const mp::Path& data_dir, const QString& bridge_name)
 {
     auto network_dir = mp::utils::make_dir(QDir(data_dir), "network");
     const auto subnet = mp::backend::get_subnet(network_dir, bridge_name);
@@ -214,15 +212,13 @@ mp::DNSMasqServer create_dnsmasq_server(const mp::ProcessFactory* process_factor
     const auto bridge_addr = mp::IPAddress{fmt::format("{}.1", subnet)};
     const auto start_addr = mp::IPAddress{fmt::format("{}.2", subnet)};
     const auto end_addr = mp::IPAddress{fmt::format("{}.254", subnet)};
-    return {process_factory, network_dir, bridge_name, bridge_addr, start_addr, end_addr};
+    return {network_dir, bridge_name, bridge_addr, start_addr, end_addr};
 }
 } // namespace
 
-mp::QemuVirtualMachineFactory::QemuVirtualMachineFactory(const ProcessFactory* process_factory,
-                                                         const mp::Path& data_dir)
-    : process_factory{process_factory},
-      bridge_name{QString::fromStdString(multipass_bridge_name)},
-      dnsmasq_server{create_dnsmasq_server(process_factory, data_dir, bridge_name)}
+mp::QemuVirtualMachineFactory::QemuVirtualMachineFactory(const mp::Path& data_dir)
+    : bridge_name{QString::fromStdString(multipass_bridge_name)},
+      dnsmasq_server{create_dnsmasq_server(data_dir, bridge_name)}
 {
 }
 
@@ -237,7 +233,7 @@ mp::VirtualMachine::UPtr mp::QemuVirtualMachineFactory::create_virtual_machine(c
     auto tap_device_name = generate_tap_device_name(desc.vm_name);
     create_tap_device(QString::fromStdString(tap_device_name), bridge_name);
 
-    auto vm = std::make_unique<mp::QemuVirtualMachine>(process_factory, desc, tap_device_name, dnsmasq_server, monitor);
+    auto vm = std::make_unique<mp::QemuVirtualMachine>(desc, tap_device_name, dnsmasq_server, monitor);
 
     name_to_mac_map.emplace(desc.vm_name, desc.mac_addr);
     return vm;
@@ -260,14 +256,14 @@ mp::FetchType mp::QemuVirtualMachineFactory::fetch_type()
 mp::VMImage mp::QemuVirtualMachineFactory::prepare_source_image(const mp::VMImage& source_image)
 {
     VMImage image{source_image};
-    image.image_path = mp::backend::convert_to_qcow_if_necessary(process_factory, source_image.image_path);
+    image.image_path = mp::backend::convert_to_qcow_if_necessary(source_image.image_path);
     return image;
 }
 
 void mp::QemuVirtualMachineFactory::prepare_instance_image(const mp::VMImage& instance_image,
                                                            const VirtualMachineDescription& desc)
 {
-    mp::backend::resize_instance_image(process_factory, desc.disk_space, instance_image.image_path);
+    mp::backend::resize_instance_image(desc.disk_space, instance_image.image_path);
 }
 
 void mp::QemuVirtualMachineFactory::configure(const std::string& /*name*/, YAML::Node& /*meta_config*/,

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.h
@@ -25,12 +25,10 @@
 
 namespace multipass
 {
-class ProcessFactory;
-
 class QemuVirtualMachineFactory final : public VirtualMachineFactory
 {
 public:
-    explicit QemuVirtualMachineFactory(const ProcessFactory* process_factory, const Path& data_dir);
+    explicit QemuVirtualMachineFactory(const Path& data_dir);
     ~QemuVirtualMachineFactory();
 
     VirtualMachine::UPtr create_virtual_machine(const VirtualMachineDescription& desc,
@@ -47,7 +45,6 @@ public:
     };
 
 private:
-    const ProcessFactory* process_factory;
     const QString bridge_name;
     DNSMasqServer dnsmasq_server;
     std::unordered_map<std::string, std::string> name_to_mac_map;

--- a/src/platform/backends/shared/linux/backend_utils.h
+++ b/src/platform/backends/shared/linux/backend_utils.h
@@ -32,10 +32,9 @@ namespace backend
 std::string generate_random_subnet();
 std::string get_subnet(const Path& network_dir, const QString& bridge_name);
 void check_hypervisor_support();
-void resize_instance_image(const ProcessFactory* process_factory, const MemorySize& disk_space,
-                           const multipass::Path& image_path);
-Path convert_to_qcow_if_necessary(const ProcessFactory* process_factory, const Path& image_path);
+void resize_instance_image(const MemorySize& disk_space, const multipass::Path& image_path);
+Path convert_to_qcow_if_necessary(const Path& image_path);
 QString cpu_arch();
-}
-}
+} // namespace backend
+} // namespace multipass
 #endif // MULTIPASS_BACKEND_UTILS_H

--- a/src/platform/backends/shared/linux/process_factory.cpp
+++ b/src/platform/backends/shared/linux/process_factory.cpp
@@ -21,6 +21,8 @@
 
 namespace mp = multipass;
 
+namespace
+{
 class UnsecuredProcess : public mp::LinuxProcess
 {
 public:
@@ -28,6 +30,12 @@ public:
     {
     }
 };
+} // namespace
+
+mp::ProcessFactory::ProcessFactory(const Singleton<ProcessFactory>::PrivatePass& pass)
+    : Singleton<ProcessFactory>::Singleton{pass}
+{
+}
 
 // This is the default ProcessFactory that creates a Process with no security mechanisms enabled
 std::unique_ptr<mp::Process> mp::ProcessFactory::create_process(std::unique_ptr<mp::ProcessSpec>&& process_spec) const

--- a/src/platform/backends/shared/linux/process_factory.h
+++ b/src/platform/backends/shared/linux/process_factory.h
@@ -20,17 +20,19 @@
 
 #include <memory>
 
+#include <multipass/singleton.h>
+
 namespace multipass
 {
 class Process;
 class ProcessSpec;
 
-class ProcessFactory
+class ProcessFactory : public Singleton<ProcessFactory>
 {
 public:
     using UPtr = std::unique_ptr<ProcessFactory>;
 
-    ProcessFactory() = default;
+    ProcessFactory(const Singleton<ProcessFactory>::PrivatePass&);
     virtual ~ProcessFactory() = default;
 
     virtual std::unique_ptr<Process> create_process(std::unique_ptr<ProcessSpec>&& process_spec) const;

--- a/src/platform/backends/shared/linux/process_factory.h
+++ b/src/platform/backends/shared/linux/process_factory.h
@@ -30,10 +30,8 @@ class ProcessSpec;
 class ProcessFactory : public Singleton<ProcessFactory>
 {
 public:
-    using UPtr = std::unique_ptr<ProcessFactory>;
-
     ProcessFactory(const Singleton<ProcessFactory>::PrivatePass&);
-    virtual ~ProcessFactory() = default;
+    //    virtual ~ProcessFactory() = default;
 
     virtual std::unique_ptr<Process> create_process(std::unique_ptr<ProcessSpec>&& process_spec) const;
 };

--- a/src/platform/backends/shared/linux/process_factory.h
+++ b/src/platform/backends/shared/linux/process_factory.h
@@ -20,18 +20,19 @@
 
 #include <memory>
 
+#include "process_spec.h"
+#include <multipass/process.h>
 #include <multipass/singleton.h>
 
 namespace multipass
 {
-class Process;
-class ProcessSpec;
+// class Process;
+// class ProcessSpec;
 
 class ProcessFactory : public Singleton<ProcessFactory>
 {
 public:
     ProcessFactory(const Singleton<ProcessFactory>::PrivatePass&);
-    //    virtual ~ProcessFactory() = default;
 
     virtual std::unique_ptr<Process> create_process(std::unique_ptr<ProcessSpec>&& process_spec) const;
 };

--- a/src/platform/backends/shared/linux/process_factory.h
+++ b/src/platform/backends/shared/linux/process_factory.h
@@ -21,13 +21,11 @@
 #include <memory>
 
 #include "process_spec.h"
-#include <multipass/process.h>
 #include <multipass/singleton.h>
 
 namespace multipass
 {
-// class Process;
-// class ProcessSpec;
+class Process;
 
 class ProcessFactory : public Singleton<ProcessFactory>
 {

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -23,25 +23,10 @@
 
 #include "backends/libvirt/libvirt_virtual_machine_factory.h"
 #include "backends/qemu/qemu_virtual_machine_factory.h"
-#include "backends/shared/linux/process_factory.h"
 #include "logger/journald_logger.h"
 #include <disabled_update_prompt.h>
 
 namespace mp = multipass;
-
-namespace
-{
-static mp::ProcessFactory::UPtr static_process_factory;
-
-mp::ProcessFactory* process_factory()
-{
-    if (!static_process_factory)
-    {
-        static_process_factory = std::make_unique<mp::ProcessFactory>();
-    }
-    return static_process_factory.get();
-}
-} // namespace
 
 std::string mp::platform::default_server_address()
 {
@@ -53,9 +38,9 @@ mp::VirtualMachineFactory::UPtr mp::platform::vm_backend(const mp::Path& data_di
     auto driver = qgetenv("MULTIPASS_VM_DRIVER");
 
     if (driver.isEmpty() || driver == "QEMU")
-        return std::make_unique<QemuVirtualMachineFactory>(::process_factory(), data_dir);
+        return std::make_unique<QemuVirtualMachineFactory>(data_dir);
     else if (driver == "LIBVIRT")
-        return std::make_unique<LibVirtVirtualMachineFactory>(::process_factory(), data_dir);
+        return std::make_unique<LibVirtVirtualMachineFactory>(data_dir);
 
     throw std::runtime_error("Invalid virtualization driver set in the environment");
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+set (CMAKE_AUTOMOC ON)
+
 list(APPEND CMOCK_TARGETS
   ssh_test
   sshfs_mount_test
@@ -110,6 +112,7 @@ add_executable(multipass_tests
   test_ssh_session.cpp
   test_ubuntu_image_host.cpp
   test_utils.cpp
+  ${CMAKE_SOURCE_DIR}/include/multipass/process.h # need to run MOC on this
 
   ${BACKEND_TESTS}
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ include(c_mock_defines.cmake)
 
 list(APPEND BACKEND_TESTS
   mock_libvirt.cpp
+  stub_process_factory.cpp
   test_qemu_backend.cpp
   test_dnsmasq_server.cpp
   test_libvirt_backend.cpp
@@ -79,7 +80,6 @@ add_executable(multipass_tests
   mock_ssh.cpp
   mock_ssh_client.cpp
   path.cpp
-  stub_process_factory.cpp
   temp_dir.cpp
   temp_file.cpp
   test_cli_client.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,6 +77,7 @@ add_executable(multipass_tests
   mock_ssh.cpp
   mock_ssh_client.cpp
   path.cpp
+  stub_process_factory.cpp
   temp_dir.cpp
   temp_file.cpp
   test_cli_client.cpp

--- a/tests/stub_process_factory.cpp
+++ b/tests/stub_process_factory.cpp
@@ -1,11 +1,125 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 #include "stub_process_factory.h"
 
 namespace mp = multipass;
 namespace mpt = multipass::test;
+using namespace ::testing;
 
-std::unique_ptr<mp::Process> mpt::StubProcessFactory::create_process(std::unique_ptr<ProcessSpec>&&) const
+namespace
 {
-    return std::make_unique<mpt::StubProcess>();
+
+class StubProcess : public mp::Process
+{
+public:
+    StubProcess(std::unique_ptr<mp::ProcessSpec>&& spec,
+                std::vector<mpt::StubProcessFactory::ProcessInfo>& process_list)
+    {
+        mpt::StubProcessFactory::ProcessInfo p{spec->program(), spec->arguments()};
+        process_list.emplace_back(p);
+    }
+
+    QString program() const override
+    {
+        return "";
+    }
+    QStringList arguments() const override
+    {
+        return {};
+    }
+    QString working_directory() const override
+    {
+        return "";
+    }
+    QProcessEnvironment process_environment() const override
+    {
+        return QProcessEnvironment();
+    }
+
+    void start(const QStringList& extra_arguments = QStringList()) override
+    {
+        emit started();
+    }
+    void kill() override
+    {
+        emit finished(0, QProcess::NormalExit);
+    }
+
+    bool wait_for_started(int msecs = 30000) override
+    {
+        return true;
+    }
+    bool wait_for_finished(int msecs = 30000) override
+    {
+        return true;
+    }
+
+    bool running() const override
+    {
+        return true;
+    }
+
+    QByteArray read_all_standard_output() override
+    {
+        return "";
+    }
+    QByteArray read_all_standard_error() override
+    {
+        return "";
+    }
+
+    qint64 write(const QByteArray& data) override
+    {
+        return 0;
+    }
+
+    bool run_and_return_status(const QStringList& = QStringList(), const int timeout = 3000) override
+    {
+        return true;
+    }
+    QString run_and_return_output(const QStringList& = QStringList(), const int timeout = 3000) override
+    {
+        return "";
+    }
+};
+} // namespace
+
+std::unique_ptr<mp::Process> mpt::StubProcessFactory::create_process(std::unique_ptr<ProcessSpec>&& spec) const
+{
+    return std::make_unique<StubProcess>(std::move(spec),
+                                         const_cast<std::vector<mpt::StubProcessFactory::ProcessInfo>&>(process_list));
+}
+
+std::unique_ptr<mp::test::StubProcessFactory::Scope> mp::test::StubProcessFactory::Inject()
+{
+    ProcessFactory::reset(); // cannot mock unless singleton reset
+    ProcessFactory::mock<StubProcessFactory>();
+    return std::make_unique<mp::test::StubProcessFactory::Scope>();
+}
+
+mpt::StubProcessFactory::Scope::~Scope()
+{
+    ProcessFactory::reset();
+}
+
+std::vector<mpt::StubProcessFactory::ProcessInfo> mpt::StubProcessFactory::Scope::process_list()
+{
+    return stub_instance().process_list;
 }
 
 mpt::StubProcessFactory& mpt::StubProcessFactory::stub_instance()

--- a/tests/stub_process_factory.cpp
+++ b/tests/stub_process_factory.cpp
@@ -1,0 +1,14 @@
+#include "stub_process_factory.h"
+
+namespace mp = multipass;
+namespace mpt = multipass::test;
+
+std::unique_ptr<mp::Process> mpt::StubProcessFactory::create_process(std::unique_ptr<ProcessSpec>&&) const
+{
+    return std::make_unique<mpt::StubProcess>();
+}
+
+mpt::StubProcessFactory& mpt::StubProcessFactory::stub_instance()
+{
+    return dynamic_cast<mpt::StubProcessFactory&>(instance());
+}

--- a/tests/stub_process_factory.h
+++ b/tests/stub_process_factory.h
@@ -28,37 +28,82 @@ namespace test
 class StubProcess : public Process
 {
 public:
-    StubProcess() {}
+    StubProcess()
+    {
+    }
 
-    QString program() const { return ""; }
-    QStringList arguments() const { return {}; }
-    QString working_directory() const { return ""; }
-    QProcessEnvironment process_environment() const { return QProcessEnvironment(); }
+    QString program() const
+    {
+        return "";
+    }
+    QStringList arguments() const
+    {
+        return {};
+    }
+    QString working_directory() const
+    {
+        return "";
+    }
+    QProcessEnvironment process_environment() const
+    {
+        return QProcessEnvironment();
+    }
 
-    void start(const QStringList& extra_arguments = QStringList()) {}
-    void kill() {}
+    void start(const QStringList& extra_arguments = QStringList())
+    {
+    }
+    void kill()
+    {
+    }
 
-    bool wait_for_started(int msecs = 30000) { return true; }
-    bool wait_for_finished(int msecs = 30000) { return true; }
+    bool wait_for_started(int msecs = 30000)
+    {
+        return true;
+    }
+    bool wait_for_finished(int msecs = 30000)
+    {
+        return true;
+    }
 
-    bool running() const { return true; }
+    bool running() const
+    {
+        return true;
+    }
 
-    QByteArray read_all_standard_output() { return ""; }
-    QByteArray read_all_standard_error() { return ""; }
+    QByteArray read_all_standard_output()
+    {
+        return "";
+    }
+    QByteArray read_all_standard_error()
+    {
+        return "";
+    }
 
-    qint64 write(const QByteArray &data) { return 0; }
+    qint64 write(const QByteArray& data)
+    {
+        return 0;
+    }
 
-    bool run_and_return_status(const QStringList& extra_arguments = QStringList(), const int timeout = 30000) { return true; }
-    QString run_and_return_output(const QStringList& extra_arguments = QStringList(), const int timeout = 30000) { return ""; }
+    bool run_and_return_status(const QStringList& extra_arguments = QStringList(), const int timeout = 30000)
+    {
+        return true;
+    }
+    QString run_and_return_output(const QStringList& extra_arguments = QStringList(), const int timeout = 30000)
+    {
+        return "";
+    }
 };
 
 class StubProcessFactory : public ProcessFactory
 {
-    std::unique_ptr<Process> create_process(std::unique_ptr<ProcessSpec>&&) const override
-    {
-        return std::make_unique<StubProcess>();
-    }
+public:
+    using ProcessFactory::ProcessFactory;
+
+    std::unique_ptr<Process> create_process(std::unique_ptr<ProcessSpec>&&) const override;
+
+    static StubProcessFactory& stub_instance();
 };
+
 } // namespace test
 } // namespace multipass
 

--- a/tests/stub_process_factory.h
+++ b/tests/stub_process_factory.h
@@ -21,87 +21,41 @@
 #include <multipass/process.h>
 #include <src/platform/backends/shared/linux/process_factory.h>
 
+#include <gtest/gtest.h>
+
 namespace multipass
 {
 namespace test
 {
-class StubProcess : public Process
-{
-public:
-    StubProcess()
-    {
-    }
-
-    QString program() const
-    {
-        return "";
-    }
-    QStringList arguments() const
-    {
-        return {};
-    }
-    QString working_directory() const
-    {
-        return "";
-    }
-    QProcessEnvironment process_environment() const
-    {
-        return QProcessEnvironment();
-    }
-
-    void start(const QStringList& extra_arguments = QStringList())
-    {
-    }
-    void kill()
-    {
-    }
-
-    bool wait_for_started(int msecs = 30000)
-    {
-        return true;
-    }
-    bool wait_for_finished(int msecs = 30000)
-    {
-        return true;
-    }
-
-    bool running() const
-    {
-        return true;
-    }
-
-    QByteArray read_all_standard_output()
-    {
-        return "";
-    }
-    QByteArray read_all_standard_error()
-    {
-        return "";
-    }
-
-    qint64 write(const QByteArray& data)
-    {
-        return 0;
-    }
-
-    bool run_and_return_status(const QStringList& extra_arguments = QStringList(), const int timeout = 30000)
-    {
-        return true;
-    }
-    QString run_and_return_output(const QStringList& extra_arguments = QStringList(), const int timeout = 30000)
-    {
-        return "";
-    }
-};
 
 class StubProcessFactory : public ProcessFactory
 {
 public:
+    struct ProcessInfo
+    {
+        QString command;
+        QStringList arguments;
+    };
+
+    // StubProcessFactory installed with Inject() call, and uninstalled when the Scope object deleted
+    struct Scope
+    {
+        ~Scope();
+
+        // Get info about the Processes launched with this list
+        std::vector<ProcessInfo> process_list();
+    };
+
+    static std::unique_ptr<Scope> Inject();
+
+    // Implementation
     using ProcessFactory::ProcessFactory;
 
-    std::unique_ptr<Process> create_process(std::unique_ptr<ProcessSpec>&&) const override;
+    std::unique_ptr<Process> create_process(std::unique_ptr<ProcessSpec>&& spec) const override;
 
+private:
     static StubProcessFactory& stub_instance();
+    std::vector<ProcessInfo> process_list;
 };
 
 } // namespace test

--- a/tests/test_dnsmasq_server.cpp
+++ b/tests/test_dnsmasq_server.cpp
@@ -21,10 +21,8 @@
 #include <multipass/logging/logger.h>
 
 #include "file_operations.h"
-#include "stub_process_factory.h"
 #include "temp_dir.h"
 #include "test_with_mocked_bin_path.h"
-
 #include <QDir>
 
 #include <memory>
@@ -48,7 +46,7 @@ struct CapturingLogger : public mp::logging::Logger
     mutable std::vector<std::string> logged_lines;
 };
 
-struct DNSMasqServer : public ::testing::Test
+struct DNSMasqServer : public mpt::TestWithMockedBinPath
 {
     DNSMasqServer()
     {
@@ -67,7 +65,6 @@ struct DNSMasqServer : public ::testing::Test
 
     mpt::TempDir data_dir;
     std::shared_ptr<CapturingLogger> logger = std::make_shared<CapturingLogger>();
-    mpt::StubProcessFactory& mock_settings = mpt::StubProcessFactory::stub_instance();
     const QString bridge_name{"dummy-bridge"};
     const mp::IPAddress bridge_addr{"192.168.64.1"};
     const mp::IPAddress start_addr{"192.168.64.2"};
@@ -78,6 +75,7 @@ struct DNSMasqServer : public ::testing::Test
         "0 "s + hw_addr + " "s + expected_ip + " dummy_name 00:01:02:03:04:05:06:07:08:09:0a:0b:0c:0d:0e:0f:10:11:12";
 };
 } // namespace
+
 TEST_F(DNSMasqServer, starts_dnsmasq_process)
 {
     EXPECT_NO_THROW(mp::DNSMasqServer dns(data_dir.path(), bridge_name, bridge_addr, start_addr, end_addr));

--- a/tests/test_dnsmasq_server.cpp
+++ b/tests/test_dnsmasq_server.cpp
@@ -67,7 +67,7 @@ struct DNSMasqServer : public mpt::TestWithMockedBinPath
 
     mpt::TempDir data_dir;
     std::shared_ptr<CapturingLogger> logger = std::make_shared<CapturingLogger>();
-    mpt::StubProcessFactory process_factory;
+    // mpt::StubProcessFactory process_factory;
     const QString bridge_name{"dummy-bridge"};
     const mp::IPAddress bridge_addr{"192.168.64.1"};
     const mp::IPAddress start_addr{"192.168.64.2"};
@@ -80,12 +80,12 @@ struct DNSMasqServer : public mpt::TestWithMockedBinPath
 } // namespace
 TEST_F(DNSMasqServer, starts_dnsmasq_process)
 {
-    EXPECT_NO_THROW(mp::DNSMasqServer dns(&process_factory, data_dir.path(), bridge_name, bridge_addr, start_addr, end_addr));
+    EXPECT_NO_THROW(mp::DNSMasqServer dns(data_dir.path(), bridge_name, bridge_addr, start_addr, end_addr));
 }
 
 TEST_F(DNSMasqServer, finds_ip)
 {
-    mp::DNSMasqServer dns{&process_factory, data_dir.path(), bridge_name, bridge_addr, start_addr, end_addr};
+    mp::DNSMasqServer dns{data_dir.path(), bridge_name, bridge_addr, start_addr, end_addr};
     make_lease_entry();
 
     auto ip = dns.get_ip_for(hw_addr);
@@ -96,7 +96,7 @@ TEST_F(DNSMasqServer, finds_ip)
 
 TEST_F(DNSMasqServer, returns_null_ip_when_leases_file_does_not_exist)
 {
-    mp::DNSMasqServer dns{&process_factory, data_dir.path(), bridge_name, bridge_addr, start_addr, end_addr};
+    mp::DNSMasqServer dns{data_dir.path(), bridge_name, bridge_addr, start_addr, end_addr};
 
     const std::string hw_addr{"00:01:02:03:04:05"};
     auto ip = dns.get_ip_for(hw_addr);
@@ -108,7 +108,7 @@ TEST_F(DNSMasqServer, release_mac_releases_ip)
 {
     const QString dchp_release_called{QDir{data_dir.path()}.filePath("dhcp_release_called")};
 
-    mp::DNSMasqServer dns{&process_factory, data_dir.path(), dchp_release_called, bridge_addr, start_addr, end_addr};
+    mp::DNSMasqServer dns{data_dir.path(), dchp_release_called, bridge_addr, start_addr, end_addr};
     make_lease_entry();
 
     dns.release_mac(hw_addr);
@@ -120,7 +120,7 @@ TEST_F(DNSMasqServer, release_mac_logs_failure_on_missing_ip)
 {
     const QString dchp_release_called{QDir{data_dir.path()}.filePath("dhcp_release_called")};
 
-    mp::DNSMasqServer dns{&process_factory, data_dir.path(), dchp_release_called, bridge_addr, start_addr, end_addr};
+    mp::DNSMasqServer dns{data_dir.path(), dchp_release_called, bridge_addr, start_addr, end_addr};
     dns.release_mac(hw_addr);
 
     EXPECT_FALSE(QFile::exists(dchp_release_called));
@@ -131,7 +131,7 @@ TEST_F(DNSMasqServer, release_mac_logs_failures)
 {
     const QString dchp_release_called{QDir{data_dir.path()}.filePath("dhcp_release_called.fail")};
 
-    mp::DNSMasqServer dns{&process_factory, data_dir.path(), dchp_release_called, bridge_addr, start_addr, end_addr};
+    mp::DNSMasqServer dns{data_dir.path(), dchp_release_called, bridge_addr, start_addr, end_addr};
     make_lease_entry();
 
     dns.release_mac(hw_addr);

--- a/tests/test_dnsmasq_server.cpp
+++ b/tests/test_dnsmasq_server.cpp
@@ -48,7 +48,7 @@ struct CapturingLogger : public mp::logging::Logger
     mutable std::vector<std::string> logged_lines;
 };
 
-struct DNSMasqServer : public mpt::TestWithMockedBinPath
+struct DNSMasqServer : public ::testing::Test
 {
     DNSMasqServer()
     {
@@ -67,7 +67,7 @@ struct DNSMasqServer : public mpt::TestWithMockedBinPath
 
     mpt::TempDir data_dir;
     std::shared_ptr<CapturingLogger> logger = std::make_shared<CapturingLogger>();
-    // mpt::StubProcessFactory process_factory;
+    mpt::StubProcessFactory& mock_settings = mpt::StubProcessFactory::stub_instance();
     const QString bridge_name{"dummy-bridge"};
     const mp::IPAddress bridge_addr{"192.168.64.1"};
     const mp::IPAddress start_addr{"192.168.64.2"};

--- a/tests/test_libvirt_backend.cpp
+++ b/tests/test_libvirt_backend.cpp
@@ -60,7 +60,6 @@ struct LibVirtBackend : public Test
     }
     mpt::TempFile dummy_image;
     mpt::TempFile dummy_cloud_init_iso;
-    mpt::StubProcessFactory process_factory;
     mp::VirtualMachineDescription default_description{2,
                                                       mp::MemorySize{"3M"},
                                                       mp::MemorySize{}, // not used
@@ -80,7 +79,7 @@ struct LibVirtBackend : public Test
 TEST_F(LibVirtBackend, failed_connection_throws)
 {
     REPLACE(virConnectOpen, [](auto...) { return nullptr; });
-    EXPECT_THROW(mp::LibVirtVirtualMachineFactory backend(&process_factory, data_dir.path()), std::runtime_error);
+    EXPECT_THROW(mp::LibVirtVirtualMachineFactory backend(data_dir.path()), std::runtime_error);
 }
 
 TEST_F(LibVirtBackend, creates_in_off_state)
@@ -100,7 +99,7 @@ TEST_F(LibVirtBackend, creates_in_off_state)
     });
     REPLACE(virDomainHasManagedSaveImage, [](auto...) { return 0; });
 
-    mp::LibVirtVirtualMachineFactory backend{&process_factory, data_dir.path()};
+    mp::LibVirtVirtualMachineFactory backend{data_dir.path()};
     mpt::StubVMStatusMonitor stub_monitor;
     auto machine = backend.create_virtual_machine(default_description, stub_monitor);
 
@@ -124,7 +123,7 @@ TEST_F(LibVirtBackend, creates_in_suspended_state_with_managed_save)
     });
     REPLACE(virDomainHasManagedSaveImage, [](auto...) { return 1; });
 
-    mp::LibVirtVirtualMachineFactory backend{&process_factory, data_dir.path()};
+    mp::LibVirtVirtualMachineFactory backend{data_dir.path()};
     mpt::StubVMStatusMonitor stub_monitor;
     auto machine = backend.create_virtual_machine(default_description, stub_monitor);
 
@@ -151,7 +150,7 @@ TEST_F(LibVirtBackend, machine_sends_monitoring_events)
     REPLACE(virDomainManagedSave, [](auto...) { return 0; });
     REPLACE(virDomainHasManagedSaveImage, [](auto...) { return 0; });
 
-    mp::LibVirtVirtualMachineFactory backend{&process_factory, data_dir.path()};
+    mp::LibVirtVirtualMachineFactory backend{data_dir.path()};
     NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
     auto machine = backend.create_virtual_machine(default_description, mock_monitor);
 
@@ -187,7 +186,7 @@ TEST_F(LibVirtBackend, machine_persists_and_sets_state_on_start)
     REPLACE(virDomainManagedSave, [](auto...) { return 0; });
     REPLACE(virDomainHasManagedSaveImage, [](auto...) { return 0; });
 
-    mp::LibVirtVirtualMachineFactory backend{&process_factory, data_dir.path()};
+    mp::LibVirtVirtualMachineFactory backend{data_dir.path()};
     NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
     auto machine = backend.create_virtual_machine(default_description, mock_monitor);
 
@@ -217,7 +216,7 @@ TEST_F(LibVirtBackend, machine_persists_and_sets_state_on_shutdown)
     REPLACE(virDomainManagedSave, [](auto...) { return 0; });
     REPLACE(virDomainHasManagedSaveImage, [](auto...) { return 0; });
 
-    mp::LibVirtVirtualMachineFactory backend{&process_factory, data_dir.path()};
+    mp::LibVirtVirtualMachineFactory backend{data_dir.path()};
     NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
     auto machine = backend.create_virtual_machine(default_description, mock_monitor);
 
@@ -248,7 +247,7 @@ TEST_F(LibVirtBackend, machine_persists_and_sets_state_on_suspend)
     REPLACE(virDomainManagedSave, [](auto...) { return 0; });
     REPLACE(virDomainHasManagedSaveImage, [](auto...) { return 0; });
 
-    mp::LibVirtVirtualMachineFactory backend{&process_factory, data_dir.path()};
+    mp::LibVirtVirtualMachineFactory backend{data_dir.path()};
     NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
     auto machine = backend.create_virtual_machine(default_description, mock_monitor);
 
@@ -279,7 +278,7 @@ TEST_F(LibVirtBackend, machine_unknown_state_properly_shuts_down)
     REPLACE(virDomainManagedSave, [](auto...) { return 0; });
     REPLACE(virDomainHasManagedSaveImage, [](auto...) { return 0; });
 
-    mp::LibVirtVirtualMachineFactory backend{&process_factory, data_dir.path()};
+    mp::LibVirtVirtualMachineFactory backend{data_dir.path()};
     NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
     auto machine = backend.create_virtual_machine(default_description, mock_monitor);
 

--- a/tests/test_qemu_backend.cpp
+++ b/tests/test_qemu_backend.cpp
@@ -39,7 +39,7 @@ struct QemuBackend : public mpt::TestWithMockedBinPath
 {
     mpt::TempFile dummy_image;
     mpt::TempFile dummy_cloud_init_iso;
-    mp::ProcessFactory process_factory; // want to launch actual processes
+    // mp::ProcessFactory process_factory; // want to launch actual processes
     mp::VirtualMachineDescription default_description{2,
                                                       mp::MemorySize{"3M"},
                                                       mp::MemorySize{}, // not used
@@ -54,7 +54,7 @@ struct QemuBackend : public mpt::TestWithMockedBinPath
 TEST_F(QemuBackend, creates_in_off_state)
 {
     mpt::StubVMStatusMonitor stub_monitor;
-    mp::QemuVirtualMachineFactory backend{&process_factory, data_dir.path()};
+    mp::QemuVirtualMachineFactory backend{data_dir.path()};
 
     auto machine = backend.create_virtual_machine(default_description, stub_monitor);
     EXPECT_THAT(machine->current_state(), Eq(mp::VirtualMachine::State::off));
@@ -63,7 +63,7 @@ TEST_F(QemuBackend, creates_in_off_state)
 TEST_F(QemuBackend, machine_start_shutdown_sends_monitoring_events)
 {
     NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
-    mp::QemuVirtualMachineFactory backend{&process_factory, data_dir.path()};
+    mp::QemuVirtualMachineFactory backend{data_dir.path()};
 
     auto machine = backend.create_virtual_machine(default_description, mock_monitor);
 
@@ -81,7 +81,7 @@ TEST_F(QemuBackend, machine_start_shutdown_sends_monitoring_events)
 TEST_F(QemuBackend, machine_start_suspend_sends_monitoring_event)
 {
     NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
-    mp::QemuVirtualMachineFactory backend{&process_factory, data_dir.path()};
+    mp::QemuVirtualMachineFactory backend{data_dir.path()};
 
     auto machine = backend.create_virtual_machine(default_description, mock_monitor);
 
@@ -99,7 +99,7 @@ TEST_F(QemuBackend, machine_start_suspend_sends_monitoring_event)
 TEST_F(QemuBackend, throws_when_starting_while_suspending)
 {
     NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
-    mp::QemuVirtualMachineFactory backend{&process_factory, data_dir.path()};
+    mp::QemuVirtualMachineFactory backend{data_dir.path()};
 
     auto machine = backend.create_virtual_machine(default_description, mock_monitor);
 
@@ -111,7 +111,7 @@ TEST_F(QemuBackend, throws_when_starting_while_suspending)
 TEST_F(QemuBackend, machine_unknown_state_properly_shuts_down)
 {
     NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
-    mp::QemuVirtualMachineFactory backend{&process_factory, data_dir.path()};
+    mp::QemuVirtualMachineFactory backend{data_dir.path()};
 
     auto machine = backend.create_virtual_machine(default_description, mock_monitor);
 
@@ -128,27 +128,27 @@ TEST_F(QemuBackend, machine_unknown_state_properly_shuts_down)
     EXPECT_THAT(machine->current_state(), Eq(mp::VirtualMachine::State::off));
 }
 
-TEST_F(QemuBackend, verify_dnsmasq_and_qemu_processes_created)
-{
-    NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
-    mpt::FakeLinuxProcessFactory factory;
-    mp::QemuVirtualMachineFactory backend{&factory, data_dir.path()};
+// TEST_F(QemuBackend, verify_dnsmasq_and_qemu_processes_created)
+//{
+//    NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
+//    // mpt::FakeLinuxProcessFactory factory;
+//    mp::QemuVirtualMachineFactory backend{data_dir.path()};
 
-    auto machine = backend.create_virtual_machine(default_description, mock_monitor);
+//    auto machine = backend.create_virtual_machine(default_description, mock_monitor);
 
-    ASSERT_EQ(factory.created_processes.size(), 2u);
-    EXPECT_EQ(factory.created_processes[0].program, "dnsmasq");
-    EXPECT_TRUE(factory.created_processes[1].program.startsWith("qemu-system-"));
-}
+//    ASSERT_EQ(factory.created_processes.size(), 2u);
+//    EXPECT_EQ(factory.created_processes[0].program, "dnsmasq");
+//    EXPECT_TRUE(factory.created_processes[1].program.startsWith("qemu-system-"));
+//}
 
-TEST_F(QemuBackend, verify_qemu_arguments)
-{
-    NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
-    mpt::FakeLinuxProcessFactory factory;
-    mp::QemuVirtualMachineFactory backend{&factory, data_dir.path()};
+// TEST_F(QemuBackend, verify_qemu_arguments)
+//{
+//    NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
+//    // mpt::FakeLinuxProcessFactory factory;
+//    mp::QemuVirtualMachineFactory backend{data_dir.path()};
 
-    auto machine = backend.create_virtual_machine(default_description, mock_monitor);
+//    auto machine = backend.create_virtual_machine(default_description, mock_monitor);
 
-    ASSERT_EQ(factory.created_processes.size(), 2u);
-    EXPECT_TRUE(factory.created_processes[1].arguments.contains("virtio-net-pci,netdev=hostnet0,id=net0,mac="));
-}
+//    ASSERT_EQ(factory.created_processes.size(), 2u);
+//    EXPECT_TRUE(factory.created_processes[1].arguments.contains("virtio-net-pci,netdev=hostnet0,id=net0,mac="));
+//}

--- a/tests/test_qemu_backend.cpp
+++ b/tests/test_qemu_backend.cpp
@@ -17,7 +17,6 @@
 
 #include <src/platform/backends/qemu/qemu_virtual_machine_factory.h>
 
-#include "mock_process_factory.h"
 #include "mock_status_monitor.h"
 #include "stub_process_factory.h"
 #include "stub_ssh_key_provider.h"

--- a/tests/test_qemu_backend.cpp
+++ b/tests/test_qemu_backend.cpp
@@ -16,10 +16,10 @@
  */
 
 #include <src/platform/backends/qemu/qemu_virtual_machine_factory.h>
-#include <src/platform/backends/shared/linux/process_factory.h>
 
-#include "fake_linux_process_factory.h"
+#include "mock_process_factory.h"
 #include "mock_status_monitor.h"
+#include "stub_process_factory.h"
 #include "stub_ssh_key_provider.h"
 #include "stub_status_monitor.h"
 #include "temp_dir.h"
@@ -39,7 +39,6 @@ struct QemuBackend : public mpt::TestWithMockedBinPath
 {
     mpt::TempFile dummy_image;
     mpt::TempFile dummy_cloud_init_iso;
-    // mp::ProcessFactory process_factory; // want to launch actual processes
     mp::VirtualMachineDescription default_description{2,
                                                       mp::MemorySize{"3M"},
                                                       mp::MemorySize{}, // not used
@@ -128,27 +127,37 @@ TEST_F(QemuBackend, machine_unknown_state_properly_shuts_down)
     EXPECT_THAT(machine->current_state(), Eq(mp::VirtualMachine::State::off));
 }
 
-// TEST_F(QemuBackend, verify_dnsmasq_and_qemu_processes_created)
-//{
-//    NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
-//    // mpt::FakeLinuxProcessFactory factory;
-//    mp::QemuVirtualMachineFactory backend{data_dir.path()};
+TEST_F(QemuBackend, verify_dnsmasq_qemuimg_and_qemu_processes_created)
+{
+    NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
+    auto factory = mpt::StubProcessFactory::Inject();
+    mp::QemuVirtualMachineFactory backend{data_dir.path()};
 
-//    auto machine = backend.create_virtual_machine(default_description, mock_monitor);
+    auto machine = backend.create_virtual_machine(default_description, mock_monitor);
 
-//    ASSERT_EQ(factory.created_processes.size(), 2u);
-//    EXPECT_EQ(factory.created_processes[0].program, "dnsmasq");
-//    EXPECT_TRUE(factory.created_processes[1].program.startsWith("qemu-system-"));
-//}
+    ASSERT_EQ(factory->process_list().size(), 2u);
+    EXPECT_EQ(factory->process_list()[0].command, "dnsmasq");
+    EXPECT_TRUE(factory->process_list()[1].command.startsWith("qemu-system-"));
+}
 
-// TEST_F(QemuBackend, verify_qemu_arguments)
-//{
-//    NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
-//    // mpt::FakeLinuxProcessFactory factory;
-//    mp::QemuVirtualMachineFactory backend{data_dir.path()};
+TEST_F(QemuBackend, verify_qemu_arguments)
+{
+    NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
+    auto factory = mpt::StubProcessFactory::Inject();
+    mp::QemuVirtualMachineFactory backend{data_dir.path()};
 
-//    auto machine = backend.create_virtual_machine(default_description, mock_monitor);
+    auto machine = backend.create_virtual_machine(default_description, mock_monitor);
 
-//    ASSERT_EQ(factory.created_processes.size(), 2u);
-//    EXPECT_TRUE(factory.created_processes[1].arguments.contains("virtio-net-pci,netdev=hostnet0,id=net0,mac="));
-//}
+    ASSERT_EQ(factory->process_list().size(), 2u);
+    auto qemu = factory->process_list()[1];
+    EXPECT_TRUE(qemu.arguments.contains("--enable-kvm"));
+    EXPECT_TRUE(qemu.arguments.contains("virtio-net-pci,netdev=hostnet0,id=net0,mac="));
+    EXPECT_TRUE(qemu.arguments.contains("-nographic"));
+    EXPECT_TRUE(qemu.arguments.contains("-serial"));
+    EXPECT_TRUE(qemu.arguments.contains("-qmp"));
+    EXPECT_TRUE(qemu.arguments.contains("stdio"));
+    EXPECT_TRUE(qemu.arguments.contains("-cpu"));
+    EXPECT_TRUE(qemu.arguments.contains("host"));
+    EXPECT_TRUE(qemu.arguments.contains("-chardev"));
+    EXPECT_TRUE(qemu.arguments.contains("null,id=char0"));
+}


### PR DESCRIPTION
We need to launch Processes all around our codebase. Piping a ProcessFactory pointer around to all those location is tedious. Instead I was inspired by @ricab 's Singleton work, and wish to propose this.

We'll be able to use this to launch a Process as conveniently as we do with QProcess, but it will be fully mockable & testable.

I've added StubProcessFactory to enhance our testing, as it keeps track of each process we launch, so we can check their arguments (just applied to Qemu backend tests currently, will do others next). I'll have a Mock ready shortly in a followup PR.