### PR TITLE
Small changes to enhance cross-platform support

### DIFF
--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -57,8 +57,8 @@ bool is_alias_supported(const std::string& alias, const std::string& remote);
 bool is_remote_supported(const std::string& remote);
 bool is_image_url_supported();
 
-void emit_signal_when_parent_dies(int sig);
-int wait_for_signals(const std::vector<int>& sigs);
+void emit_signal_when_parent_dies();
+int wait_for_quit_signals();
 } // namespace platform
 } // namespace multipass
 #endif // MULTIPASS_PLATFORM_H

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -167,7 +167,7 @@ bool mp::platform::is_image_url_supported()
     return true;
 }
 
-void mp::platform::emit_signal_when_parent_dies(int sig)
+void mp::platform::emit_signal_when_parent_dies()
 {
-    prctl(PR_SET_PDEATHSIG, sig); // ensures if parent dies, this process it sent this signal
+    prctl(PR_SET_PDEATHSIG, SIGHUP); // ensures if parent dies, this process it sent this signal
 }

--- a/src/platform/platform_unix.cpp
+++ b/src/platform/platform_unix.cpp
@@ -104,9 +104,9 @@ sigset_t mp::platform::make_and_block_signals(const std::vector<int>& sigs)
     return sigset;
 }
 
-int mp::platform::wait_for_signals(const std::vector<int>& sigs)
+int mp::platform::wait_for_quit_signals()
 {
-    auto sigset{make_and_block_signals(sigs)};
+    auto sigset{make_and_block_signals({SIGQUIT, SIGTERM, SIGHUP})};
     int sig = -1;
     sigwait(&sigset, &sig);
     return sig;

--- a/src/sshfs_mount/sshfs_server.cpp
+++ b/src/sshfs_mount/sshfs_server.cpp
@@ -29,8 +29,6 @@
 #include <multipass/ssh/ssh_session.h>
 #include <multipass/sshfs_mount/sshfs_mount.h>
 
-#include <signal.h>
-
 namespace mp = multipass;
 namespace mpl = multipass::logging;
 namespace mpp = multipass::platform;
@@ -67,7 +65,7 @@ unordered_map<int, int> deserialise_id_map(const char* in)
 
 int main(int argc, char* argv[])
 {
-    mpp::emit_signal_when_parent_dies(SIGHUP); // works on linux only
+    mpp::emit_signal_when_parent_dies(); // works on linux only
 
     if (argc != 8)
     {
@@ -75,7 +73,7 @@ int main(int argc, char* argv[])
         exit(2);
     }
 
-    const auto key = getenv("KEY");
+    const auto key = qgetenv("KEY");
     if (key == nullptr)
     {
         cerr << "KEY not set" << endl;
@@ -100,7 +98,7 @@ int main(int argc, char* argv[])
         mp::SshfsMount sshfs_mount(move(session), source_path, target_path, gid_map, uid_map);
 
         // ssh lives on its own thread, use this thread to listen for quit signal
-        int sig = mpp::wait_for_signals({SIGQUIT, SIGTERM, SIGHUP});
+        int sig = mpp::wait_for_quit_signals();
         cout << "Received signal " << sig << ". Stopping" << endl;
         sshfs_mount.stop();
         exit(0);

--- a/tests/stub_process_factory.cpp
+++ b/tests/stub_process_factory.cpp
@@ -118,7 +118,7 @@ public:
 };
 } // namespace
 
-std::unique_ptr<mp::Process> mpt::StubProcessFactory::create_process(std::unique_ptr<ProcessSpec>&& spec) const
+std::unique_ptr<mp::Process> mpt::StubProcessFactory::create_process(std::unique_ptr<mp::ProcessSpec>&& spec) const
 {
     return std::make_unique<StubProcess>(std::move(spec),
                                          const_cast<std::vector<mpt::StubProcessFactory::ProcessInfo>&>(process_list));


### PR DESCRIPTION
Main change: while signal.h is a Windows header too, is it far more limited in functionality. Best not use it except in platform-specific places