### PR TITLE
Process - add API to fetch process state and close_write_channel

### DIFF
--- a/include/multipass/process.h
+++ b/include/multipass/process.h
@@ -47,6 +47,18 @@ struct ProcessState
     {
         return !error && exit_code && exit_code.value() == 0;
     }
+    QString failure_message() const
+    {
+        if (error)
+        {
+            return error->message;
+        }
+        if (exit_code && exit_code.value() != 0)
+        {
+            return QString("Process returned exit code: %1").arg(exit_code.value());
+        }
+        return QString();
+    }
 
     multipass::optional<int> exit_code; // only set if process stops successfully. Can be set even if success() is false
 

--- a/include/multipass/process.h
+++ b/include/multipass/process.h
@@ -74,8 +74,10 @@ public:
     virtual void start() = 0;
     virtual void kill() = 0;
 
-    virtual bool wait_for_started(int msecs = 30000) = 0;  // return false if process fails to start
-    virtual bool wait_for_finished(int msecs = 30000) = 0; // return false if wait times-out, or process never started
+    virtual multipass::optional<ProcessExitState>
+    wait_for_started(int msecs = 30000) = 0; // optional set if process fails to start
+    virtual const ProcessExitState
+    wait_for_finished(int msecs = 30000) = 0; // check ProcessExitState to see wait times-out, or process never started
 
     virtual bool running() const = 0;
 
@@ -83,6 +85,7 @@ public:
     virtual QByteArray read_all_standard_error() = 0;
 
     virtual qint64 write(const QByteArray& data) = 0;
+    virtual void close_write_channel() = 0;
 
     virtual const ProcessExitState execute(const int timeout = 30000) = 0;
 

--- a/include/multipass/process.h
+++ b/include/multipass/process.h
@@ -27,22 +27,23 @@ namespace multipass
 {
 
 /***
- * ProcessExitState - encapsulates info on an exited process
+ * ProcessState - encapsulates info on an process
  *
  * Possible states this encapsulates are:
- * +--------------------------------+---------+-----------+--------------------------+
- * |             state              | success | exit_code |          error           |
- * +--------------------------------+---------+-----------+--------------------------+
- * | normal exit (returns 0)        | true    | set       | N/A.                     |
- * | normal exit (returns non-zero) | false   | set       | N/A.                     |
- * | failed to start                | false   | N/A       | FailedToStart            |
- * | crash exit                     | false   | N/A       | Crashed                  |
- * | timeout                        | false   | N/A       | Timedout (still running) |
- * +--------------------------------+---------+-----------+--------------------------+
+ * +--------------------------------+------------------------+-----------+--------------------------+
+ * |             state              | completed_successfully | exit_code |          error           |
+ * +--------------------------------+------------------------+-----------+--------------------------+
+ * | running                        | false                  | N/A       | N/A.                     |
+ * | normal exit (returns 0)        | true                   | set       | N/A.                     |
+ * | normal exit (returns non-zero) | false                  | set       | N/A.                     |
+ * | failed to start                | false                  | N/A       | FailedToStart            |
+ * | crash exit                     | false                  | N/A       | Crashed                  |
+ * | timeout                        | false                  | N/A       | Timedout (still running) |
+ * +--------------------------------+------------------------+-----------+--------------------------+
  */
-struct ProcessExitState
+struct ProcessState
 {
-    bool success() const // if process stops successfully with exit code 0
+    bool completed_successfully() const // if process stopped successfully with exit code 0
     {
         return !error && exit_code && exit_code.value() == 0;
     }
@@ -74,12 +75,11 @@ public:
     virtual void start() = 0;
     virtual void kill() = 0;
 
-    virtual multipass::optional<ProcessExitState>
-    wait_for_started(int msecs = 30000) = 0; // optional set if process fails to start
-    virtual const ProcessExitState
-    wait_for_finished(int msecs = 30000) = 0; // check ProcessExitState to see wait times-out, or process never started
+    virtual bool wait_for_started(int msecs = 30000) = 0;
+    virtual bool wait_for_finished(int msecs = 30000) = 0;
 
     virtual bool running() const = 0;
+    virtual ProcessState process_state() const = 0;
 
     virtual QByteArray read_all_standard_output() = 0;
     virtual QByteArray read_all_standard_error() = 0;
@@ -87,11 +87,11 @@ public:
     virtual qint64 write(const QByteArray& data) = 0;
     virtual void close_write_channel() = 0;
 
-    virtual const ProcessExitState execute(const int timeout = 30000) = 0;
+    virtual ProcessState execute(const int timeout = 30000) = 0;
 
 signals:
     void started();
-    void finished(const ProcessExitState exit_state);
+    void finished(ProcessState process_state);
     void state_changed(QProcess::ProcessState state);  // not running, starting, running
     void error_occurred(QProcess::ProcessError error); // FailedToStart (file not found / resource error) Crashed,
                                                        // Timedout, ReadError, WriteError, UnknownError

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -145,7 +145,7 @@ bool instance_image_has_snapshot(const mp::Path& image_path)
     if (!process_state.completed_successfully())
     {
         throw std::runtime_error(fmt::format("Internal error: qemu-img failed ({}) with output: {}",
-                                             process_state.error.value().message, process->read_all_standard_error()));
+                                             process_state.failure_message(), process->read_all_standard_error()));
     }
 
     auto output = process->read_all_standard_output().split('\n');

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -141,11 +141,11 @@ auto hmc_to_qmp_json(const QString& command_line)
 bool instance_image_has_snapshot(const mp::Path& image_path)
 {
     auto process = mp::ProcessFactory::instance().create_process("qemu-img", QStringList{"snapshot", "-l", image_path});
-    auto exit_state = process->execute();
-    if (!exit_state.success())
+    auto process_state = process->execute();
+    if (!process_state.completed_successfully())
     {
         throw std::runtime_error(fmt::format("Internal error: qemu-img failed ({}) with output: {}",
-                                             exit_state.error.value().message, process->read_all_standard_error()));
+                                             process_state.error.value().message, process->read_all_standard_error()));
     }
 
     auto output = process->read_all_standard_output().split('\n');
@@ -264,16 +264,17 @@ mp::QemuVirtualMachine::QemuVirtualMachine(const VirtualMachineDescription& desc
         }
     });
 
-    QObject::connect(vm_process.get(), &Process::finished, [this](ProcessExitState exit_state) {
-        if (exit_state.exit_code)
+    QObject::connect(vm_process.get(), &Process::finished, [this](ProcessState process_state) {
+        if (process_state.exit_code)
         {
             mpl::log(mpl::Level::info, vm_name,
-                     fmt::format("process finished with exit code {}", exit_state.exit_code.value()));
+                     fmt::format("process finished with exit code {}", process_state.exit_code.value()));
         }
-        if (exit_state.error)
+        if (process_state.error)
         {
-            mpl::log(mpl::Level::error, vm_name,
-                     fmt::format("process returned error {}: {}", exit_state.error->state, exit_state.error->message));
+            mpl::log(
+                mpl::Level::error, vm_name,
+                fmt::format("process returned error {}: {}", process_state.error->state, process_state.error->message));
         }
 
         if (update_shutdown_status || state == State::starting)
@@ -318,23 +319,22 @@ void mp::QemuVirtualMachine::start()
     }
 
     vm_process->start();
-    auto start_failed = vm_process->wait_for_started();
-
-    if (start_failed)
+    if (!vm_process->wait_for_started())
     {
-        if (start_failed->error)
+        auto process_state = vm_process->process_state();
+        if (process_state.error)
         {
-            mpl::log(mpl::Level::error, vm_name, fmt::format("Qemu failed to start: {}", start_failed->error->message));
-            throw std::runtime_error(fmt::format("failed to start qemu instance: {}", start_failed->error->message));
+            mpl::log(mpl::Level::error, vm_name, fmt::format("Qemu failed to start: {}", process_state.error->message));
+            throw std::runtime_error(fmt::format("failed to start qemu instance: {}", process_state.error->message));
         }
-        else if (start_failed->exit_code)
+        else if (process_state.exit_code)
         {
             mpl::log(mpl::Level::error, vm_name,
                      fmt::format("Qemu quit unexpectedly with exit code {} and with output:\n{}",
-                                 start_failed->exit_code.value(), vm_process->read_all_standard_error()));
+                                 process_state.exit_code.value(), vm_process->read_all_standard_error()));
             throw std::runtime_error(
                 fmt::format("qemu quit unexpectedly with exit code {}, check logs for more details",
-                            start_failed->exit_code.value()));
+                            process_state.exit_code.value()));
         }
     }
 

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
@@ -286,7 +286,7 @@ QString mp::QemuVirtualMachineFactory::get_backend_version_string()
     auto version_re = QRegularExpression("^QEMU emulator version ([\\d\\.]+)");
     auto exit_state = process->execute();
 
-    if (exit_state.success())
+    if (exit_state.completed_successfully())
     {
         auto match = version_re.match(process->read_all_standard_output());
 

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -144,7 +144,7 @@ void mp::backend::resize_instance_image(const MemorySize& disk_space, const mp::
     if (!process_state.completed_successfully())
     {
         throw std::runtime_error(fmt::format("Cannot resize instance image: qemu-img failed ({}) with output: {}",
-                                             process_state.error.value().message,
+                                             process_state.failure_message(),
                                              qemuimg_process->read_all_standard_error()));
     }
 }
@@ -162,7 +162,7 @@ mp::Path mp::backend::convert_to_qcow_if_necessary(const mp::Path& image_path)
     if (!process_state.completed_successfully())
     {
         throw std::runtime_error(fmt::format("Cannot read image format: qemu-img failed ({}) with output: {}",
-                                             process_state.error.value().message,
+                                             process_state.failure_message(),
                                              qemuimg_process->read_all_standard_error()));
     }
 
@@ -179,7 +179,7 @@ mp::Path mp::backend::convert_to_qcow_if_necessary(const mp::Path& image_path)
         if (!process_state.completed_successfully())
         {
             throw std::runtime_error(fmt::format("Failed to convert image format: qemu-img failed ({}) with output: {}",
-                                                 process_state.error.value().message,
+                                                 process_state.failure_message(),
                                                  qemuimg_process->read_all_standard_error()));
         }
         return qcow2_path;

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -140,11 +140,11 @@ void mp::backend::resize_instance_image(const MemorySize& disk_space, const mp::
     auto qemuimg_spec = std::make_unique<mp::QemuImgProcessSpec>(QStringList{"resize", image_path, disk_size});
     auto qemuimg_process = mp::ProcessFactory::instance().create_process(std::move(qemuimg_spec));
 
-    auto exit_state = qemuimg_process->execute();
-    if (!exit_state.success())
+    auto process_state = qemuimg_process->execute();
+    if (!process_state.completed_successfully())
     {
         throw std::runtime_error(fmt::format("Cannot resize instance image: qemu-img failed ({}) with output: {}",
-                                             exit_state.error.value().message,
+                                             process_state.error.value().message,
                                              qemuimg_process->read_all_standard_error()));
     }
 }
@@ -158,11 +158,11 @@ mp::Path mp::backend::convert_to_qcow_if_necessary(const mp::Path& image_path)
     auto qemuimg_spec = std::make_unique<mp::QemuImgProcessSpec>(QStringList{"info", "--output=json", image_path});
     auto qemuimg_process = mp::ProcessFactory::instance().create_process(std::move(qemuimg_spec));
 
-    auto exit_state = qemuimg_process->execute();
-    if (!exit_state.success())
+    auto process_state = qemuimg_process->execute();
+    if (!process_state.completed_successfully())
     {
         throw std::runtime_error(fmt::format("Cannot read image format: qemu-img failed ({}) with output: {}",
-                                             exit_state.error.value().message,
+                                             process_state.error.value().message,
                                              qemuimg_process->read_all_standard_error()));
     }
 
@@ -174,12 +174,12 @@ mp::Path mp::backend::convert_to_qcow_if_necessary(const mp::Path& image_path)
         qemuimg_spec = std::make_unique<mp::QemuImgProcessSpec>(
             QStringList{"convert", "-p", "-O", "qcow2", image_path, qcow2_path});
         qemuimg_process = mp::ProcessFactory::instance().create_process(std::move(qemuimg_spec));
-        exit_state = qemuimg_process->execute(-1);
+        process_state = qemuimg_process->execute(-1);
 
-        if (!exit_state.success())
+        if (!process_state.completed_successfully())
         {
             throw std::runtime_error(fmt::format("Failed to convert image format: qemu-img failed ({}) with output: {}",
-                                                 exit_state.error.value().message,
+                                                 process_state.error.value().message,
                                                  qemuimg_process->read_all_standard_error()));
         }
         return qcow2_path;

--- a/src/platform/backends/shared/linux/linux_process.h
+++ b/src/platform/backends/shared/linux/linux_process.h
@@ -40,12 +40,11 @@ public:
     void start() override;
     void kill() override;
 
-    multipass::optional<ProcessExitState>
-    wait_for_started(int msecs = 30000) override; // optional set if process fails to start
-    const ProcessExitState
-    wait_for_finished(int msecs = 30000) override; // optional set if wait times-out, or process never started
+    bool wait_for_started(int msecs = 30000) override;
+    bool wait_for_finished(int msecs = 30000) override;
 
     bool running() const override;
+    ProcessState process_state() const override;
 
     QByteArray read_all_standard_output() override;
     QByteArray read_all_standard_error() override;
@@ -53,7 +52,7 @@ public:
     qint64 write(const QByteArray& data) override;
     void close_write_channel() override;
 
-    const ProcessExitState execute(const int timeout = 30000) override;
+    ProcessState execute(const int timeout = 30000) override;
 
 protected:
     LinuxProcess(std::unique_ptr<ProcessSpec>&& spec);

--- a/src/platform/backends/shared/linux/linux_process.h
+++ b/src/platform/backends/shared/linux/linux_process.h
@@ -40,8 +40,10 @@ public:
     void start() override;
     void kill() override;
 
-    bool wait_for_started(int msecs = 30000) override;  // return false if process fails to start
-    bool wait_for_finished(int msecs = 30000) override; // return false if wait times-out, or process never started
+    multipass::optional<ProcessExitState>
+    wait_for_started(int msecs = 30000) override; // optional set if process fails to start
+    const ProcessExitState
+    wait_for_finished(int msecs = 30000) override; // optional set if wait times-out, or process never started
 
     bool running() const override;
 
@@ -49,6 +51,7 @@ public:
     QByteArray read_all_standard_error() override;
 
     qint64 write(const QByteArray& data) override;
+    void close_write_channel() override;
 
     const ProcessExitState execute(const int timeout = 30000) override;
 

--- a/tests/mock_process.cpp
+++ b/tests/mock_process.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <cstdlib>
 #include <iostream>
 

--- a/tests/mock_process.cpp
+++ b/tests/mock_process.cpp
@@ -1,8 +1,31 @@
+#include <cassert>
 #include <cstdlib>
 #include <iostream>
 
-int main(int /*argc*/, char* argv[])
+int main(int argc, char* argv[])
 {
-    // deliberately will crash if argument 1 missing
+    if (argc == 1)
+    {
+        // deliberately will crash if argument 1 missing
+        assert(false);
+    }
+    // Exit immediately if only 1 argument
+    else if (argc == 2)
+    {
+        return atoi(argv[1]);
+    }
+
+    // If more than 1 argument, run until get EOF from input
+    std::string s;
+    std::getline(std::cin, s, '\0');
+
+    // Crash on demand
+    if (s == "crash")
+    {
+        assert(false);
+    }
+
+    // Print out what was supplied by stdin
+    std::cout << s;
     return atoi(argv[1]);
 }

--- a/tests/mock_process.cpp
+++ b/tests/mock_process.cpp
@@ -7,7 +7,7 @@ int main(int argc, char* argv[])
     if (argc == 1)
     {
         // deliberately will crash if argument 1 missing
-        assert(false);
+        abort();
     }
     // Exit immediately if only 1 argument
     else if (argc == 2)
@@ -22,7 +22,7 @@ int main(int argc, char* argv[])
     // Crash on demand
     if (s == "crash")
     {
-        assert(false);
+        abort();
     }
 
     // Print out what was supplied by stdin

--- a/tests/mock_process_factory.cpp
+++ b/tests/mock_process_factory.cpp
@@ -40,11 +40,12 @@ mpt::MockProcess::MockProcess(std::unique_ptr<mp::ProcessSpec>&& spec,
 
     ON_CALL(*this, start()).WillByDefault(Invoke([this] { emit started(); }));
     ON_CALL(*this, kill()).WillByDefault(Invoke([this] {
-        mp::ProcessExitState exit_state;
+        mp::ProcessState exit_state;
         exit_state.exit_code = 0;
         emit finished(exit_state);
     }));
     ON_CALL(*this, running()).WillByDefault(Return(true));
+    ON_CALL(*this, process_state()).WillByDefault(Return(success_exit_state));
     ON_CALL(*this, execute(_)).WillByDefault(Return(success_exit_state));
 
     mpt::MockProcessFactory::ProcessInfo p{program(), arguments()};
@@ -120,4 +121,8 @@ bool mpt::MockProcess::wait_for_finished(int)
 qint64 mpt::MockProcess::write(const QByteArray&)
 {
     return 0;
+}
+
+void mpt::MockProcess::close_write_channel()
+{
 }

--- a/tests/mock_process_factory.h
+++ b/tests/mock_process_factory.h
@@ -76,7 +76,8 @@ public:
     MOCK_METHOD0(start, void());
     MOCK_METHOD0(kill, void());
     MOCK_CONST_METHOD0(running, bool());
-    MOCK_METHOD1(execute, const ProcessExitState(int));
+    MOCK_CONST_METHOD0(process_state, ProcessState());
+    MOCK_METHOD1(execute, ProcessState(int));
 
     MockProcess(std::unique_ptr<ProcessSpec>&& spec, std::vector<MockProcessFactory::ProcessInfo>& process_list);
 
@@ -90,10 +91,11 @@ public:
     MOCK_METHOD0(read_all_standard_output, QByteArray());
     MOCK_METHOD0(read_all_standard_error, QByteArray());
     qint64 write(const QByteArray& data) override;
+    void close_write_channel() override;
 
 private:
     const std::unique_ptr<ProcessSpec> spec;
-    ProcessExitState success_exit_state;
+    ProcessState success_exit_state;
 };
 } // namespace test
 } // namespace multipass

--- a/tests/stub_process_factory.cpp
+++ b/tests/stub_process_factory.cpp
@@ -57,7 +57,7 @@ public:
     }
     void kill() override
     {
-        mp::ProcessExitState exit_state;
+        mp::ProcessState exit_state;
         exit_state.exit_code = 0;
         emit finished(exit_state);
     }
@@ -76,6 +76,11 @@ public:
         return true;
     }
 
+    mp::ProcessState process_state() const override
+    {
+        return mp::ProcessState();
+    }
+
     QByteArray read_all_standard_output() override
     {
         return "";
@@ -90,11 +95,15 @@ public:
         return 0;
     }
 
-    const mp::ProcessExitState execute(const int /*timeout*/ = 3000) override
+    void close_write_channel() override
     {
-        mp::ProcessExitState exit_state;
-        exit_state.exit_code = 0;
-        return exit_state;
+    }
+
+    mp::ProcessState execute(const int /*timeout*/ = 3000) override
+    {
+        mp::ProcessState process_state;
+        process_state.exit_code = 0;
+        return process_state;
     }
 };
 } // namespace

--- a/tests/test_linux_process.cpp
+++ b/tests/test_linux_process.cpp
@@ -65,6 +65,7 @@ TEST_F(LinuxProcessTest, execute_good_command_with_positive_exit_code)
     EXPECT_FALSE(process_state.completed_successfully());
     EXPECT_TRUE(process_state.exit_code);
     EXPECT_EQ(exit_code, process_state.exit_code.value());
+    EXPECT_EQ("Process returned exit code: 7", process_state.failure_message());
 
     EXPECT_FALSE(process_state.error);
 }
@@ -78,6 +79,7 @@ TEST_F(LinuxProcessTest, execute_good_command_with_zero_exit_code)
     EXPECT_TRUE(process_state.completed_successfully());
     EXPECT_TRUE(process_state.exit_code);
     EXPECT_EQ(exit_code, process_state.exit_code.value());
+    EXPECT_EQ(QString(), process_state.failure_message());
 
     EXPECT_FALSE(process_state.error);
 }

--- a/tests/test_qemu_backend.cpp
+++ b/tests/test_qemu_backend.cpp
@@ -283,7 +283,7 @@ TEST_F(QemuBackend, returns_version_string)
     mpt::MockProcessFactory::Callback callback = [](mpt::MockProcess* process) {
         if (process->program().contains("qemu-system-") && process->arguments().contains("--version"))
         {
-            mp::ProcessExitState exit_state;
+            mp::ProcessState exit_state;
             exit_state.exit_code = 0;
             EXPECT_CALL(*process, execute(_)).WillOnce(Return(exit_state));
             EXPECT_CALL(*process, read_all_standard_output()).WillOnce(Return(qemu_version_output));
@@ -305,7 +305,7 @@ TEST_F(QemuBackend, returns_version_string_when_failed_parsing)
     mpt::MockProcessFactory::Callback callback = [](mpt::MockProcess* process) {
         if (process->program().contains("qemu-system-") && process->arguments().contains("--version"))
         {
-            mp::ProcessExitState exit_state;
+            mp::ProcessState exit_state;
             exit_state.exit_code = 0;
             EXPECT_CALL(*process, execute(_)).WillOnce(Return(exit_state));
             EXPECT_CALL(*process, read_all_standard_output()).WillRepeatedly(Return(qemu_version_output));
@@ -325,7 +325,7 @@ TEST_F(QemuBackend, returns_version_string_when_errored)
     mpt::MockProcessFactory::Callback callback = [](mpt::MockProcess* process) {
         if (process->program().contains("qemu-system-") && process->arguments().contains("--version"))
         {
-            mp::ProcessExitState exit_state;
+            mp::ProcessState exit_state;
             exit_state.exit_code = 1;
             EXPECT_CALL(*process, execute(_)).WillOnce(Return(exit_state));
             EXPECT_CALL(*process, read_all_standard_output()).WillOnce(Return("Standard output\n"));
@@ -346,8 +346,8 @@ TEST_F(QemuBackend, returns_version_string_when_exec_failed)
     mpt::MockProcessFactory::Callback callback = [](mpt::MockProcess* process) {
         if (process->program().contains("qemu-system-") && process->arguments().contains("--version"))
         {
-            mp::ProcessExitState exit_state;
-            exit_state.error = mp::ProcessExitState::Error{QProcess::Crashed, "Error message"};
+            mp::ProcessState exit_state;
+            exit_state.error = mp::ProcessState::Error{QProcess::Crashed, "Error message"};
             EXPECT_CALL(*process, execute(_)).WillOnce(Return(exit_state));
             EXPECT_CALL(*process, read_all_standard_output()).Times(0);
         }

--- a/tests/test_qemu_backend.cpp
+++ b/tests/test_qemu_backend.cpp
@@ -62,7 +62,7 @@ struct QemuBackend : public mpt::TestWithMockedBinPath
         // Have "qemu-img snapshot" return a string with the suspend tag in it
         if (process->program().contains("qemu-img") && process->arguments().contains("snapshot"))
         {
-            mp::ProcessExitState exit_state;
+            mp::ProcessState exit_state;
             exit_state.exit_code = 0;
             ON_CALL(*process, execute(_)).WillByDefault(Return(exit_state));
             ON_CALL(*process, read_all_standard_output()).WillByDefault(Return(suspend_tag));
@@ -250,7 +250,7 @@ TEST_F(QemuBackend, verify_qemu_arguments_from_metadata_are_used)
     mpt::MockProcessFactory::Callback callback = [](mpt::MockProcess* process) {
         if (process->program().contains("qemu-img") && process->arguments().contains("snapshot"))
         {
-            mp::ProcessExitState exit_state;
+            mp::ProcessState exit_state;
             exit_state.exit_code = 0;
             EXPECT_CALL(*process, execute(_)).WillOnce(Return(exit_state));
             EXPECT_CALL(*process, read_all_standard_output()).WillOnce(Return(suspend_tag));


### PR DESCRIPTION
This renames ProcessExitState with ProcessState, and allows user to fetch process state from Process at any stage.



And quoting myself:
> The wait_for functions return false if the process exits unexpectedly, or the timeout hits. 

Not always true! wait_for_finished will return true if process crashes. wait_for_started return true after forking, so if the program doesn't exist, it doesn't notice.