### PR TITLE
ProcessFactory exit state improvements

### DIFF
--- a/include/multipass/process.h
+++ b/include/multipass/process.h
@@ -21,9 +21,29 @@
 #include <QProcessEnvironment>
 #include <QStringList>
 #include <memory>
+#include <multipass/optional.h>
 
 namespace multipass
 {
+
+struct ProcessExitState
+{
+    bool success() const
+    {
+        return !error && exit_code && exit_code.value() == 0;
+    }
+
+    multipass::optional<int> exit_code; // not set if FailedToStart. Can be set if success() is false
+
+    struct Error
+    {
+        QProcess::ProcessError state; // FailedToStart (file not found / resource error), Crashed,
+                                      // Timedout, ReadError, WriteError, UnknownError
+        QString message;
+    };
+
+    multipass::optional<Error> error;
+};
 
 class Process : public QObject
 {
@@ -51,16 +71,14 @@ public:
 
     virtual qint64 write(const QByteArray& data) = 0;
 
-    virtual bool run_and_return_status(const int timeout = 30000) = 0;
-    virtual QString run_and_return_output(const int timeout = 30000) = 0;
+    virtual const ProcessExitState run_and_return_exit_state(const int timeout = 30000) = 0;
 
 signals:
     void started();
-    void finished(int exitCode, QProcess::ExitStatus exit_status); // normal or crash
-    void error_occurred(QProcess::ProcessError error);             // not running, starting, running
-    void state_changed(QProcess::ProcessState state); // FailedToStart (file not found / resource error) Crashed,
-                                                      // Timedout, ReadError, WriteError, UnknownError
-
+    void finished(const ProcessExitState exit_state);
+    void state_changed(QProcess::ProcessState state);  // not running, starting, running
+    void error_occurred(QProcess::ProcessError error); // FailedToStart (file not found / resource error) Crashed,
+                                                       // Timedout, ReadError, WriteError, UnknownError
     void ready_read_standard_output();
     void ready_read_standard_error();
 };

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -141,7 +141,7 @@ auto hmc_to_qmp_json(const QString& command_line)
 bool instance_image_has_snapshot(const mp::Path& image_path)
 {
     auto process = mp::ProcessFactory::instance().create_process("qemu-img", QStringList{"snapshot", "-l", image_path});
-    auto exit_state = process->run_and_return_exit_state();
+    auto exit_state = process->execute();
     if (!exit_state.success())
     {
         throw std::runtime_error(fmt::format("Internal error: qemu-img failed ({}) with output: {}",
@@ -272,7 +272,7 @@ mp::QemuVirtualMachine::QemuVirtualMachine(const VirtualMachineDescription& desc
         }
         if (exit_state.error)
         {
-            mpl::log(mpl::Level::info, vm_name,
+            mpl::log(mpl::Level::error, vm_name,
                      fmt::format("process returned error {}: {}", exit_state.error->state, exit_state.error->message));
         }
 

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -141,7 +141,14 @@ auto hmc_to_qmp_json(const QString& command_line)
 bool instance_image_has_snapshot(const mp::Path& image_path)
 {
     auto process = mp::ProcessFactory::instance().create_process("qemu-img", QStringList{"snapshot", "-l", image_path});
-    auto output = process->run_and_return_output().split('\n');
+    auto exit_state = process->run_and_return_exit_state();
+    if (!exit_state.success())
+    {
+        throw std::runtime_error(fmt::format("Internal error: qemu-img failed ({}) with output: {}",
+                                             exit_state.error.value().message, process->read_all_standard_error()));
+    }
+
+    auto output = process->read_all_standard_output().split('\n');
 
     for (const auto& line : output)
     {
@@ -257,9 +264,18 @@ mp::QemuVirtualMachine::QemuVirtualMachine(const VirtualMachineDescription& desc
         }
     });
 
-    QObject::connect(vm_process.get(), &Process::finished, [this](int exitCode, QProcess::ExitStatus exitStatus) {
-        mpl::log(mpl::Level::info, vm_name,
-                 fmt::format("process finished with exit code {} ({})", exitCode, utils::qenum_to_string(exitStatus)));
+    QObject::connect(vm_process.get(), &Process::finished, [this](ProcessExitState exit_state) {
+        if (exit_state.exit_code)
+        {
+            mpl::log(mpl::Level::info, vm_name,
+                     fmt::format("process finished with exit code {}", exit_state.exit_code.value()));
+        }
+        if (exit_state.error)
+        {
+            mpl::log(mpl::Level::info, vm_name,
+                     fmt::format("process returned error {}: {}", exit_state.error->state, exit_state.error->message));
+        }
+
         if (update_shutdown_status || state == State::starting)
         {
             on_shutdown();

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -140,7 +140,7 @@ void mp::backend::resize_instance_image(const MemorySize& disk_space, const mp::
     auto qemuimg_spec = std::make_unique<mp::QemuImgProcessSpec>(QStringList{"resize", image_path, disk_size});
     auto qemuimg_process = mp::ProcessFactory::instance().create_process(std::move(qemuimg_spec));
 
-    auto exit_state = qemuimg_process->run_and_return_exit_state();
+    auto exit_state = qemuimg_process->execute();
     if (!exit_state.success())
     {
         throw std::runtime_error(fmt::format("Cannot resize instance image: qemu-img failed ({}) with output: {}",
@@ -158,7 +158,7 @@ mp::Path mp::backend::convert_to_qcow_if_necessary(const mp::Path& image_path)
     auto qemuimg_spec = std::make_unique<mp::QemuImgProcessSpec>(QStringList{"info", "--output=json", image_path});
     auto qemuimg_process = mp::ProcessFactory::instance().create_process(std::move(qemuimg_spec));
 
-    auto exit_state = qemuimg_process->run_and_return_exit_state();
+    auto exit_state = qemuimg_process->execute();
     if (!exit_state.success())
     {
         throw std::runtime_error(fmt::format("Cannot read image format: qemu-img failed ({}) with output: {}",
@@ -174,7 +174,7 @@ mp::Path mp::backend::convert_to_qcow_if_necessary(const mp::Path& image_path)
         qemuimg_spec = std::make_unique<mp::QemuImgProcessSpec>(
             QStringList{"convert", "-p", "-O", "qcow2", image_path, qcow2_path});
         qemuimg_process = mp::ProcessFactory::instance().create_process(std::move(qemuimg_spec));
-        exit_state = qemuimg_process->run_and_return_exit_state(-1);
+        exit_state = qemuimg_process->execute(-1);
 
         if (!exit_state.success())
         {

--- a/src/platform/backends/shared/linux/linux_process.cpp
+++ b/src/platform/backends/shared/linux/linux_process.cpp
@@ -34,7 +34,7 @@ mp::LinuxProcess::LinuxProcess(std::unique_ptr<mp::ProcessSpec>&& spec) : proces
                 {
                     exit_state.exit_code = exit_code;
                 }
-                else
+                else // crash
                 {
                     exit_state.error = mp::ProcessExitState::Error{process.error(), process.errorString()};
                 }
@@ -117,7 +117,7 @@ qint64 mp::LinuxProcess::write(const QByteArray& data)
     return process.write(data);
 }
 
-const mp::ProcessExitState mp::LinuxProcess::run_and_return_exit_state(const int timeout)
+const mp::ProcessExitState mp::LinuxProcess::execute(const int timeout)
 {
     mp::ProcessExitState exit_state;
     start();

--- a/src/platform/backends/shared/linux/linux_process.h
+++ b/src/platform/backends/shared/linux/linux_process.h
@@ -50,17 +50,13 @@ public:
 
     qint64 write(const QByteArray& data) override;
 
-    bool run_and_return_status(const int timeout = 30000) override;
-    QString run_and_return_output(const int timeout = 30000) override;
+    const ProcessExitState run_and_return_exit_state(const int timeout = 30000) override;
 
 protected:
     LinuxProcess(std::unique_ptr<ProcessSpec>&& spec);
     const std::unique_ptr<ProcessSpec> process_spec;
 
     QProcess process; // ease testing
-
-private:
-    void run_and_wait_until_finished(const int timeout);
 };
 
 } // namespace multipass

--- a/src/platform/backends/shared/linux/linux_process.h
+++ b/src/platform/backends/shared/linux/linux_process.h
@@ -50,7 +50,7 @@ public:
 
     qint64 write(const QByteArray& data) override;
 
-    const ProcessExitState run_and_return_exit_state(const int timeout = 30000) override;
+    const ProcessExitState execute(const int timeout = 30000) override;
 
 protected:
     LinuxProcess(std::unique_ptr<ProcessSpec>&& spec);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,15 @@ set_target_properties(dhcp_release
   RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/bin/mocks"
   RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin/mocks")
 
+add_executable(qemu-img
+  mock_qemuimg.cpp)
+
+set_target_properties(qemu-img
+  PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/mocks"
+  RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/bin/mocks"
+  RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin/mocks")
+
 list(APPEND CMOCK_TARGETS libvirt_backend_test)
 target_compile_definitions(libvirt_backend_test PRIVATE
     ${c_mock_defines})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ list(APPEND BACKEND_TESTS
   test_qemu_backend.cpp
   test_qemu_vm_process_spec.cpp
   test_dnsmasq_server.cpp
+  test_linux_process.cpp
   test_libvirt_backend.cpp
   test_with_mocked_bin_path.cpp)
 
@@ -68,6 +69,15 @@ add_executable(qemu-img
   mock_qemuimg.cpp)
 
 set_target_properties(qemu-img
+  PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/mocks"
+  RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/bin/mocks"
+  RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin/mocks")
+
+add_executable(mock_process
+  mock_process.cpp)
+
+set_target_properties(mock_process
   PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/mocks"
   RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/bin/mocks"

--- a/tests/mock_process.cpp
+++ b/tests/mock_process.cpp
@@ -1,0 +1,8 @@
+#include <cstdlib>
+#include <iostream>
+
+int main(int /*argc*/, char* argv[])
+{
+    // deliberately will crash if argument 1 missing
+    return atoi(argv[1]);
+}

--- a/tests/mock_process_factory.cpp
+++ b/tests/mock_process_factory.cpp
@@ -29,7 +29,7 @@ std::unique_ptr<mp::Process> mpt::MockProcessFactory::create_process(std::unique
         std::make_unique<mpt::MockProcess>(std::move(spec), const_cast<std::vector<ProcessInfo>&>(process_list));
     if (callback)
         callback.value()(process.get());
-    return std::move(process);
+    return process;
 }
 
 mpt::MockProcess::MockProcess(std::unique_ptr<mp::ProcessSpec>&& spec,
@@ -45,7 +45,7 @@ mpt::MockProcess::MockProcess(std::unique_ptr<mp::ProcessSpec>&& spec,
         emit finished(exit_state);
     }));
     ON_CALL(*this, running()).WillByDefault(Return(true));
-    ON_CALL(*this, run_and_return_exit_state(_)).WillByDefault(Return(success_exit_state));
+    ON_CALL(*this, execute(_)).WillByDefault(Return(success_exit_state));
 
     mpt::MockProcessFactory::ProcessInfo p{program(), arguments()};
     process_list.emplace_back(p);

--- a/tests/mock_process_factory.cpp
+++ b/tests/mock_process_factory.cpp
@@ -29,18 +29,23 @@ std::unique_ptr<mp::Process> mpt::MockProcessFactory::create_process(std::unique
         std::make_unique<mpt::MockProcess>(std::move(spec), const_cast<std::vector<ProcessInfo>&>(process_list));
     if (callback)
         callback.value()(process.get());
-    return process;
+    return std::move(process);
 }
 
 mpt::MockProcess::MockProcess(std::unique_ptr<mp::ProcessSpec>&& spec,
                               std::vector<mpt::MockProcessFactory::ProcessInfo>& process_list)
     : spec{std::move(spec)}
 {
+    success_exit_state.exit_code = 0;
+
     ON_CALL(*this, start()).WillByDefault(Invoke([this] { emit started(); }));
-    ON_CALL(*this, kill()).WillByDefault(Invoke([this] { emit finished(0, QProcess::NormalExit); }));
+    ON_CALL(*this, kill()).WillByDefault(Invoke([this] {
+        mp::ProcessExitState exit_state;
+        exit_state.exit_code = 0;
+        emit finished(exit_state);
+    }));
     ON_CALL(*this, running()).WillByDefault(Return(true));
-    ON_CALL(*this, run_and_return_status(_)).WillByDefault(Return(true));
-    ON_CALL(*this, run_and_return_output(_)).WillByDefault(Return(""));
+    ON_CALL(*this, run_and_return_exit_state(_)).WillByDefault(Return(success_exit_state));
 
     mpt::MockProcessFactory::ProcessInfo p{program(), arguments()};
     process_list.emplace_back(p);
@@ -103,15 +108,6 @@ bool mpt::MockProcess::wait_for_started(int)
 bool mpt::MockProcess::wait_for_finished(int)
 {
     return true;
-}
-
-QByteArray mpt::MockProcess::read_all_standard_output()
-{
-    return "";
-}
-QByteArray mpt::MockProcess::read_all_standard_error()
-{
-    return "";
 }
 
 qint64 mpt::MockProcess::write(const QByteArray&)

--- a/tests/mock_process_factory.h
+++ b/tests/mock_process_factory.h
@@ -76,7 +76,7 @@ public:
     MOCK_METHOD0(start, void());
     MOCK_METHOD0(kill, void());
     MOCK_CONST_METHOD0(running, bool());
-    MOCK_METHOD1(run_and_return_exit_state, const ProcessExitState(int));
+    MOCK_METHOD1(execute, const ProcessExitState(int));
 
     MockProcess(std::unique_ptr<ProcessSpec>&& spec, std::vector<MockProcessFactory::ProcessInfo>& process_list);
 

--- a/tests/mock_process_factory.h
+++ b/tests/mock_process_factory.h
@@ -76,8 +76,7 @@ public:
     MOCK_METHOD0(start, void());
     MOCK_METHOD0(kill, void());
     MOCK_CONST_METHOD0(running, bool());
-    MOCK_METHOD1(run_and_return_status, bool(int));
-    MOCK_METHOD1(run_and_return_output, QString(int));
+    MOCK_METHOD1(run_and_return_exit_state, const ProcessExitState(int));
 
     MockProcess(std::unique_ptr<ProcessSpec>&& spec, std::vector<MockProcessFactory::ProcessInfo>& process_list);
 
@@ -88,12 +87,13 @@ public:
 
     bool wait_for_started(int msecs = 30000) override;
     bool wait_for_finished(int msecs = 30000) override;
-    QByteArray read_all_standard_output() override;
-    QByteArray read_all_standard_error() override;
+    MOCK_METHOD0(read_all_standard_output, QByteArray());
+    MOCK_METHOD0(read_all_standard_error, QByteArray());
     qint64 write(const QByteArray& data) override;
 
 private:
     const std::unique_ptr<ProcessSpec> spec;
+    ProcessExitState success_exit_state;
 };
 } // namespace test
 } // namespace multipass

--- a/tests/mock_qemuimg.cpp
+++ b/tests/mock_qemuimg.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main()
+{
+    return 0;
+}

--- a/tests/stub_process_factory.cpp
+++ b/tests/stub_process_factory.cpp
@@ -57,7 +57,9 @@ public:
     }
     void kill() override
     {
-        emit finished(0, QProcess::NormalExit);
+        mp::ProcessExitState exit_state;
+        exit_state.exit_code = 0;
+        emit finished(exit_state);
     }
 
     bool wait_for_started(int msecs = 30000) override
@@ -88,13 +90,11 @@ public:
         return 0;
     }
 
-    bool run_and_return_status(const int timeout = 3000) override
+    const mp::ProcessExitState run_and_return_exit_state(const int /*timeout*/ = 3000) override
     {
-        return true;
-    }
-    QString run_and_return_output(const int timeout = 3000) override
-    {
-        return "";
+        mp::ProcessExitState exit_state;
+        exit_state.exit_code = 0;
+        return exit_state;
     }
 };
 } // namespace

--- a/tests/stub_process_factory.cpp
+++ b/tests/stub_process_factory.cpp
@@ -90,7 +90,7 @@ public:
         return 0;
     }
 
-    const mp::ProcessExitState run_and_return_exit_state(const int /*timeout*/ = 3000) override
+    const mp::ProcessExitState execute(const int /*timeout*/ = 3000) override
     {
         mp::ProcessExitState exit_state;
         exit_state.exit_code = 0;

--- a/tests/test_linux_process.cpp
+++ b/tests/test_linux_process.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <multipass/process.h>
+#include <src/platform/backends/shared/linux/process_factory.h>
+
+#include "test_with_mocked_bin_path.h"
+
+#include <gmock/gmock.h>
+
+namespace mp = multipass;
+namespace mpt = multipass::test;
+
+using namespace testing;
+
+struct LinuxProcessTest : public mpt::TestWithMockedBinPath
+{
+    const mp::ProcessFactory& process_factory = mp::ProcessFactory::instance();
+};
+
+TEST_F(LinuxProcessTest, execute_missing_command)
+{
+    auto process = process_factory.create_process("a_missing_command");
+    auto exit_state = process->execute();
+
+    EXPECT_FALSE(exit_state.success());
+    EXPECT_FALSE(exit_state.exit_code);
+
+    EXPECT_TRUE(exit_state.error);
+    EXPECT_EQ(QProcess::ProcessError::FailedToStart, exit_state.error->state);
+}
+
+TEST_F(LinuxProcessTest, execute_crashing_command)
+{
+    auto process = process_factory.create_process("mock_process");
+    auto exit_state = process->execute();
+
+    EXPECT_FALSE(exit_state.success());
+    EXPECT_FALSE(exit_state.exit_code);
+
+    EXPECT_TRUE(exit_state.error);
+    EXPECT_EQ(QProcess::ProcessError::Crashed, exit_state.error->state);
+}
+
+TEST_F(LinuxProcessTest, execute_good_command_with_positive_exit_code)
+{
+    const int exit_code = 7;
+    auto process = process_factory.create_process("mock_process", {QString::number(exit_code)});
+    auto exit_state = process->execute();
+
+    EXPECT_FALSE(exit_state.success());
+    EXPECT_TRUE(exit_state.exit_code);
+    EXPECT_EQ(exit_code, exit_state.exit_code.value());
+
+    EXPECT_FALSE(exit_state.error);
+}
+
+TEST_F(LinuxProcessTest, execute_good_command_with_zero_exit_code)
+{
+    const int exit_code = 0;
+    auto process = process_factory.create_process("mock_process", {QString::number(exit_code)});
+    auto exit_state = process->execute();
+
+    EXPECT_TRUE(exit_state.success());
+    EXPECT_TRUE(exit_state.exit_code);
+    EXPECT_EQ(exit_code, exit_state.exit_code.value());
+
+    EXPECT_FALSE(exit_state.error);
+}

--- a/tests/test_qemu_backend.cpp
+++ b/tests/test_qemu_backend.cpp
@@ -62,7 +62,10 @@ struct QemuBackend : public mpt::TestWithMockedBinPath
         // Have "qemu-img snapshot" return a string with the suspend tag in it
         if (process->program().contains("qemu-img") && process->arguments().contains("snapshot"))
         {
-            ON_CALL(*process, run_and_return_output(_)).WillByDefault(Return(suspend_tag));
+            mp::ProcessExitState exit_state;
+            exit_state.exit_code = 0;
+            ON_CALL(*process, run_and_return_exit_state(_)).WillByDefault(Return(exit_state));
+            ON_CALL(*process, read_all_standard_output()).WillByDefault(Return(suspend_tag));
         }
     };
 };
@@ -247,7 +250,10 @@ TEST_F(QemuBackend, verify_qemu_arguments_from_metadata_are_used)
     mpt::MockProcessFactory::Callback callback = [](mpt::MockProcess* process) {
         if (process->program().contains("qemu-img") && process->arguments().contains("snapshot"))
         {
-            EXPECT_CALL(*process, run_and_return_output(_)).WillOnce(Return(suspend_tag));
+            mp::ProcessExitState exit_state;
+            exit_state.exit_code = 0;
+            EXPECT_CALL(*process, run_and_return_exit_state(_)).WillOnce(Return(exit_state));
+            EXPECT_CALL(*process, read_all_standard_output()).WillOnce(Return(suspend_tag));
         }
     };
 

--- a/tests/test_qemu_backend.cpp
+++ b/tests/test_qemu_backend.cpp
@@ -64,7 +64,7 @@ struct QemuBackend : public mpt::TestWithMockedBinPath
         {
             mp::ProcessExitState exit_state;
             exit_state.exit_code = 0;
-            ON_CALL(*process, run_and_return_exit_state(_)).WillByDefault(Return(exit_state));
+            ON_CALL(*process, execute(_)).WillByDefault(Return(exit_state));
             ON_CALL(*process, read_all_standard_output()).WillByDefault(Return(suspend_tag));
         }
     };
@@ -252,7 +252,7 @@ TEST_F(QemuBackend, verify_qemu_arguments_from_metadata_are_used)
         {
             mp::ProcessExitState exit_state;
             exit_state.exit_code = 0;
-            EXPECT_CALL(*process, run_and_return_exit_state(_)).WillOnce(Return(exit_state));
+            EXPECT_CALL(*process, execute(_)).WillOnce(Return(exit_state));
             EXPECT_CALL(*process, read_all_standard_output()).WillOnce(Return(suspend_tag));
         }
     };


### PR DESCRIPTION
It's not perfect, but I think it improves typical Process use.

Most of the time we run a short-lived utility process and want to read either its exit code, or output, so the old API provided methods for each. But it's inflexible, as what if you want both exit code & output? And then, what if the utilty process fails? 

The goal here is to return an object that contains all the state that is of interest when a process completes (and if it completes inside the timeout), i.e. the exit code, and then any the error state info.

The process output can already be read from Process::read_all_standard_output/error, which can be called after ProcessExitState indicates success anyway.

I'm curious what you think. I'll admit does make a quick Process call a little more wordy, but I prefer that to throwing away possibly useful state.