### PR TITLE
snap: Remove the libvirt plug since we are using classic confinement

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,7 +27,6 @@ apps:
       XDG_CONFIG_HOME: &daemon-config $SNAP_DATA/config
       DAEMON_CONFIG_HOME: *daemon-config # temporary
     daemon: simple
-    plugs: [libvirt]
   multipass:
     environment:
       <<: &client-environment


### PR DESCRIPTION
It's considered an error to define a plug while using classic confinement.