### PR TITLE
Fix exception slicing

### DIFF
--- a/src/sshfs_mount/sshfs_server.cpp
+++ b/src/sshfs_mount/sshfs_server.cpp
@@ -103,7 +103,7 @@ int main(int argc, char* argv[])
         sshfs_mount.stop();
         exit(0);
     }
-    catch (const mp::SSHFSMissingError)
+    catch (const mp::SSHFSMissingError&)
     {
         cerr << "SSHFS was not found on the host: " << host << endl;
         exit(9);


### PR DESCRIPTION
Exceptions should be caught by reference to avoid slicing. My compiler (gcc 8.3) detected that and failed the build. This fixes it.