### PR TITLE
[snap] add remove hook (Fixes #916)

### DIFF
--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+rm -rf ${SNAP_COMMON}/cache
+rm -rf ${SNAP_COMMON}/apparmor.d
+rm ${SNAP_COMMON}/dnsmasq.pid
+rm ${SNAP_COMMON}/snap_config


### PR DESCRIPTION
Clean up any non-persistent data to avoid snapshotting it.

See https://forum.snapcraft.io/t/automatic-snapshot-opt-out/12131 for
reference.

---
The difference:
```
$ snap saved
Set  Snap       Age    Version                  Rev   Size    Notes
10   multipass  13.7m  0.9.0-dev.118+g8169155e  x1     3682B  auto
11   multipass  1m43s  0.9.0-dev.117+g37892a1   1101   339MB  auto
```