### PR TITLE
snap: Fix missing libssl package in the archive

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -149,9 +149,9 @@ parts:
   libssl11:
     plugin: dump
     source:
-    - on amd64: http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4.3_amd64.deb
-    - on armhf: http://ports.ubuntu.com/ubuntu-ports/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4.3_armhf.deb
-    - on arm64: http://ports.ubuntu.com/ubuntu-ports/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4.3_arm64.deb
+    - on amd64: http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb
+    - on armhf: http://ports.ubuntu.com/ubuntu-ports/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_armhf.deb
+    - on arm64: http://ports.ubuntu.com/ubuntu-ports/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_arm64.deb
 
   libharfbuzz0b:
     plugin: dump


### PR DESCRIPTION
Seems the archive has removed a newer version of libssl that is compatible with
Qt, so need to download the older version instead.

Note: The newer version of libssl was tried, but QSslSocket failed with
unresolved symbols.