### PR TITLE
Fix set tests

### DIFF
--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -1451,10 +1451,14 @@ TEST_F(Client, set_cmd_falls_through_instances_when_another_driver)
     aux_set_cmd_rejects_bad_val(mp::driver_key, "other");
 }
 
-TEST_F(Client, set_cmd_fails_when_grpc_problem)
+TEST_F(Client, set_cmd_fails_when_needs_daemon_and_grpc_problem)
 {
-    EXPECT_CALL(mock_daemon, list(_, _, _)).WillOnce(Return(grpc::Status{grpc::StatusCode::ABORTED, "msg"}));
-    EXPECT_THAT(send_command({"set", keyval_arg(mp::driver_key, "libvirt")}), Eq(mp::ReturnCode::CommandFail));
+    const auto driver = "libvirt";
+    if (mp::platform::is_backend_supported(driver))
+    {
+        EXPECT_CALL(mock_daemon, list(_, _, _)).WillOnce(Return(grpc::Status{grpc::StatusCode::ABORTED, "msg"}));
+        EXPECT_THAT(send_command({"set", keyval_arg(mp::driver_key, driver)}), Eq(mp::ReturnCode::CommandFail));
+    }
 }
 
 struct TestSetDriverWithInstances

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -25,6 +25,7 @@
 #include <multipass/constants.h>
 #include <multipass/exceptions/settings_exceptions.h>
 #include <multipass/logging/log.h>
+#include <multipass/platform.h>
 #include <src/client/cli/client.h>
 #include <src/daemon/daemon_rpc.h>
 
@@ -1462,22 +1463,28 @@ struct TestSetDriverWithInstances
 {
 };
 
-const std::vector<std::pair<std::vector<mp::InstanceStatus_Status>, mp::ReturnCode>> set_driver_expected{
-    {{}, mp::ReturnCode::Ok},
-    {{mp::InstanceStatus::STOPPED}, mp::ReturnCode::Ok},
-    {{mp::InstanceStatus::STOPPED, mp::InstanceStatus::STOPPED}, mp::ReturnCode::Ok},
-    {{mp::InstanceStatus::RUNNING}, mp::ReturnCode::CommandFail},
-    {{mp::InstanceStatus::STARTING}, mp::ReturnCode::CommandFail},
-    {{mp::InstanceStatus::RESTARTING}, mp::ReturnCode::CommandFail},
-    {{mp::InstanceStatus::DELETED}, mp::ReturnCode::CommandFail},
-    {{mp::InstanceStatus::DELAYED_SHUTDOWN}, mp::ReturnCode::CommandFail},
-    {{mp::InstanceStatus::SUSPENDING}, mp::ReturnCode::CommandFail},
-    {{mp::InstanceStatus::SUSPENDED}, mp::ReturnCode::CommandFail},
-    {{mp::InstanceStatus::UNKNOWN}, mp::ReturnCode::CommandFail},
-    {{mp::InstanceStatus::RUNNING, mp::InstanceStatus::STOPPED}, mp::ReturnCode::CommandFail},
-    {{mp::InstanceStatus::STARTING, mp::InstanceStatus::STOPPED}, mp::ReturnCode::CommandFail},
-    {{mp::InstanceStatus::SUSPENDED, mp::InstanceStatus::STOPPED}, mp::ReturnCode::CommandFail},
-};
+const std::vector<std::pair<std::vector<mp::InstanceStatus_Status>, mp::ReturnCode>> gen_driver_expected()
+{
+    if (mp::platform::is_backend_supported("libvirt"))
+        return {
+            {{}, mp::ReturnCode::Ok},
+            {{mp::InstanceStatus::STOPPED}, mp::ReturnCode::Ok},
+            {{mp::InstanceStatus::STOPPED, mp::InstanceStatus::STOPPED}, mp::ReturnCode::Ok},
+            {{mp::InstanceStatus::RUNNING}, mp::ReturnCode::CommandFail},
+            {{mp::InstanceStatus::STARTING}, mp::ReturnCode::CommandFail},
+            {{mp::InstanceStatus::RESTARTING}, mp::ReturnCode::CommandFail},
+            {{mp::InstanceStatus::DELETED}, mp::ReturnCode::CommandFail},
+            {{mp::InstanceStatus::DELAYED_SHUTDOWN}, mp::ReturnCode::CommandFail},
+            {{mp::InstanceStatus::SUSPENDING}, mp::ReturnCode::CommandFail},
+            {{mp::InstanceStatus::SUSPENDED}, mp::ReturnCode::CommandFail},
+            {{mp::InstanceStatus::UNKNOWN}, mp::ReturnCode::CommandFail},
+            {{mp::InstanceStatus::RUNNING, mp::InstanceStatus::STOPPED}, mp::ReturnCode::CommandFail},
+            {{mp::InstanceStatus::STARTING, mp::InstanceStatus::STOPPED}, mp::ReturnCode::CommandFail},
+            {{mp::InstanceStatus::SUSPENDED, mp::InstanceStatus::STOPPED}, mp::ReturnCode::CommandFail},
+        };
+    else
+        return {};
+}
 
 TEST_P(TestSetDriverWithInstances, inspects_instance_states)
 {
@@ -1485,7 +1492,7 @@ TEST_P(TestSetDriverWithInstances, inspects_instance_states)
     EXPECT_THAT(send_command({"set", keyval_arg(mp::driver_key, "libvirt")}), Eq(GetParam().second));
 }
 
-INSTANTIATE_TEST_SUITE_P(Client, TestSetDriverWithInstances, ValuesIn(set_driver_expected));
+INSTANTIATE_TEST_SUITE_P(Client, TestSetDriverWithInstances, ValuesIn(gen_driver_expected()));
 
 // general help tests
 TEST_F(Client, help_returns_ok_return_code)

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -1461,6 +1461,16 @@ TEST_F(Client, set_cmd_fails_when_needs_daemon_and_grpc_problem)
     }
 }
 
+TEST_F(Client, set_cmd_succeeds_when_daemon_not_around)
+{
+    const auto driver = "libvirt";
+    if (mp::platform::is_backend_supported(driver))
+    {
+        EXPECT_CALL(mock_daemon, list(_, _, _)).WillOnce(Return(grpc::Status{grpc::StatusCode::NOT_FOUND, "msg"}));
+        EXPECT_THAT(send_command({"set", keyval_arg(mp::driver_key, driver)}), Eq(mp::ReturnCode::Ok));
+    }
+}
+
 struct TestSetDriverWithInstances
     : Client,
       WithParamInterface<std::pair<std::vector<mp::InstanceStatus_Status>, mp::ReturnCode>>


### PR DESCRIPTION
This fixes new failures when moving to other platforms, on tests that rely on the qemu->libvirt switch specifics. It basically bypasses those tests when not applicable, changing names accordingly. It also adds a grpc-related test to complement the previous one.