### PR TITLE
[settings] Fix client config path on the GUI

### DIFF
--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -57,9 +57,10 @@ QString file_for(const QString& key) // the key should have passed checks at thi
 {
     // static consts ensure these stay fixed
     static const auto file_pattern = QStringLiteral("%2.%1").arg(file_extension); // note the order
-    static const auto client_dir_path = QDir{QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation)};
+    static const auto user_config_path = QDir{QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)};
+    static const auto cli_client_dir_path = QDir{user_config_path.absoluteFilePath(mp::client_name)};
     static const auto daemon_dir_path = QDir{mp::platform::daemon_config_home()}; // temporary, replace w/ AppConfigLoc
-    static const auto client_file_path = client_dir_path.absoluteFilePath(file_pattern.arg(mp::client_name));
+    static const auto client_file_path = cli_client_dir_path.absoluteFilePath(file_pattern.arg(mp::client_name));
     static const auto daemon_file_path = daemon_dir_path.absoluteFilePath(file_pattern.arg(mp::daemon_name));
 
     assert(key.startsWith(daemon_root) || key.startsWith("client"));


### PR DESCRIPTION
Derive the client configuration path without relying on the `ApplicationName` (which is set on `QApplication`). This allows the GUI client to look for the client config in the correct place.

This is required for #978 to function properly and clears up the stage for further development on #944.