### PR TITLE
[submodule] Add scope_guard

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,3 +18,6 @@
 [submodule "3rd-party/semver"]
 	path = 3rd-party/semver
 	url = https://github.com/CanonicalLtd/semver.git
+[submodule "3rd-party/scope_guard"]
+	path = 3rd-party/scope_guard
+	url = https://github.com/ricab/scope_guard.git

--- a/3rd-party/CMakeLists.txt
+++ b/3rd-party/CMakeLists.txt
@@ -95,6 +95,11 @@ add_library(premock INTERFACE)
 target_include_directories(premock INTERFACE
   ${CMAKE_CURRENT_SOURCE_DIR}/premock)
 
+# scope_guard header only library
+add_library(scope_guard INTERFACE)
+target_include_directories(scope_guard INTERFACE
+  ${CMAKE_CURRENT_SOURCE_DIR}/scope_guard)
+
 # semver library
 # Set option to disable tests, avoid a Boost dependency that is test-only
 set(ENABLE_TESTS OFF CACHE BOOL "Disable tests in Semver lib" FORCE)


### PR DESCRIPTION
Can I?

@Saviq I know we discussed copy-pasting the header instead in Malta. I ended up not needing it in that occasion, so dropped it. Now I again needed it and thought I might as well add it as a submodule, to pick up any updates (e.g. to deal with compiler bugs).