### PR TITLE
Split sshfs into separate process

### DIFF
--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -21,6 +21,8 @@
 #define MULTIPASS_PLATFORM_H
 
 #include <multipass/logging/logger.h>
+#include <multipass/process.h>
+#include <multipass/sshfs_server_config.h>
 #include <multipass/update_prompt.h>
 #include <multipass/virtual_machine_factory.h>
 
@@ -28,6 +30,7 @@
 
 #include <QString>
 
+#include <memory>
 #include <string>
 
 namespace multipass
@@ -38,11 +41,12 @@ QString autostart_test_data(); // returns a platform-specific string, for testin
 void setup_gui_autostart_prerequisites();
 std::string default_server_address();
 QString default_driver();
-QString daemon_config_home(); // temporary
+QString daemon_config_home();                      // temporary
 bool is_backend_supported(const QString& backend); // temporary
 VirtualMachineFactory::UPtr vm_backend(const Path& data_dir);
 logging::Logger::UPtr make_logger(logging::Level level);
 UpdatePrompt::UPtr make_update_prompt();
+std::unique_ptr<Process> make_sshfs_server_process(const SSHFSServerConfig& config);
 int chown(const char* path, unsigned int uid, unsigned int gid);
 bool symlink(const char* target, const char* link, bool is_dir);
 bool link(const char* target, const char* link);

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -32,6 +32,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace multipass
 {
@@ -55,6 +56,9 @@ int symlink_attr_from(const char* path, sftp_attributes_struct* attr);
 bool is_alias_supported(const std::string& alias, const std::string& remote);
 bool is_remote_supported(const std::string& remote);
 bool is_image_url_supported();
+
+void emit_signal_when_parent_dies(int sig);
+int wait_for_signals(const std::vector<int>& sigs);
 } // namespace platform
 } // namespace multipass
 #endif // MULTIPASS_PLATFORM_H

--- a/include/multipass/process.h
+++ b/include/multipass/process.h
@@ -85,6 +85,7 @@ public:
     virtual QProcessEnvironment process_environment() const = 0;
 
     virtual void start() = 0;
+    virtual void terminate() = 0;
     virtual void kill() = 0;
 
     virtual bool wait_for_started(int msecs = 30000) = 0;
@@ -103,7 +104,7 @@ public:
 
 signals:
     void started();
-    void finished(ProcessState process_state);
+    void finished(multipass::ProcessState process_state);
     void state_changed(QProcess::ProcessState state);  // not running, starting, running
     void error_occurred(QProcess::ProcessError error); // FailedToStart (file not found / resource error) Crashed,
                                                        // Timedout, ReadError, WriteError, UnknownError
@@ -114,4 +115,7 @@ protected:
     virtual void setup_child_process() = 0;
 };
 } // namespace multipass
+
+Q_DECLARE_METATYPE(multipass::ProcessState)
+
 #endif // MULTIPASS_PROCESS_H

--- a/include/multipass/sshfs_mount/sshfs_mount.h
+++ b/include/multipass/sshfs_mount/sshfs_mount.h
@@ -22,16 +22,12 @@
 #include <thread>
 #include <unordered_map>
 
-#include <QObject>
-
 namespace multipass
 {
 class SSHSession;
 class SftpServer;
-class SshfsMount : public QObject
+class SshfsMount
 {
-    Q_OBJECT
-
 public:
     SshfsMount(SSHSession&& session, const std::string& source, const std::string& target,
                const std::unordered_map<int, int>& gid_map, const std::unordered_map<int, int>& uid_map);
@@ -40,14 +36,11 @@ public:
 
     void stop();
 
-signals:
-    void finished();
-
 private:
     // sftp_server Doesn't need to be a pointer, but done for now to avoid bringing sftp.h
     // which has an error with -pedantic.
     std::unique_ptr<SftpServer> sftp_server;
     std::thread sftp_thread;
 };
-}
+} // namespace multipass
 #endif // MULTIPASS_SSHFS_MOUNT

--- a/include/multipass/sshfs_mount/sshfs_mounts.h
+++ b/include/multipass/sshfs_mount/sshfs_mounts.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2017-2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_SSHFSMOUNTS_H
+#define MULTIPASS_SSHFSMOUNTS_H
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include <multipass/process.h>
+#include <multipass/qt_delete_later_unique_ptr.h>
+#include <multipass/virtual_machine.h>
+
+namespace multipass
+{
+
+class SSHFSMounts : public QObject
+{
+    Q_OBJECT
+public:
+    explicit SSHFSMounts(const SSHKeyProvider& ssh_key_provider);
+
+    void start_mount(VirtualMachine* vm, const std::string& source_path, const std::string& target_path,
+                     const std::unordered_map<int, int>& gid_map, const std::unordered_map<int, int>& uid_map);
+
+    bool stop_mount(const std::string& instance, const std::string& path);
+    void stop_all_mounts_for_instance(const std::string& instance);
+
+    bool has_instance_already_mounted(const std::string& instance, const std::string& path) const;
+
+private:
+    const std::string key;
+    std::unordered_map<std::string, std::unordered_map<std::string, qt_delete_later_unique_ptr<Process>>>
+        mount_processes;
+};
+
+} // namespace multipass
+#endif // MULTIPASS_SSHFSMOUNTS_H

--- a/include/multipass/sshfs_mount/sshfs_mounts.h
+++ b/include/multipass/sshfs_mount/sshfs_mounts.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,11 +23,12 @@
 #include <unordered_map>
 
 #include <multipass/process.h>
+#include <multipass/ssh/ssh_key_provider.h>
 #include <multipass/qt_delete_later_unique_ptr.h>
-#include <multipass/virtual_machine.h>
 
 namespace multipass
 {
+class VirtualMachine;
 
 class SSHFSMounts : public QObject
 {

--- a/include/multipass/sshfs_server_config.h
+++ b/include/multipass/sshfs_server_config.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_SSHFS_SERVER_CONFIG_H
+#define MULTIPASS_SSHFS_SERVER_CONFIG_H
+
+#include <string>
+#include <unordered_map>
+
+namespace multipass
+{
+
+struct SSHFSServerConfig
+{
+    std::string host;
+    int port;
+    std::string username;
+    std::string instance;
+    std::string private_key;
+    std::string source_path;
+    std::string target_path;
+    std::unordered_map<int, int> gid_map;
+    std::unordered_map<int, int> uid_map;
+};
+
+} // namespace multipass
+#endif // MULTIPASS_SSHFS_SERVER_CONFIG_H

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -24,7 +24,7 @@
 #include <multipass/delayed_shutdown_timer.h>
 #include <multipass/memory_size.h>
 #include <multipass/metrics_provider.h>
-#include <multipass/sshfs_mount/sshfs_mount.h>
+#include <multipass/sshfs_mount/sshfs_mounts.h>
 #include <multipass/virtual_machine.h>
 #include <multipass/vm_status_monitor.h>
 
@@ -135,10 +135,6 @@ public slots:
 
 private:
     void persist_instances();
-    void start_mount(VirtualMachine *vm, const std::string& name, const std::string& source_path,
-                     const std::string& target_path, const std::unordered_map<int, int>& gid_map,
-                     const std::unordered_map<int, int>& uid_map);
-    void stop_mounts_for_instance(const std::string& instance);
     void release_resources(const std::string& instance);
     std::string check_instance_operational(const std::string& instance_name) const;
     std::string check_instance_exists(const std::string& instance_name) const;
@@ -148,7 +144,7 @@ private:
     grpc::Status shutdown_vm(VirtualMachine& vm, const std::chrono::milliseconds delay);
     grpc::Status cancel_vm_shutdown(const VirtualMachine& vm);
     grpc::Status cmd_vms(const std::vector<std::string>& tgts, std::function<grpc::Status(VirtualMachine&)> cmd);
-    void install_sshfs(VirtualMachine *vm, const std::string& name);
+    void install_sshfs(VirtualMachine* vm, const std::string& name);
 
     struct AsyncOperationStatus
     {
@@ -169,7 +165,6 @@ private:
     std::unordered_map<std::string, VMSpecs> vm_instance_specs;
     std::unordered_map<std::string, VirtualMachine::ShPtr> vm_instances;
     std::unordered_map<std::string, VirtualMachine::ShPtr> deleted_instances;
-    std::unordered_map<std::string, std::unordered_map<std::string, std::unique_ptr<SshfsMount>>> mount_threads;
     std::unordered_map<std::string, std::unique_ptr<DelayedShutdownTimer>> delayed_shutdown_instances;
     std::unordered_set<std::string> allocated_mac_addrs;
     std::unordered_map<std::string, VMImageHost*> remote_image_host_map;
@@ -177,6 +172,7 @@ private:
     QTimer source_images_maintenance_task;
     MetricsProvider metrics_provider;
     MetricsOptInData metrics_opt_in;
+    SSHFSMounts instance_mounts;
     std::vector<std::unique_ptr<QFutureWatcher<AsyncOperationStatus>>> async_future_watchers;
     std::unordered_map<std::string, QFuture<std::string>> async_running_futures;
     std::mutex start_mutex;

--- a/src/platform/backends/shared/CMakeLists.txt
+++ b/src/platform/backends/shared/CMakeLists.txt
@@ -17,7 +17,8 @@ set (CMAKE_AUTOMOC ON)
 add_library(shared STATIC
   basic_process.cpp
   process_spec.cpp
-  simple_process_spec.cpp)
+  simple_process_spec.cpp
+  sshfs_server_process_spec.cpp)
 
 target_link_libraries(shared
   Qt5::Core)

--- a/src/platform/backends/shared/basic_process.cpp
+++ b/src/platform/backends/shared/basic_process.cpp
@@ -97,6 +97,11 @@ void mp::BasicProcess::start()
     process.start();
 }
 
+void mp::BasicProcess::terminate()
+{
+    process.terminate();
+}
+
 void mp::BasicProcess::kill()
 {
     process.kill();

--- a/src/platform/backends/shared/basic_process.h
+++ b/src/platform/backends/shared/basic_process.h
@@ -42,6 +42,7 @@ public:
     QProcessEnvironment process_environment() const override;
 
     void start() override;
+    void terminate() override;
     void kill() override;
 
     bool wait_for_started(int msecs = 30000) override;

--- a/src/platform/backends/shared/linux/process_factory.cpp
+++ b/src/platform/backends/shared/linux/process_factory.cpp
@@ -75,6 +75,7 @@ mp::optional<mp::AppArmor> create_apparmor()
 mp::ProcessFactory::ProcessFactory(const Singleton<ProcessFactory>::PrivatePass& pass)
     : Singleton<ProcessFactory>::Singleton{pass}, apparmor{create_apparmor()}
 {
+    qRegisterMetaType<multipass::ProcessState>();
 }
 
 // This is the default ProcessFactory that creates a Process with no security mechanisms enabled

--- a/src/platform/backends/shared/sshfs_server_process_spec.cpp
+++ b/src/platform/backends/shared/sshfs_server_process_spec.cpp
@@ -18,8 +18,6 @@
 #include "sshfs_server_process_spec.h"
 
 #include <QCoreApplication>
-#include <QCryptographicHash>
-#include <QDir>
 
 namespace mp = multipass;
 

--- a/src/platform/backends/shared/sshfs_server_process_spec.cpp
+++ b/src/platform/backends/shared/sshfs_server_process_spec.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "sshfs_server_process_spec.h"
+
+#include <QCoreApplication>
+#include <QCryptographicHash>
+#include <QDir>
+
+namespace mp = multipass;
+
+namespace
+{
+QString serialise_id_map(const std::unordered_map<int, int>& id_map)
+{
+    QString out;
+    for (auto ids : id_map)
+    {
+        out += QString("%1:%2,").arg(ids.first).arg(ids.second);
+    }
+    return out;
+}
+} // namespace
+
+mp::SSHFSServerProcessSpec::SSHFSServerProcessSpec(const SSHFSServerConfig& config) : config(config)
+{
+}
+
+QString mp::SSHFSServerProcessSpec::program() const
+{
+    return QCoreApplication::applicationDirPath() + "/sshfs_server";
+}
+
+QStringList mp::SSHFSServerProcessSpec::arguments() const
+{
+    return QStringList() << QString::fromStdString(config.host) << QString::number(config.port)
+                         << QString::fromStdString(config.username) << QString::fromStdString(config.source_path)
+                         << QString::fromStdString(config.target_path) << serialise_id_map(config.uid_map)
+                         << serialise_id_map(config.gid_map);
+}
+
+QProcessEnvironment mp::SSHFSServerProcessSpec::environment() const
+{
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    env.insert("KEY", QString::fromStdString(config.private_key));
+    return env;
+}
+
+mp::logging::Level mp::SSHFSServerProcessSpec::error_log_level() const
+{
+    return mp::logging::Level::debug;
+}
+
+QString mp::SSHFSServerProcessSpec::apparmor_profile() const
+{
+    return QString();
+}

--- a/src/platform/backends/shared/sshfs_server_process_spec.h
+++ b/src/platform/backends/shared/sshfs_server_process_spec.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_SSHFS_SERVER_PROCESS_SPEC_H
+#define MULTIPASS_SSHFS_SERVER_PROCESS_SPEC_H
+
+#include <multipass/process_spec.h>
+#include <multipass/sshfs_server_config.h>
+
+namespace multipass
+{
+
+class SSHFSServerProcessSpec : public ProcessSpec
+{
+public:
+    explicit SSHFSServerProcessSpec(const SSHFSServerConfig& config);
+
+    QString program() const override;
+    QStringList arguments() const override;
+    QProcessEnvironment environment() const override;
+
+    logging::Level error_log_level() const override;
+
+    QString apparmor_profile() const override;
+
+private:
+    const SSHFSServerConfig config;
+};
+
+} // namespace multipass
+
+#endif // MULTIPASS_SSHFS_SERVER_PROCESS_SPEC_H

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -27,13 +27,11 @@
 #include "backends/libvirt/libvirt_virtual_machine_factory.h"
 #include "backends/qemu/qemu_virtual_machine_factory.h"
 #include "logger/journald_logger.h"
+#include "shared/linux/process_factory.h"
+#include "shared/sshfs_server_process_spec.h"
 #include <disabled_update_prompt.h>
 
 #include <QStandardPaths>
-
-#include <cerrno>
-#include <cstring>
-#include <stdexcept>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;
@@ -129,6 +127,11 @@ mp::VirtualMachineFactory::UPtr mp::platform::vm_backend(const mp::Path& data_di
         return std::make_unique<LibVirtVirtualMachineFactory>(data_dir);
     else
         throw std::runtime_error(fmt::format("Unsupported virtualization driver: {}", driver));
+}
+
+std::unique_ptr<mp::Process> mp::platform::make_sshfs_server_process(const mp::SSHFSServerConfig& config)
+{
+    return mp::ProcessFactory::instance().create_process(std::make_unique<mp::SSHFSServerProcessSpec>(config));
 }
 
 mp::UpdatePrompt::UPtr mp::platform::make_update_prompt()

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -33,6 +33,9 @@
 
 #include <QStandardPaths>
 
+#include <signal.h>
+#include <sys/prctl.h>
+
 namespace mp = multipass;
 namespace mpl = multipass::logging;
 namespace mu = multipass::utils;
@@ -162,4 +165,9 @@ bool mp::platform::is_remote_supported(const std::string& remote)
 bool mp::platform::is_image_url_supported()
 {
     return true;
+}
+
+void mp::platform::emit_signal_when_parent_dies(int sig)
+{
+    prctl(PR_SET_PDEATHSIG, sig); // ensures if parent dies, this process it sent this signal
 }

--- a/src/platform/platform_unix.cpp
+++ b/src/platform/platform_unix.cpp
@@ -72,7 +72,9 @@ int mp::platform::utime(const char* path, int atime, int mtime)
 
 int mp::platform::symlink_attr_from(const char* path, sftp_attributes_struct* attr)
 {
-    struct stat st{};
+    struct stat st
+    {
+    };
 
     auto ret = lstat(path, &st);
 
@@ -100,4 +102,12 @@ sigset_t mp::platform::make_and_block_signals(const std::vector<int>& sigs)
     auto sigset{make_sigset(sigs)};
     sigprocmask(SIG_BLOCK, &sigset, nullptr);
     return sigset;
+}
+
+int mp::platform::wait_for_signals(const std::vector<int>& sigs)
+{
+    auto sigset{make_and_block_signals(sigs)};
+    int sig = -1;
+    sigwait(&sigset, &sig);
+    return sig;
 }

--- a/src/sshfs_mount/CMakeLists.txt
+++ b/src/sshfs_mount/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017 Canonical Ltd.
+# Copyright © 2017-2019 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -18,8 +18,11 @@ function(add_sshfs_mount_target TARGET_NAME)
 
   add_library(${TARGET_NAME} STATIC
     sshfs_mount.cpp
+    sshfs_mounts.cpp
     sftp_server.cpp
-    ${CMAKE_SOURCE_DIR}/include/multipass/sshfs_mount/sshfs_mount.h)
+    # Need to run MOC on these
+    ${CMAKE_SOURCE_DIR}/include/multipass/sshfs_mount/sshfs_mount.h
+    ${CMAKE_SOURCE_DIR}/include/multipass/sshfs_mount/sshfs_mounts.h)
 
   target_link_libraries(${TARGET_NAME}
     fmt
@@ -34,3 +37,14 @@ add_sshfs_mount_target(sshfs_mount)
 if(MULTIPASS_ENABLE_TESTS)
   add_sshfs_mount_target(sshfs_mount_test)
 endif()
+
+add_executable(sshfs_server
+  sshfs_server.cpp)
+
+target_link_libraries(sshfs_server
+  logger
+  sshfs_mount)
+
+install(TARGETS sshfs_server
+  DESTINATION bin
+  COMPONENT multipassd)

--- a/src/sshfs_mount/sshfs_mount.cpp
+++ b/src/sshfs_mount/sshfs_mount.cpp
@@ -25,6 +25,8 @@
 
 #include <multipass/format.h>
 
+#include <iostream>
+
 namespace mp = multipass;
 namespace mpl = multipass::logging;
 
@@ -95,13 +97,14 @@ auto make_sftp_server(mp::SSHSession&& session, const std::string& source, const
                                             default_gid);
 }
 
-} // namespace anonymous
+} // namespace
 
 mp::SshfsMount::SshfsMount(SSHSession&& session, const std::string& source, const std::string& target,
                            const std::unordered_map<int, int>& gid_map, const std::unordered_map<int, int>& uid_map)
     : sftp_server{make_sftp_server(std::move(session), source, target, gid_map, uid_map)}, sftp_thread{[this] {
+          std::cout << "Connected" << std::endl;
           sftp_server->run();
-          emit finished();
+          std::cout << "Stopped" << std::endl;
       }}
 {
 }

--- a/src/sshfs_mount/sshfs_mounts.cpp
+++ b/src/sshfs_mount/sshfs_mounts.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,6 +22,7 @@
 #include <multipass/ssh/ssh_key_provider.h>
 #include <multipass/sshfs_mount/sshfs_mounts.h>
 #include <multipass/sshfs_server_config.h>
+#include <multipass/virtual_machine.h>
 
 #include <QEventLoop>
 

--- a/src/sshfs_mount/sshfs_mounts.cpp
+++ b/src/sshfs_mount/sshfs_mounts.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2017-2019 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <multipass/exceptions/sshfs_missing_error.h>
+#include <multipass/format.h>
+#include <multipass/logging/log.h>
+#include <multipass/platform.h>
+#include <multipass/ssh/ssh_key_provider.h>
+#include <multipass/sshfs_mount/sshfs_mounts.h>
+#include <multipass/sshfs_server_config.h>
+
+#include <QEventLoop>
+
+namespace mp = multipass;
+namespace mpl = multipass::logging;
+
+namespace
+{
+constexpr auto category = "sshfs-mounts";
+
+template <typename Signal>
+void start_and_block_until(mp::Process* process, Signal signal, std::function<bool(mp::Process* process)> ready_decider)
+{
+    QEventLoop event_loop;
+    auto stop_conn =
+        QObject::connect(process, &mp::Process::finished, [&event_loop](mp::ProcessState) { event_loop.quit(); });
+
+    auto running_conn = QObject::connect(process, signal, [process, ready_decider, &event_loop]() {
+        if (ready_decider(process))
+        {
+            event_loop.quit();
+        }
+    });
+
+    process->start();
+
+    // This blocks and waits either ready_decider to return true, or failure.
+    event_loop.exec();
+
+    QObject::disconnect(stop_conn);
+    QObject::disconnect(running_conn);
+}
+} // namespace
+
+mp::SSHFSMounts::SSHFSMounts(const SSHKeyProvider& key_provider) : key(key_provider.private_key_as_base64())
+{
+}
+
+void mp::SSHFSMounts::start_mount(VirtualMachine* vm, const std::string& source_path, const std::string& target_path,
+                                  const std::unordered_map<int, int>& gid_map,
+                                  const std::unordered_map<int, int>& uid_map)
+{
+    mp::SSHFSServerConfig config;
+    config.host = vm->ssh_hostname();
+    config.port = vm->ssh_port();
+    config.username = vm->ssh_username();
+    config.instance = vm->vm_name;
+    config.target_path = target_path;
+    config.source_path = source_path;
+    config.uid_map = uid_map;
+    config.gid_map = gid_map;
+    config.private_key = key;
+
+    auto sshfs_server_process_t = mp::platform::make_sshfs_server_process(config);
+    // FIXME: ProcessFactory really should return qt_delete_later_unique_ptr<Process> as Process emits signals
+    // and the respective slots may be called on the event loop, but unique_ptr can delete the Process before
+    // the slots are fired, causing a crash.
+    mp::qt_delete_later_unique_ptr<mp::Process> sshfs_server_process(sshfs_server_process_t.release());
+
+    QObject::connect(
+        sshfs_server_process.get(), &mp::Process::finished, this,
+        [this, instance = vm->vm_name, target_path](mp::ProcessState exit_state) {
+            if (exit_state.completed_successfully())
+            {
+                mpl::log(mpl::Level::info, category,
+                         fmt::format("Mount '{}' in instance \"{}\" has stopped", target_path, instance));
+            }
+            else
+            {
+                mpl::log(mpl::Level::warning, // not error as it failing can indicate we need to install sshfs in the VM
+                         category,
+                         fmt::format("Mount '{}' in instance \"{}\" has stopped unexpectedly: {}", target_path,
+                                     instance, exit_state.failure_message()));
+            }
+
+            mount_processes[instance].erase(target_path);
+        });
+
+    QObject::connect(
+        sshfs_server_process.get(), &mp::Process::error_occurred, this,
+        [instance = vm->vm_name, target_path, process = sshfs_server_process.get()](QProcess::ProcessError error) {
+            mpl::log(mpl::Level::error, category,
+                     fmt::format("There was an error with sshfs_server for instance \"{}\" with path '{}': {}",
+                                 instance, target_path, error));
+        });
+
+    mpl::log(mpl::Level::info, category, fmt::format("mounting {} => {} in {}", source_path, target_path, vm->vm_name));
+    mpl::log(mpl::Level::info, category,
+             fmt::format("process program '{}'", sshfs_server_process->program().toStdString()));
+    mpl::log(mpl::Level::info, category,
+             fmt::format("process arguments '{}'", sshfs_server_process->arguments().join(", ").toStdString()));
+
+    start_and_block_until(
+        sshfs_server_process.get(), &mp::Process::ready_read_standard_output, [](mp::Process* process) {
+            return process->read_all_standard_output().contains("Connected"); // Magic string printed by sshfs_server
+        });
+
+    // Check in case sshfs_server stopped, usually due to an error
+    auto process_state = sshfs_server_process->process_state();
+    if (process_state.exit_code == 9) // Magic number returned by sshfs_server
+    {
+        throw mp::SSHFSMissingError();
+    }
+    else if (process_state.exit_code || process_state.error)
+    {
+        throw std::runtime_error(
+            fmt::format("{}: {}", process_state.failure_message(), sshfs_server_process->read_all_standard_error()));
+    }
+
+    mount_processes[vm->vm_name][target_path] = std::move(sshfs_server_process);
+}
+
+bool mp::SSHFSMounts::stop_mount(const std::string& instance, const std::string& path)
+{
+    auto sshfs_mount_it = mount_processes.find(instance);
+    if (sshfs_mount_it == mount_processes.end())
+    {
+        return false;
+    }
+
+    auto& sshfs_mount_map = sshfs_mount_it->second;
+    auto map_entry = sshfs_mount_map.find(path);
+    if (map_entry != sshfs_mount_map.end())
+    {
+        auto& sshfs_mount = map_entry->second;
+        mpl::log(mpl::Level::info, category,
+                 fmt::format("stopping sshfs_server for \"{}\" serving '{}'", instance, path));
+        sshfs_mount->terminate(); // TODO - if non-responsive, then kill()
+        return true;
+    }
+    return false;
+}
+
+void mp::SSHFSMounts::stop_all_mounts_for_instance(const std::string& instance)
+{
+    auto mounts_it = mount_processes.find(instance);
+    if (mounts_it == mount_processes.end() || mounts_it->second.empty())
+    {
+        mpl::log(mpl::Level::debug, category, fmt::format("No mounts to stop for instance \"{}\"", instance));
+    }
+    else
+    {
+        for (auto& sshfs_mount : mounts_it->second)
+        {
+            mpl::log(mpl::Level::debug, category,
+                     fmt::format("Stopping mount '{}' in instance \"{}\"", sshfs_mount.first, instance));
+            sshfs_mount.second->terminate();
+        }
+    }
+    mount_processes.clear();
+}
+
+bool mp::SSHFSMounts::has_instance_already_mounted(const std::string& instance, const std::string& path) const
+{
+    auto entry = mount_processes.find(instance);
+    if (entry != mount_processes.end() && entry->second.find(path) != entry->second.end())
+    {
+        return true;
+    }
+    return false;
+}

--- a/src/sshfs_mount/sshfs_server.cpp
+++ b/src/sshfs_mount/sshfs_server.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/sshfs_mount/sshfs_server.cpp
+++ b/src/sshfs_mount/sshfs_server.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2018 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <QStringList>
+
+#include "../ssh/ssh_client_key_provider.h" // FIXME
+#include <multipass/exceptions/sshfs_missing_error.h>
+#include <multipass/logging/log.h>
+#include <multipass/logging/standard_logger.h>
+#include <multipass/ssh/ssh_session.h>
+#include <multipass/sshfs_mount/sshfs_mount.h>
+
+#include <signal.h>
+#include <sys/prctl.h>
+
+namespace mp = multipass;
+namespace mpl = multipass::logging;
+using namespace std;
+
+namespace
+{
+unordered_map<int, int> deserialise_id_map(const char* in)
+{
+    unordered_map<int, int> id_map;
+    QString input(in);
+    auto maps = input.split(',', QString::SkipEmptyParts);
+    for (auto map : maps)
+    {
+        auto ids = map.split(":");
+        if (ids.count() != 2)
+        {
+            cerr << "Incorrect ID mapping syntax";
+            continue;
+        }
+        bool ok1, ok2;
+        int from = ids.first().toInt(&ok1);
+        int to = ids.last().toInt(&ok2);
+        if (!ok1 || !ok2)
+        {
+            cerr << "Incorrect ID mapping ids found, ignored" << endl;
+            continue;
+        }
+        id_map.insert({from, to});
+    }
+    return id_map;
+}
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    prctl(PR_SET_PDEATHSIG, SIGHUP); // ensure if parent dies, this process gets the SIGHUP signal
+
+    if (argc != 8)
+    {
+        cerr << "Incorrect arguments" << endl;
+        exit(2);
+    }
+
+    const auto key = getenv("KEY");
+    if (key == nullptr)
+    {
+        cerr << "KEY not set" << endl;
+        exit(2);
+    }
+    const auto priv_key_blob = string(key);
+    const auto host = string(argv[1]);
+    const int port = atoi(argv[2]);
+    const auto username = string(argv[3]);
+    const auto source_path = string(argv[4]);
+    const auto target_path = string(argv[5]);
+    const unordered_map<int, int> gid_map = deserialise_id_map(argv[6]);
+    const unordered_map<int, int> uid_map = deserialise_id_map(argv[7]);
+
+    auto logger = std::make_shared<mpl::StandardLogger>(mpl::Level::error); // QUESTION - how to pass verbosity level?
+    mpl::set_logger(logger);
+
+    try
+    {
+        mp::SSHSession session{host, port, username, mp::SSHClientKeyProvider{priv_key_blob}};
+
+        mp::SshfsMount sshfs_mount(move(session), source_path, target_path, gid_map, uid_map);
+
+        // ssh lives on its own thread, use this thread to listen for quit signal
+        sigset_t sigset;
+        sigemptyset(&sigset);
+        sigaddset(&sigset, SIGQUIT);
+        sigaddset(&sigset, SIGTERM);
+        sigaddset(&sigset, SIGHUP);
+        sigprocmask(SIG_BLOCK, &sigset, nullptr);
+        int sig = -1;
+
+        sigwait(&sigset, &sig);
+        cout << "Received signal " << sig << ". Stopping" << endl;
+        sshfs_mount.stop();
+        exit(0);
+    }
+    catch (const mp::SSHFSMissingError)
+    {
+        cerr << "SSHFS was not found on the host: " << host << endl;
+        exit(9);
+    }
+    catch (const exception& e)
+    {
+        cerr << e.what();
+    }
+    return 1;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -125,7 +125,9 @@ add_executable(multipass_tests
   test_sftp_client.cpp
   test_sftpserver.cpp
   test_ssl_cert_provider.cpp
+  test_sshfs_server_process_spec.cpp
   test_sshfsmount.cpp
+  test_sshfsmounts.cpp
   test_ssh_client.cpp
   test_ssh_key_provider.cpp
   test_ssh_process.cpp

--- a/tests/mock_process_factory.h
+++ b/tests/mock_process_factory.h
@@ -74,6 +74,7 @@ class MockProcess : public Process
 {
 public:
     MOCK_METHOD0(start, void());
+    MOCK_METHOD0(terminate, void());
     MOCK_METHOD0(kill, void());
     MOCK_CONST_METHOD0(running, bool());
     MOCK_CONST_METHOD0(process_state, ProcessState());

--- a/tests/mock_virtual_machine.h
+++ b/tests/mock_virtual_machine.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_MOCK_VIRTUAL_MACHINE_H
+#define MULTIPASS_MOCK_VIRTUAL_MACHINE_H
+
+#include <gmock/gmock.h>
+#include <multipass/virtual_machine.h>
+
+namespace multipass
+{
+namespace test
+{
+struct MockVirtualMachine : public multipass::VirtualMachine
+{
+    MockVirtualMachine(const std::string vm_name) : VirtualMachine{vm_name}
+    {
+        ON_CALL(*this, current_state()).WillByDefault(Return(multipass::VirtualMachine::State::off));
+        ON_CALL(*this, ssh_port()).WillByDefault(Return(42));
+        ON_CALL(*this, ssh_hostname()).WillByDefault(Return("localhost"));
+        ON_CALL(*this, ssh_username()).WillByDefault(Return("ubuntu"));
+        ON_CALL(*this, ipv4()).WillByDefault(Return("0.0.0.0"));
+        ON_CALL(*this, ipv6()).WillByDefault(Return("::/0"));
+    }
+
+    MOCK_METHOD0(start, void());
+    MOCK_METHOD0(stop, void());
+    MOCK_METHOD0(shutdown, void());
+    MOCK_METHOD0(suspend, void());
+    MOCK_METHOD0(current_state, multipass::VirtualMachine::State());
+    MOCK_METHOD0(ssh_port, int());
+    MOCK_METHOD0(ssh_hostname, std::string());
+    MOCK_METHOD0(ssh_username, std::string());
+    MOCK_METHOD0(ipv4, std::string());
+    MOCK_METHOD0(ipv6, std::string());
+    MOCK_METHOD0(ensure_vm_is_running, void());
+    MOCK_METHOD1(wait_until_ssh_up, void(std::chrono::milliseconds));
+    MOCK_METHOD0(update_state, void());
+};
+} // namespace test
+} // namespace multipass
+#endif // MULTIPASS_MOCK_VIRTUAL_MACHINE_H

--- a/tests/stub_process_factory.cpp
+++ b/tests/stub_process_factory.cpp
@@ -55,10 +55,16 @@ public:
     {
         emit started();
     }
-    void kill() override
+    void terminate() override
     {
         mp::ProcessState exit_state;
         exit_state.exit_code = 0;
+        emit finished(exit_state);
+    }
+    void kill() override
+    {
+        mp::ProcessState exit_state;
+        exit_state.error->state = QProcess::Crashed;
         emit finished(exit_state);
     }
 

--- a/tests/test_sshfs_server_process_spec.cpp
+++ b/tests/test_sshfs_server_process_spec.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <src/platform/backends/shared/sshfs_server_process_spec.h>
+
+#include <multipass/sshfs_server_config.h>
+
+#include "mock_environment_helpers.h"
+
+#include <gmock/gmock.h>
+
+namespace mp = multipass;
+namespace mpt = multipass::test;
+using namespace testing;
+
+struct TestSSHFSServerProcessSpec : public Test
+{
+    mp::SSHFSServerConfig config{"host",
+                                 42,
+                                 "username",
+                                 "instance",
+                                 "private_key",
+                                 "source_path",
+                                 "target_path",
+                                 {{1, 2}, {3, 4}},
+                                 {{5, -1}, {6, 10}}};
+};
+
+TEST_F(TestSSHFSServerProcessSpec, program_correct)
+{
+    mp::SSHFSServerProcessSpec spec(config);
+    EXPECT_TRUE(spec.program().endsWith("sshfs_server"));
+}
+
+TEST_F(TestSSHFSServerProcessSpec, arguments_correct)
+{
+    mp::SSHFSServerProcessSpec spec(config);
+    EXPECT_EQ(spec.arguments(),
+              QStringList({"host", "42", "username", "source_path", "target_path", "6:10,5:-1,", "3:4,1:2,"}));
+}
+
+TEST_F(TestSSHFSServerProcessSpec, environment_correct)
+{
+    mp::SSHFSServerProcessSpec spec(config);
+
+    ASSERT_TRUE(spec.environment().contains("KEY"));
+    EXPECT_EQ(spec.environment().value("KEY"), "private_key");
+}

--- a/tests/test_sshfsmounts.cpp
+++ b/tests/test_sshfsmounts.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <multipass/exceptions/sshfs_missing_error.h>
+#include <multipass/sshfs_mount/sshfs_mounts.h>
+
+#include "mock_environment_helpers.h"
+#include "mock_process_factory.h"
+#include "mock_virtual_machine.h"
+#include "stub_ssh_key_provider.h"
+
+#include <QCoreApplication>
+#include <QTimer>
+#include <gmock/gmock.h>
+
+namespace mp = multipass;
+namespace mpt = multipass::test;
+
+using namespace testing;
+
+struct SSHFSMountsTest : public ::Test
+{
+    void TearDown() override
+    {
+        // Deliberately spin the event loop to ensure all deleteLater()'ed QObjects are cleaned up, so
+        // the mock tests are performed
+        qApp->processEvents(QEventLoop::AllEvents);
+    }
+
+    mpt::StubSSHKeyProvider key_provider;
+    std::string source_path{"/my/source/path"}, target_path{"/the/target/path"};
+    std::unordered_map<int, int> gid_map{{1, 2}, {3, 4}}, uid_map{{5, -1}, {6, 10}};
+    mpt::SetEnvScope env_scope{"DISABLE_APPARMOR", "1"};
+
+    mpt::MockProcessFactory::Callback sshfs_prints_connected = [](mpt::MockProcess* process) {
+        if (process->program().contains("sshfs_server"))
+        {
+            // Have "sshfs_server" print "Connected" to its stdout after short delay
+            ON_CALL(*process, read_all_standard_output()).WillByDefault(Return("Connected"));
+            QTimer::singleShot(100, process, [process]() { emit process->ready_read_standard_output(); });
+
+            // Ensure process_state() does not have an exit code set (i.e. still running)
+            mp::ProcessState running_state;
+            ON_CALL(*process, process_state()).WillByDefault(Return(running_state));
+        }
+    };
+};
+
+TEST_F(SSHFSMountsTest, mount_creates_sshfs_process)
+{
+    auto factory = mpt::MockProcessFactory::Inject();
+    factory->register_callback(sshfs_prints_connected);
+
+    mp::SSHFSMounts sshfs_mounts(key_provider);
+
+    mpt::MockVirtualMachine vm{"my_instance"};
+    EXPECT_CALL(vm, ssh_port());
+    EXPECT_CALL(vm, ssh_hostname());
+    EXPECT_CALL(vm, ssh_username());
+
+    sshfs_mounts.start_mount(&vm, source_path, target_path, gid_map, uid_map);
+
+    ASSERT_EQ(factory->process_list().size(), 1u);
+    auto sshfs_command = factory->process_list()[0];
+    EXPECT_TRUE(sshfs_command.command.endsWith("sshfs_server"));
+    EXPECT_EQ(sshfs_command.arguments, QStringList({"localhost", "42", "ubuntu", "/my/source/path", "/the/target/path",
+                                                    "6:10,5:-1,", "3:4,1:2,"}));
+}
+
+TEST_F(SSHFSMountsTest, sshfs_process_failing_with_return_code_9_causes_exception)
+{
+    auto factory = mpt::MockProcessFactory::Inject();
+
+    mpt::MockProcessFactory::Callback sshfs_fails_with_exit_code_nine = [](mpt::MockProcess* process) {
+        if (process->program().contains("sshfs_server"))
+        {
+            mp::ProcessState exit_state;
+            exit_state.exit_code = 9;
+
+            // Have "sshfs_server" die after short delay
+            QTimer::singleShot(100, process, [process, exit_state]() { emit process->finished(exit_state); });
+
+            ON_CALL(*process, process_state()).WillByDefault(Return(exit_state));
+        }
+    };
+    factory->register_callback(sshfs_fails_with_exit_code_nine);
+
+    mp::SSHFSMounts sshfs_mounts(key_provider);
+    NiceMock<mpt::MockVirtualMachine> vm{"my_instance"};
+
+    EXPECT_THROW(sshfs_mounts.start_mount(&vm, source_path, target_path, gid_map, uid_map), mp::SSHFSMissingError);
+
+    ASSERT_EQ(factory->process_list().size(), 1u);
+    auto sshfs_command = factory->process_list()[0];
+    EXPECT_TRUE(sshfs_command.command.endsWith("sshfs_server"));
+}
+
+TEST_F(SSHFSMountsTest, sshfs_process_failing_causes_runtime_exception)
+{
+    auto factory = mpt::MockProcessFactory::Inject();
+
+    mpt::MockProcessFactory::Callback sshfs_fails = [](mpt::MockProcess* process) {
+        if (process->program().contains("sshfs_server"))
+        {
+            mp::ProcessState exit_state;
+            exit_state.exit_code = 1;
+
+            // Have "sshfs_server" die after short delay
+            ON_CALL(*process, read_all_standard_error()).WillByDefault(Return("Whoopsie"));
+            QTimer::singleShot(100, process, [process, exit_state]() { emit process->finished(exit_state); });
+
+            ON_CALL(*process, process_state()).WillByDefault(Return(exit_state));
+        }
+    };
+    factory->register_callback(sshfs_fails);
+
+    mp::SSHFSMounts sshfs_mounts(key_provider);
+    NiceMock<mpt::MockVirtualMachine> vm{"my_instance"};
+
+    EXPECT_THROW(try { sshfs_mounts.start_mount(&vm, source_path, target_path, gid_map, uid_map); } catch (
+                     const std::runtime_error& e) {
+        EXPECT_STREQ(e.what(), "Process returned exit code: 1: Whoopsie");
+        throw;
+    },
+                 std::runtime_error);
+}
+
+TEST_F(SSHFSMountsTest, stop_terminates_sshfs_process)
+{
+    auto factory = mpt::MockProcessFactory::Inject();
+    mpt::MockProcessFactory::Callback sshfs_fails = [this](mpt::MockProcess* process) {
+        sshfs_prints_connected(process);
+
+        if (process->program().contains("sshfs_server"))
+        {
+            EXPECT_CALL(*process, terminate);
+        }
+    };
+    factory->register_callback(sshfs_fails);
+
+    mp::SSHFSMounts sshfs_mounts(key_provider);
+
+    NiceMock<mpt::MockVirtualMachine> vm{"my_instance"};
+
+    sshfs_mounts.start_mount(&vm, source_path, target_path, gid_map, uid_map);
+    int ret = sshfs_mounts.stop_mount(vm.vm_name, target_path);
+    ASSERT_TRUE(ret);
+}
+
+TEST_F(SSHFSMountsTest, stop_all_mounts_terminates_all_sshfs_processes)
+{
+    auto factory = mpt::MockProcessFactory::Inject();
+    mpt::MockProcessFactory::Callback sshfs_fails = [this](mpt::MockProcess* process) {
+        sshfs_prints_connected(process);
+
+        if (process->program().contains("sshfs_server"))
+        {
+            EXPECT_CALL(*process, terminate);
+        }
+    };
+    factory->register_callback(sshfs_fails);
+
+    mp::SSHFSMounts sshfs_mounts(key_provider);
+
+    NiceMock<mpt::MockVirtualMachine> vm{"my_instance"};
+
+    sshfs_mounts.start_mount(&vm, "/source/one", "/target/one", gid_map, uid_map);
+    sshfs_mounts.start_mount(&vm, "/source/two", "/target/two", gid_map, uid_map);
+    sshfs_mounts.start_mount(&vm, "/source/three", "/target/three", gid_map, uid_map);
+
+    sshfs_mounts.stop_all_mounts_for_instance(vm.vm_name);
+}
+
+TEST_F(SSHFSMountsTest, has_instance_already_mounted_returns_true_when_found)
+{
+    auto factory = mpt::MockProcessFactory::Inject();
+    factory->register_callback(sshfs_prints_connected);
+
+    mp::SSHFSMounts sshfs_mounts(key_provider);
+
+    NiceMock<mpt::MockVirtualMachine> vm{"my_instance"};
+
+    sshfs_mounts.start_mount(&vm, source_path, target_path, gid_map, uid_map);
+
+    EXPECT_TRUE(sshfs_mounts.has_instance_already_mounted(vm.vm_name, target_path));
+}
+
+TEST_F(SSHFSMountsTest, has_instance_already_mounted_returns_false_when_no_such_mount)
+{
+    auto factory = mpt::MockProcessFactory::Inject();
+    factory->register_callback(sshfs_prints_connected);
+
+    mp::SSHFSMounts sshfs_mounts(key_provider);
+
+    NiceMock<mpt::MockVirtualMachine> vm{"my_instance"};
+
+    sshfs_mounts.start_mount(&vm, source_path, target_path, gid_map, uid_map);
+
+    EXPECT_FALSE(sshfs_mounts.has_instance_already_mounted(vm.vm_name, "/bad/path"));
+}
+
+TEST_F(SSHFSMountsTest, has_instance_already_mounted_returns_false_when_no_such_instance)
+{
+    auto factory = mpt::MockProcessFactory::Inject();
+    factory->register_callback(sshfs_prints_connected);
+
+    mp::SSHFSMounts sshfs_mounts(key_provider);
+
+    NiceMock<mpt::MockVirtualMachine> vm{"my_instance"};
+
+    sshfs_mounts.start_mount(&vm, source_path, target_path, gid_map, uid_map);
+
+    EXPECT_FALSE(sshfs_mounts.has_instance_already_mounted("bad_vm_name", target_path));
+}


### PR DESCRIPTION
Move sshfs server from thread to separate process. Each mount spawns a new sshfs process.
Move book-keeping of mounts into dedicated SSHFSMounts class to simplify Daemon.

Make creation of this sshfs server process a platform responsibility (as different platforms will apply different security policies - will be applied in followup).