### PR TITLE
delayed_shutdown: Shut down mounts before shutting down vm

### DIFF
--- a/include/multipass/delayed_shutdown_timer.h
+++ b/include/multipass/delayed_shutdown_timer.h
@@ -25,6 +25,7 @@
 #include <QTimer>
 
 #include <chrono>
+#include <functional>
 
 namespace multipass
 {
@@ -33,7 +34,9 @@ class DelayedShutdownTimer : public QObject
     Q_OBJECT
 
 public:
-    DelayedShutdownTimer(VirtualMachine* virtual_machine, optional<SSHSession>&& session);
+    using StopMounts = std::function<void(const std::string&)>;
+    DelayedShutdownTimer(VirtualMachine* virtual_machine, optional<SSHSession>&& session,
+                         const StopMounts& stop_mounts);
     ~DelayedShutdownTimer();
 
     void start(const std::chrono::milliseconds delay);
@@ -48,6 +51,7 @@ private:
     QTimer shutdown_timer;
     VirtualMachine* virtual_machine;
     optional<SSHSession> ssh_session;
+    const StopMounts stop_mounts;
     std::chrono::milliseconds delay;
     std::chrono::milliseconds time_remaining;
 };

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2060,8 +2060,8 @@ grpc::Status mp::Daemon::shutdown_vm(VirtualMachine& vm, const std::chrono::mill
                      fmt::format("Cannot open ssh session on \"{}\" shutdown: {}", name, e.what()));
         }
 
-        auto& shutdown_timer = delayed_shutdown_instances[name] =
-            std::make_unique<DelayedShutdownTimer>(&vm, std::move(session));
+        auto& shutdown_timer = delayed_shutdown_instances[name] = std::make_unique<DelayedShutdownTimer>(
+            &vm, std::move(session), std::bind(&Daemon::stop_mounts_for_instance, this, std::placeholders::_1));
 
         QObject::connect(shutdown_timer.get(), &DelayedShutdownTimer::finished,
                          [this, name]() { delayed_shutdown_instances.erase(name); });

--- a/src/daemon/delayed_shutdown_timer.cpp
+++ b/src/daemon/delayed_shutdown_timer.cpp
@@ -45,8 +45,9 @@ void write_shutdown_message(mp::optional<mp::SSHSession>& ssh_session, const std
 }
 } // namespace
 
-mp::DelayedShutdownTimer::DelayedShutdownTimer(VirtualMachine* virtual_machine, mp::optional<SSHSession>&& session)
-    : virtual_machine{virtual_machine}, ssh_session{std::move(session)}
+mp::DelayedShutdownTimer::DelayedShutdownTimer(VirtualMachine* virtual_machine, mp::optional<SSHSession>&& session,
+                                               const StopMounts& stop_mounts)
+    : virtual_machine{virtual_machine}, ssh_session{std::move(session)}, stop_mounts{stop_mounts}
 {
 }
 
@@ -120,6 +121,7 @@ std::chrono::seconds mp::DelayedShutdownTimer::get_time_remaining()
 
 void mp::DelayedShutdownTimer::shutdown_instance()
 {
+    stop_mounts(virtual_machine->vm_name);
     virtual_machine->shutdown();
     emit finished();
 }

--- a/tests/test_delayed_shutdown.cpp
+++ b/tests/test_delayed_shutdown.cpp
@@ -60,7 +60,7 @@ struct DelayedShutdown : public Test
 TEST_F(DelayedShutdown, emits_finished_after_timer_expires)
 {
     mpt::Signal finished;
-    mp::DelayedShutdownTimer delayed_shutdown_timer{vm.get(), std::move(session)};
+    mp::DelayedShutdownTimer delayed_shutdown_timer{vm.get(), std::move(session), [](const std::string&) {}};
 
     QObject::connect(&delayed_shutdown_timer, &mp::DelayedShutdownTimer::finished, [this, &finished] {
         loop.quit();
@@ -77,7 +77,7 @@ TEST_F(DelayedShutdown, emits_finished_after_timer_expires)
 TEST_F(DelayedShutdown, emits_finished_with_no_timer)
 {
     mpt::Signal finished;
-    mp::DelayedShutdownTimer delayed_shutdown_timer{vm.get(), std::move(session)};
+    mp::DelayedShutdownTimer delayed_shutdown_timer{vm.get(), std::move(session), [](const std::string&) {}};
 
     QObject::connect(&delayed_shutdown_timer, &mp::DelayedShutdownTimer::finished, [&finished] { finished.signal(); });
 
@@ -103,7 +103,7 @@ TEST_F(DelayedShutdown, vm_state_delayed_shutdown_when_timer_running)
     REPLACE(ssh_event_dopoll, event_dopoll);
 
     EXPECT_TRUE(vm->state == mp::VirtualMachine::State::running);
-    mp::DelayedShutdownTimer delayed_shutdown_timer{vm.get(), std::move(session)};
+    mp::DelayedShutdownTimer delayed_shutdown_timer{vm.get(), std::move(session), [](const std::string&) {}};
     delayed_shutdown_timer.start(std::chrono::milliseconds(1));
 
     EXPECT_TRUE(vm->state == mp::VirtualMachine::State::delayed_shutdown);
@@ -126,7 +126,7 @@ TEST_F(DelayedShutdown, vm_state_running_after_cancel)
     REPLACE(ssh_event_dopoll, event_dopoll);
 
     {
-        mp::DelayedShutdownTimer delayed_shutdown_timer{vm.get(), std::move(session)};
+        mp::DelayedShutdownTimer delayed_shutdown_timer{vm.get(), std::move(session), [](const std::string&) {}};
         delayed_shutdown_timer.start(std::chrono::milliseconds(1));
         EXPECT_TRUE(vm->state == mp::VirtualMachine::State::delayed_shutdown);
     }


### PR DESCRIPTION
Pass in the function to stop mounts before shutting down the instance.

Fixes #964