### PR TITLE
[iptables] Clear rules on also when daemon starts

### DIFF
--- a/src/platform/backends/qemu/iptables_config.cpp
+++ b/src/platform/backends/qemu/iptables_config.cpp
@@ -232,6 +232,7 @@ mp::IPTablesConfig::IPTablesConfig(const QString& bridge_name, const std::string
 {
     try
     {
+        clear_all_iptables_rules();
         set_iptables_rules(bridge_name, cidr, comment);
     }
     catch (const std::exception& e)


### PR DESCRIPTION
To only add rules to a clean `iptables` slate. Fixes #1093.