### PR TITLE
Small Process API improvements/fixes

### DIFF
--- a/include/multipass/process.h
+++ b/include/multipass/process.h
@@ -105,9 +105,10 @@ public:
 signals:
     void started();
     void finished(multipass::ProcessState process_state);
-    void state_changed(QProcess::ProcessState state);  // not running, starting, running
-    void error_occurred(QProcess::ProcessError error); // FailedToStart (file not found / resource error) Crashed,
-                                                       // Timedout, ReadError, WriteError, UnknownError
+    void state_changed(QProcess::ProcessState state); // not running, starting, running
+    void error_occurred(QProcess::ProcessError error,
+                        QString error_string); // FailedToStart (file not found / resource error) Crashed,
+                                               // Timedout, ReadError, WriteError, UnknownError
     void ready_read_standard_output();
     void ready_read_standard_error();
 

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -253,16 +253,17 @@ mp::QemuVirtualMachine::QemuVirtualMachine(const VirtualMachineDescription& desc
                  fmt::format("process state changed to {}", utils::qenum_to_string(newState)));
     });
 
-    QObject::connect(vm_process.get(), &Process::error_occurred, [this](QProcess::ProcessError error) {
-        // We just kill the process when suspending, so we don't want to print
-        // out any scary error messages for this state
-        if (update_shutdown_status)
-        {
-            mpl::log(mpl::Level::error, vm_name,
-                     fmt::format("process error occurred {}", utils::qenum_to_string(error)));
-            on_error();
-        }
-    });
+    QObject::connect(
+        vm_process.get(), &Process::error_occurred, [this](QProcess::ProcessError error, QString error_string) {
+            // We just kill the process when suspending, so we don't want to print
+            // out any scary error messages for this state
+            if (update_shutdown_status)
+            {
+                mpl::log(mpl::Level::error, vm_name,
+                         fmt::format("process error occurred {} {}", utils::qenum_to_string(error), error_string));
+                on_error();
+            }
+        });
 
     QObject::connect(vm_process.get(), &Process::finished, [this](ProcessState process_state) {
         if (process_state.exit_code)

--- a/src/platform/backends/shared/basic_process.cpp
+++ b/src/platform/backends/shared/basic_process.cpp
@@ -22,9 +22,10 @@
 namespace mp = multipass;
 namespace mpl = multipass::logging;
 
-namespace {
-    // Want to call qRegisterMetaType just once
-    static auto reg = qRegisterMetaType<multipass::ProcessState>();
+namespace
+{
+// Want to call qRegisterMetaType just once
+static auto reg = qRegisterMetaType<multipass::ProcessState>();
 } // namespace
 
 mp::BasicProcess::CustomQProcess::CustomQProcess(BasicProcess* p) : p{p}
@@ -53,7 +54,8 @@ mp::BasicProcess::BasicProcess(std::unique_ptr<mp::ProcessSpec>&& spec) : proces
                 }
                 emit mp::Process::finished(process_state);
             });
-    connect(&process, &QProcess::errorOccurred, this, &mp::Process::error_occurred);
+    connect(&process, &QProcess::errorOccurred,
+            [this](QProcess::ProcessError error) { emit mp::Process::error_occurred(error, process.errorString()); });
     connect(&process, &QProcess::readyReadStandardOutput, this, &mp::Process::ready_read_standard_output);
     connect(&process, &QProcess::readyReadStandardError, this, &mp::Process::ready_read_standard_error);
 

--- a/src/platform/backends/shared/basic_process.cpp
+++ b/src/platform/backends/shared/basic_process.cpp
@@ -25,7 +25,11 @@ namespace mpl = multipass::logging;
 namespace
 {
 // Want to call qRegisterMetaType just once
-static auto reg = qRegisterMetaType<multipass::ProcessState>();
+static auto reg = []() -> bool {
+    qRegisterMetaType<multipass::ProcessState>();
+    qRegisterMetaType<QProcess::ProcessError>();
+    return true;
+}();
 } // namespace
 
 mp::BasicProcess::CustomQProcess::CustomQProcess(BasicProcess* p) : p{p}

--- a/src/sshfs_mount/sshfs_mounts.cpp
+++ b/src/sshfs_mount/sshfs_mounts.cpp
@@ -22,6 +22,7 @@
 #include <multipass/ssh/ssh_key_provider.h>
 #include <multipass/sshfs_mount/sshfs_mounts.h>
 #include <multipass/sshfs_server_config.h>
+#include <multipass/utils.h>
 #include <multipass/virtual_machine.h>
 
 #include <QEventLoop>
@@ -103,10 +104,11 @@ void mp::SSHFSMounts::start_mount(VirtualMachine* vm, const std::string& source_
 
     QObject::connect(
         sshfs_server_process.get(), &mp::Process::error_occurred, this,
-        [instance = vm->vm_name, target_path, process = sshfs_server_process.get()](QProcess::ProcessError error) {
+        [instance = vm->vm_name, target_path, process = sshfs_server_process.get()](QProcess::ProcessError error,
+                                                                                    QString error_string) {
             mpl::log(mpl::Level::error, category,
-                     fmt::format("There was an error with sshfs_server for instance \"{}\" with path '{}': {}",
-                                 instance, target_path, error));
+                     fmt::format("There was an error with sshfs_server for instance \"{}\" with path '{}': {} - {}",
+                                 instance, target_path, mp::utils::qenum_to_string(error), error_string));
         });
 
     mpl::log(mpl::Level::info, category, fmt::format("mounting {} => {} in {}", source_path, target_path, vm->vm_name));


### PR DESCRIPTION
- If an error occurs, while ProcessError does say why, the errorString() can reveal more details as to what happened (e.g. on Windows it can return Windows API error messages that are useful)
- fix bug where ProcessError enum wasn't registered with the signal/slot mechanism