### PR TITLE
libssh: upgrading to the latest from their stable-0.9 branch

### DIFF
--- a/3rd-party/libssh/CMakeLists.txt
+++ b/3rd-party/libssh/CMakeLists.txt
@@ -33,6 +33,17 @@ set(LIBSSH_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libssh/include)
 set(LIB_INSTALL_DIR lib)
 set(BIN_INSTALL_DIR bin)
 
+# Since the main CMake file is bypassed, we have to specifically
+# set some required options from libssh/DefineOptions.cmake
+set(GLOBAL_BIND_CONFIG "/etc/ssh/libssh_server_config")
+set(GLOBAL_CLIENT_CONFIG "/etc/ssh/ssh_config")
+
+# libssh uses the EVP_PKEY_base_id() function from OpenSSL to
+# determine the type of key in use. This maps to EVP_PKEY_id()
+# in BoringSSL. Using sed to swap in the proper function name.
+execute_process(COMMAND "sed" "-i" "s/base_id/id/g" "libssh/src/pki_crypto.c"
+	WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+
 include_directories(${LIBSSH_INCLUDE_DIR})
 include_directories(${OPENSSL_INCLUDE_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/libssh)


### PR DESCRIPTION
The current hypothesis for the cause of issue #772 is a bug in libssh. It manifests as a hung ssh connection, even after the process spawned by ssh has finished. We get stuck in this loop:

```
while (ssh_channel_is_open(channel.get()) && !ssh_channel_is_eof(channel.get()))
{
  // ...
}
```

We could get stuck there if the ssh channel mishandles an EOF. Looking at the changes to libssh from what we have to the latest stable-0.9 branch, there are at least a few directly related to EOF handling:

```
multipass/3rd-party/libssh/libssh $ git log e42a423a247c8c9f0bd58d32a8b80c522f7b43f6..origin/stable-0.9 --oneline | grep EOF
95ab5f0d channel: Don't send EOF on channel more than once
9340a0af connector: Stop socket-to-channel EOF flooding
```

There have been lots of other bug fixes and improvements in the stable-0.9 branch that are probably worth bringing in. Since upgrading, I have been unable to reproduce #772.