### PR TITLE
Disable platform set tests

### DIFF
--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -1451,7 +1451,8 @@ TEST_F(Client, set_cmd_falls_through_instances_when_another_driver)
 }
 
 #ifdef MULTIPASS_PLATFORM_LINUX // These tests concern linux-specific behavior for qemu<->libvirt switching
-TEST_F(Client, set_cmd_fails_when_grpc_problem)
+
+TEST_F(Client, set_cmd_fails_driver_switch_when_needs_daemon_and_grpc_problem)
 {
     EXPECT_CALL(mock_daemon, list(_, _, _)).WillOnce(Return(grpc::Status{grpc::StatusCode::ABORTED, "msg"}));
     EXPECT_THAT(send_command({"set", keyval_arg(mp::driver_key, "libvirt")}), Eq(mp::ReturnCode::CommandFail));

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -1458,6 +1458,12 @@ TEST_F(Client, set_cmd_fails_driver_switch_when_needs_daemon_and_grpc_problem)
     EXPECT_THAT(send_command({"set", keyval_arg(mp::driver_key, "libvirt")}), Eq(mp::ReturnCode::CommandFail));
 }
 
+TEST_F(Client, set_cmd_succeeds_when_daemon_not_around)
+{
+    EXPECT_CALL(mock_daemon, list(_, _, _)).WillOnce(Return(grpc::Status{grpc::StatusCode::NOT_FOUND, "msg"}));
+    EXPECT_THAT(send_command({"set", keyval_arg(mp::driver_key, "libvirt")}), Eq(mp::ReturnCode::Ok));
+}
+
 struct TestSetDriverWithInstances
     : Client,
       WithParamInterface<std::pair<std::vector<mp::InstanceStatus_Status>, mp::ReturnCode>>

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -1450,6 +1450,7 @@ TEST_F(Client, set_cmd_falls_through_instances_when_another_driver)
     aux_set_cmd_rejects_bad_val(mp::driver_key, "other");
 }
 
+#ifdef MULTIPASS_PLATFORM_LINUX // These tests concern linux-specific behavior for qemu<->libvirt switching
 TEST_F(Client, set_cmd_fails_when_grpc_problem)
 {
     EXPECT_CALL(mock_daemon, list(_, _, _)).WillOnce(Return(grpc::Status{grpc::StatusCode::ABORTED, "msg"}));
@@ -1486,6 +1487,8 @@ TEST_P(TestSetDriverWithInstances, inspects_instance_states)
 }
 
 INSTANTIATE_TEST_SUITE_P(Client, TestSetDriverWithInstances, ValuesIn(set_driver_expected));
+
+#endif // MULTIPASS_PLATFORM_LINUX
 
 // general help tests
 TEST_F(Client, help_returns_ok_return_code)


### PR DESCRIPTION
This fixes new failures when moving to other platforms, on tests that rely on the qemu->libvirt switch specifics. It basically bypasses those tests when not applicable, changing names accordingly. It also adds a grpc-related test to complement the previous one.

This supersedes #914