### PR TITLE
[settings] Drop leftover include after c++17 move

### DIFF
--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -28,7 +28,6 @@
 #include <cassert>
 #include <cerrno>
 #include <fstream>
-#include <memory>
 #include <stdexcept>
 
 namespace mp = multipass;


### PR DESCRIPTION
Submitting this separately just for the sake of focused PRs.