### PR TITLE
gui: Put the petenv instance at the top of the tray icon menu

### DIFF
--- a/src/client/gui/gui_cmd.cpp
+++ b/src/client/gui/gui_cmd.cpp
@@ -310,33 +310,34 @@ void cmd::GuiCmd::handle_petenv_instance(const google::protobuf::RepeatedPtrFiel
 
 void cmd::GuiCmd::set_petenv_actions_for(const mp::InstanceStatus& state)
 {
-    const auto can_stop_states = {InstanceStatus::UNKNOWN, InstanceStatus::RUNNING, InstanceStatus::DELAYED_SHUTDOWN};
-    const auto can_start_states = {InstanceStatus::STOPPED, InstanceStatus::SUSPENDED};
-
-    if (std::find(can_stop_states.begin(), can_stop_states.end(), state.status()) != can_stop_states.end())
+    switch (state.status())
     {
-        if (state.status() == InstanceStatus::UNKNOWN)
-            petenv_shell_action.setEnabled(false);
-        else
-            petenv_shell_action.setEnabled(true);
-
+    case InstanceStatus::UNKNOWN:
+        petenv_start_action.setEnabled(false);
+        petenv_shell_action.setEnabled(false);
         petenv_stop_action.setEnabled(true);
+        break;
+    case InstanceStatus::RUNNING:
+    case InstanceStatus::DELAYED_SHUTDOWN:
         petenv_start_action.setEnabled(false);
-    }
-    else if (std::find(can_start_states.begin(), can_start_states.end(), state.status()) != can_start_states.end())
-    {
         petenv_shell_action.setEnabled(true);
+        petenv_stop_action.setEnabled(true);
+        break;
+    case InstanceStatus::STOPPED:
+    case InstanceStatus::SUSPENDED:
         petenv_start_action.setEnabled(true);
+        petenv_shell_action.setEnabled(true);
         petenv_stop_action.setEnabled(false);
-    }
-    else
-    {
-        if (state.status() == InstanceStatus::DELETED || state.status() == InstanceStatus::SUSPENDING)
-            petenv_shell_action.setEnabled(false);
-        else
-            petenv_shell_action.setEnabled(true);
-
+        break;
+    case InstanceStatus::DELETED:
+    case InstanceStatus::SUSPENDING:
         petenv_start_action.setEnabled(false);
+        petenv_shell_action.setEnabled(false);
+        petenv_stop_action.setEnabled(false);
+        break;
+    default:
+        petenv_start_action.setEnabled(false);
+        petenv_shell_action.setEnabled(true);
         petenv_stop_action.setEnabled(false);
     }
 }

--- a/src/client/gui/gui_cmd.h
+++ b/src/client/gui/gui_cmd.h
@@ -73,6 +73,9 @@ private:
     void initiate_about_menu_layout();
     ListReply retrieve_all_instances();
     void set_menu_actions_for(const std::string& instance_name, const InstanceStatus& state);
+    void handle_petenv_instance(const google::protobuf::RepeatedPtrField<ListVMInstance>&);
+    void set_petenv_actions_for(const InstanceStatus& state);
+    void remove_petenv_actions();
     void start_instance_for(const std::string& instance_name);
     void stop_instance_for(const std::string& instance_name);
     void suspend_instance_for(const std::string& instance_name);
@@ -81,6 +84,13 @@ private:
     QSystemTrayIcon tray_icon;
     QMenu tray_icon_menu;
 
+    QAction petenv_start_action;
+    QAction petenv_shell_action{"Open Shell"};
+    QAction petenv_stop_action{"Stop"};
+    InstanceStatus petenv_state;
+    bool petenv_exists{false};
+
+    QAction* petenv_actions_separator;
     QAction* about_separator;
     QAction* quit_action;
     QAction update_action{"Update available"};

--- a/src/client/gui/gui_cmd.h
+++ b/src/client/gui/gui_cmd.h
@@ -87,6 +87,7 @@ private:
     QAction petenv_shell_action{"Open Shell"};
     QAction petenv_stop_action{"Stop"};
     InstanceStatus petenv_state;
+    std::string current_petenv_name;
 
     QAction* petenv_actions_separator;
     QAction* about_separator;

--- a/src/client/gui/gui_cmd.h
+++ b/src/client/gui/gui_cmd.h
@@ -75,7 +75,6 @@ private:
     void set_menu_actions_for(const std::string& instance_name, const InstanceStatus& state);
     void handle_petenv_instance(const google::protobuf::RepeatedPtrField<ListVMInstance>&);
     void set_petenv_actions_for(const InstanceStatus& state);
-    void remove_petenv_actions();
     void start_instance_for(const std::string& instance_name);
     void stop_instance_for(const std::string& instance_name);
     void suspend_instance_for(const std::string& instance_name);
@@ -88,7 +87,6 @@ private:
     QAction petenv_shell_action{"Open Shell"};
     QAction petenv_stop_action{"Stop"};
     InstanceStatus petenv_state;
-    bool petenv_exists{false};
 
     QAction* petenv_actions_separator;
     QAction* about_separator;


### PR DESCRIPTION
The petenv instance gets its own section at the top of the tray icon menu.

Fixes #966

---
I followed the design spec found at https://github.com/CanonicalLtd/multipass-design#status-menu as closely as I could.  A couple of things though.
- Currently, there is no clean way to determine if the petenv instance is using the default name or another name, so I always put the petenv name in the `Start` line whereas the spec (I think) specifies only putting the alternate petenv name and don't put a name if it's the default.
- We currently have no way to determine if `suspend` is available in the backend, so I always use `Stop` for now. 