### PR TITLE
Prepare for tests using ProcessFactory to not be linux-only

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,13 +21,12 @@ list(APPEND CMOCK_TARGETS
   scp_test
   ssh_client_test)
 
+set (PLATFORM_INCLUDES ${CMAKE_SOURCE_DIR}/src/platform/backends/shared/linux)
+
 include(c_mock_defines.cmake)
 
 list(APPEND PLATFORM_TESTS
   mock_libvirt.cpp
-  mock_process_factory.cpp
-  reset_process_factory.cpp
-  stub_process_factory.cpp
   test_apparmored_process.cpp
   test_platform_linux.cpp
   test_qemu_backend.cpp
@@ -92,6 +91,7 @@ add_executable(multipass_tests
   image_host_remote_count.cpp
   main.cpp
   mischievous_url_downloader.cpp
+  mock_process_factory.cpp
   mock_scp.cpp
   mock_settings.cpp
   mock_sftp.cpp
@@ -99,6 +99,8 @@ add_executable(multipass_tests
   mock_ssh.cpp
   mock_ssh_client.cpp
   path.cpp
+  reset_process_factory.cpp
+  stub_process_factory.cpp
   temp_dir.cpp
   temp_file.cpp
   test_basic_process.cpp
@@ -143,6 +145,7 @@ add_executable(multipass_tests
 )
 
 target_include_directories(multipass_tests
+  PRIVATE ${PLATFORM_INCLUDES}
   PRIVATE ${CMAKE_SOURCE_DIR}
   PRIVATE ${CMAKE_SOURCE_DIR}/src/platform/backends
   PRIVATE ${MULTIPASS_GTEST_DIR}

--- a/tests/mock_process_factory.h
+++ b/tests/mock_process_factory.h
@@ -18,10 +18,10 @@
 #ifndef MULTIPASS_MOCK_PROCESS_FACTORY_H
 #define MULTIPASS_MOCK_PROCESS_FACTORY_H
 
+#include "process_factory.h" // rely on build system to include the right implementation
 #include <gmock/gmock.h>
 #include <multipass/optional.h>
 #include <multipass/process.h>
-#include <src/platform/backends/shared/linux/process_factory.h>
 
 #include <functional>
 

--- a/tests/reset_process_factory.h
+++ b/tests/reset_process_factory.h
@@ -18,7 +18,7 @@
 #ifndef MULTIPASS_RESETABLE_PROCESS_FACTORY_H
 #define MULTIPASS_RESETABLE_PROCESS_FACTORY_H
 
-#include <src/platform/backends/shared/linux/process_factory.h>
+#include "process_factory.h" // rely on build system to include the right implementation
 
 namespace multipass
 {

--- a/tests/stub_process_factory.h
+++ b/tests/stub_process_factory.h
@@ -18,8 +18,8 @@
 #ifndef MULTIPASS_STUB_PROCESS_FACTORY_H
 #define MULTIPASS_STUB_PROCESS_FACTORY_H
 
+#include "process_factory.h" // rely on build system to include the right implementation
 #include <multipass/process.h>
-#include <src/platform/backends/shared/linux/process_factory.h>
 
 #include <gtest/gtest.h>
 

--- a/tests/test_sshfs_server_process_spec.cpp
+++ b/tests/test_sshfs_server_process_spec.cpp
@@ -49,8 +49,15 @@ TEST_F(TestSSHFSServerProcessSpec, program_correct)
 TEST_F(TestSSHFSServerProcessSpec, arguments_correct)
 {
     mp::SSHFSServerProcessSpec spec(config);
-    EXPECT_EQ(spec.arguments(),
-              QStringList({"host", "42", "username", "source_path", "target_path", "6:10,5:-1,", "3:4,1:2,"}));
+    ASSERT_EQ(spec.arguments().size(), 7);
+    EXPECT_EQ(spec.arguments()[0], "host");
+    EXPECT_EQ(spec.arguments()[1], "42");
+    EXPECT_EQ(spec.arguments()[2], "username");
+    EXPECT_EQ(spec.arguments()[3], "source_path");
+    EXPECT_EQ(spec.arguments()[4], "target_path");
+    // Ordering of below options not guaranteed, hence the or-s.
+    EXPECT_TRUE(spec.arguments()[5] == "6:10,5:-1," || spec.arguments()[6] == "6:10,5:-1,");
+    EXPECT_TRUE(spec.arguments()[5] == "3:4,1:2," || spec.arguments()[6] == "3:4,1:2,");
 }
 
 TEST_F(TestSSHFSServerProcessSpec, environment_correct)

--- a/tests/test_sshfsmounts.cpp
+++ b/tests/test_sshfsmounts.cpp
@@ -77,8 +77,16 @@ TEST_F(SSHFSMountsTest, mount_creates_sshfs_process)
     ASSERT_EQ(factory->process_list().size(), 1u);
     auto sshfs_command = factory->process_list()[0];
     EXPECT_TRUE(sshfs_command.command.endsWith("sshfs_server"));
-    EXPECT_EQ(sshfs_command.arguments, QStringList({"localhost", "42", "ubuntu", "/my/source/path", "/the/target/path",
-                                                    "6:10,5:-1,", "3:4,1:2,"}));
+
+    ASSERT_EQ(sshfs_command.arguments.size(), 7);
+    EXPECT_EQ(sshfs_command.arguments[0], "localhost");
+    EXPECT_EQ(sshfs_command.arguments[1], "42");
+    EXPECT_EQ(sshfs_command.arguments[2], "ubuntu");
+    EXPECT_EQ(sshfs_command.arguments[3], "/my/source/path");
+    EXPECT_EQ(sshfs_command.arguments[4], "/the/target/path");
+    // Ordering of below options not guaranteed, hence the or-s.
+    EXPECT_TRUE(sshfs_command.arguments[5] == "6:10,5:-1," || sshfs_command.arguments[6] == "6:10,5:-1,");
+    EXPECT_TRUE(sshfs_command.arguments[5] == "3:4,1:2," || sshfs_command.arguments[6] == "3:4,1:2,");
 }
 
 TEST_F(SSHFSMountsTest, sshfs_process_failing_with_return_code_9_causes_exception)


### PR DESCRIPTION
And fix tests to not rely on the ordering from iterating over an unordered_map