### PR TITLE
Fix autostart tests

### DIFF
--- a/tests/test_platform_linux.cpp
+++ b/tests/test_platform_linux.cpp
@@ -99,6 +99,7 @@ TEST_F(PlatformLinux, test_autostart_desktop_file_properly_placed)
 
     QDir data_dir{test_dir.filePath("data")};
     QDir config_dir{test_dir.filePath("config")};
+    const auto guard_home = temporarily_change_env("HOME", "hide/me");
     const auto guard_xdg_config = temporarily_change_env("XDG_CONFIG_HOME", config_dir.path().toLatin1());
     const auto guard_xdg_data = temporarily_change_env("XDG_DATA_DIRS", data_dir.path().toLatin1());
 

--- a/tests/test_platform_linux.cpp
+++ b/tests/test_platform_linux.cpp
@@ -52,6 +52,7 @@ void setup_driver_settings(const QString& driver)
         expectation.WillRepeatedly(Return(driver));
 }
 
+// hold on to return until the change is to be discarded
 auto temporarily_change_env(const char* var_name, QByteArray var_value)
 {
     auto guard = sg::make_scope_guard([var_name, var_save = qgetenv(var_name)]() { qputenv(var_name, var_save); });

--- a/tests/test_platform_linux.cpp
+++ b/tests/test_platform_linux.cpp
@@ -97,17 +97,14 @@ TEST_F(PlatformLinux, test_autostart_desktop_file_properly_placed)
     QDir test_dir{QDir::temp().filePath(QString{"%1_%2"}.arg(mp::client_name, "autostart_test"))};
     ASSERT_FALSE(test_dir.exists());
 
-    const auto cleanup = sg::make_scope_guard(
-        [&test_dir, config_home_save = qgetenv("XDG_CONFIG_HOME"), data_dir_save = qgetenv("XDG_DATA_DIRS")]() {
-            test_dir.removeRecursively(); // succeeds if not there
-            qputenv("XDG_CONFIG_HOME", config_home_save);
-            qputenv("XDG_DATA_DIRS", data_dir_save);
-        });
-
     QDir data_dir{test_dir.filePath("data")};
     QDir config_dir{test_dir.filePath("config")};
-    qputenv("XDG_CONFIG_HOME", config_dir.path().toLatin1());
-    qputenv("XDG_DATA_DIRS", data_dir.path().toLatin1());
+    const auto guard_xdg_config = temporarily_change_env("XDG_CONFIG_HOME", config_dir.path().toLatin1());
+    const auto guard_xdg_data = temporarily_change_env("XDG_DATA_DIRS", data_dir.path().toLatin1());
+
+    const auto cleanup = sg::make_scope_guard([&test_dir]() {
+        test_dir.removeRecursively(); // succeeds if not there
+    });
 
     QDir mp_data_dir{data_dir.filePath(mp::client_name)};
     QDir autostart_dir{config_dir.filePath("autostart")};


### PR DESCRIPTION
Autostart tests were failing when instructions in #1045 were followed. This is because they were not accounting for a matching desktop file in HOME. This fixes that.