### PR TITLE
 Qemu: enable image compaction/garbage collection

### DIFF
--- a/src/platform/backends/libvirt/libvirt_virtual_machine.cpp
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine.cpp
@@ -146,7 +146,7 @@ auto generate_xml_config_for(const mp::VirtualMachineDescription& desc, const st
         "  <devices>\n"
         "    <emulator>{}</emulator>\n"
         "    <disk type=\'file\' device=\'disk\'>\n"
-        "      <driver name=\'qemu\' type=\'qcow2\'/>\n"
+        "      <driver name=\'qemu\' type=\'qcow2\' discard=\'unmap\'/>\n"
         "      <source file=\'{}\'/>\n"
         "      <backingStore/>\n"
         "      <target dev=\'vda\' bus=\'virtio\'/>\n"

--- a/src/platform/backends/qemu/qemu_vm_process_spec.cpp
+++ b/src/platform/backends/qemu/qemu_vm_process_spec.cpp
@@ -123,7 +123,11 @@ QStringList mp::QemuVMProcessSpec::arguments() const
 
         args << "--enable-kvm";
         // The VM image itself
-        args << "-hda" << desc.image.image_path;
+        args << "-device"
+             << "virtio-scsi-pci,id=scsi0"
+             << "-drive" << QString("file=%1,if=none,format=qcow2,discard=unmap,id=hda").arg(desc.image.image_path)
+             << "-device"
+             << "scsi-hd,drive=hda,bus=scsi0.0";
         // Number of cpu cores
         args << "-smp" << QString::number(desc.num_cores);
         // Memory to use for VM

--- a/tests/test_qemu_backend.cpp
+++ b/tests/test_qemu_backend.cpp
@@ -37,6 +37,13 @@ namespace mp = multipass;
 namespace mpt = multipass::test;
 using namespace testing;
 
+namespace
+{ // copied from QemuVirtualMachine implementation
+constexpr auto suspend_tag = "suspend";
+constexpr auto vm_command_version_tag = "command_version";
+
+} // namespace
+
 struct QemuBackend : public mpt::TestWithMockedBinPath
 {
     mpt::TempFile dummy_image;
@@ -50,6 +57,14 @@ struct QemuBackend : public mpt::TestWithMockedBinPath
                                                       {dummy_image.name(), "", "", "", "", "", "", {}},
                                                       dummy_cloud_init_iso.name()};
     mpt::TempDir data_dir;
+
+    mpt::MockProcessFactory::Callback qemu_img_snapshot_returns_true = [](mpt::MockProcess* process) {
+        // Have "qemu-img snapshot" return a string with the suspend tag in it
+        if (process->program().contains("qemu-img") && process->arguments().contains("snapshot"))
+        {
+            ON_CALL(*process, run_and_return_output(_)).WillByDefault(Return(suspend_tag));
+        }
+    };
 };
 
 TEST_F(QemuBackend, creates_in_off_state)
@@ -143,7 +158,7 @@ TEST_F(QemuBackend, verify_dnsmasq_qemuimg_and_qemu_processes_created)
     EXPECT_TRUE(factory->process_list()[2].command.startsWith("qemu-system-"));
 }
 
-TEST_F(QemuBackend, verify_qemu_arguments)
+TEST_F(QemuBackend, verify_some_common_qemu_arguments)
 {
     NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
     auto factory = mpt::StubProcessFactory::Inject();
@@ -154,7 +169,6 @@ TEST_F(QemuBackend, verify_qemu_arguments)
     ASSERT_EQ(factory->process_list().size(), 3u);
     auto qemu = factory->process_list()[2];
     EXPECT_TRUE(qemu.arguments.contains("--enable-kvm"));
-    EXPECT_TRUE(qemu.arguments.contains("-hda"));
     EXPECT_TRUE(qemu.arguments.contains("virtio-net-pci,netdev=hostnet0,id=net0,mac="));
     EXPECT_TRUE(qemu.arguments.contains("-nographic"));
     EXPECT_TRUE(qemu.arguments.contains("-serial"));
@@ -168,19 +182,10 @@ TEST_F(QemuBackend, verify_qemu_arguments)
 
 TEST_F(QemuBackend, verify_qemu_arguments_when_resuming_suspend_image)
 {
-    constexpr auto suspend_tag = "suspend";
     constexpr auto default_machine_type = "pc-i440fx-xenial";
 
-    mpt::MockProcessFactory::Callback callback = [](mpt::MockProcess* process) {
-        // Have "qemu-img snapshot" return a string with the suspend tag in it
-        if (process->program().contains("qemu-img") && process->arguments().contains("snapshot"))
-        {
-            ON_CALL(*process, run_and_return_output(_)).WillByDefault(Return(suspend_tag));
-        }
-    };
-
     auto factory = mpt::MockProcessFactory::Inject();
-    factory->register_callback(callback);
+    factory->register_callback(qemu_img_snapshot_returns_true);
     NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
 
     mp::QemuVirtualMachineFactory backend{data_dir.path()};
@@ -198,18 +203,10 @@ TEST_F(QemuBackend, verify_qemu_arguments_when_resuming_suspend_image)
 
 TEST_F(QemuBackend, verify_qemu_arguments_when_resuming_suspend_image_uses_metadata)
 {
-    constexpr auto suspend_tag = "suspend";
     constexpr auto machine_type = "k0mPuT0R";
 
-    mpt::MockProcessFactory::Callback callback = [](mpt::MockProcess* process) {
-        if (process->program().contains("qemu-img") && process->arguments().contains("snapshot"))
-        {
-            ON_CALL(*process, run_and_return_output(_)).WillByDefault(Return(suspend_tag));
-        }
-    };
-
     auto factory = mpt::MockProcessFactory::Inject();
-    factory->register_callback(callback);
+    factory->register_callback(qemu_img_snapshot_returns_true);
     NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
 
     EXPECT_CALL(mock_monitor, retrieve_metadata_for(_)).WillOnce(Return(QJsonObject({{"machine_type", machine_type}})));
@@ -225,19 +222,10 @@ TEST_F(QemuBackend, verify_qemu_arguments_when_resuming_suspend_image_uses_metad
     EXPECT_TRUE(qemu.arguments.contains(machine_type));
 }
 
-TEST_F(QemuBackend, verify_qemu_arguments_when_resuming_suspend_image_using_cdrom_key)
+TEST_F(QemuBackend, verify_qemu_command_version_when_resuming_suspend_image_using_cdrom_key)
 {
-    constexpr auto suspend_tag = "suspend";
-
-    mpt::MockProcessFactory::Callback callback = [](mpt::MockProcess* process) {
-        if (process->program().contains("qemu-img") && process->arguments().contains("snapshot"))
-        {
-            EXPECT_CALL(*process, run_and_return_output(_)).WillOnce(Return(suspend_tag));
-        }
-    };
-
     auto factory = mpt::MockProcessFactory::Inject();
-    factory->register_callback(callback);
+    factory->register_callback(qemu_img_snapshot_returns_true);
     NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
 
     EXPECT_CALL(mock_monitor, retrieve_metadata_for(_)).WillOnce(Return(QJsonObject({{"use_cdrom", true}})));

--- a/tests/test_qemu_vm_process_spec.cpp
+++ b/tests/test_qemu_vm_process_spec.cpp
@@ -40,8 +40,12 @@ TEST_F(TestQemuVMProcessSpec, default_arguments_correct)
     mp::QemuVMProcessSpec spec(desc, tap_device_name, mp::nullopt);
 
     EXPECT_EQ(spec.arguments(), QStringList({"--enable-kvm",
-                                             "-hda",
-                                             "/path/to/image",
+                                             "-device",
+                                             "virtio-scsi-pci,id=scsi0",
+                                             "-drive",
+                                             "file=/path/to/image,if=none,format=qcow2,discard=unmap,id=hda",
+                                             "-device",
+                                             "scsi-hd,drive=hda,bus=scsi0.0",
                                              "-smp",
                                              "2",
                                              "-m",


### PR DESCRIPTION
This adjusts the Qemu command to enable Qemu's image "discard=unmap" feature, which causes the disk image to shrink when blocks are trimmed by the VM kernel.

A way to see this in action is to monitor the disk image size, while running these commands in the VM:

    dd if=/dev/zero of=bigfile bs=1M count=1024

which will increase its size, and then

    rm bigfile
    sudo fstrim -v /

which should cause it to shrink again.