### PR TITLE
Compile fix for older compiler

### DIFF
--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -113,8 +113,9 @@ void checked_set(QSettings& settings, const QString& key, const QString& val)
 
 QString interpret_bool(QString val)
 { // constrain accepted values to avoid QVariant::toBool interpreting non-empty strings (such as "nope") as true
-    static constexpr auto convert_to_true = {"on", "yes", "1"};
-    static constexpr auto convert_to_false = {"off", "no", "0"};
+  // Note: "std::array" needed to please VSC++17
+    static constexpr auto convert_to_true = std::array{"on", "yes", "1"};
+    static constexpr auto convert_to_false = std::array{"off", "no", "0"};
     val = val.toLower();
 
     if (std::find(cbegin(convert_to_true), cend(convert_to_true), val) != cend(convert_to_true))


### PR DESCRIPTION
Needed to fix VSC++17 error: 
```
error C2131: expression did not evaluate to a constant
note: failure was caused by non-constant arguments or reference to a non-constant symbol
```
