### PR TITLE
Provide available settings (Fixes #1023)

### DIFF
--- a/include/multipass/settings.h
+++ b/include/multipass/settings.h
@@ -25,6 +25,7 @@
 #include <QVariant>
 
 #include <map>
+#include <set>
 
 namespace multipass
 {
@@ -33,6 +34,7 @@ class Settings : public Singleton<Settings>
 public:
     Settings(const Singleton<Settings>::PrivatePass&);
 
+    std::set<QString> keys() const;
     virtual QString get(const QString& key) const;            // throws on unknown key
     virtual void set(const QString& key, const QString& val); // throws on unknown key or bad settings
 

--- a/src/client/cli/cmd/common_cli.cpp
+++ b/src/client/cli/cmd/common_cli.cpp
@@ -21,6 +21,7 @@
 #include <multipass/cli/argparser.h>
 #include <multipass/cli/format_utils.h>
 #include <multipass/exceptions/settings_exceptions.h>
+#include <multipass/settings.h>
 
 #include <fmt/ostream.h>
 #include <sstream>
@@ -153,4 +154,11 @@ mp::ReturnCode cmd::run_cmd_and_retry(const QStringList& args, const mp::ArgPars
 auto cmd::return_code_from(const mp::SettingsException& e) -> mp::ReturnCode
 {
     return dynamic_cast<const InvalidSettingsException*>(&e) ? ReturnCode::CommandLineError : ReturnCode::CommandFail;
+}
+
+QString multipass::cmd::describe_settings_keys()
+{
+    const auto keys = Settings::instance().keys();
+    return std::accumulate(cbegin(keys), cend(keys), QStringLiteral("Keys:"),
+                           [](const auto& a, const auto& b) { return a + "\n  " + b; });
 }

--- a/src/client/cli/cmd/common_cli.h
+++ b/src/client/cli/cmd/common_cli.h
@@ -46,6 +46,7 @@ std::string instance_action_message_for(const InstanceNames& instance_names, con
 ReturnCode run_cmd(const QStringList& args, const ArgParser* parser, std::ostream& cout, std::ostream& cerr);
 ReturnCode run_cmd_and_retry(const QStringList& args, const ArgParser* parser, std::ostream& cout, std::ostream& cerr);
 ReturnCode return_code_from(const SettingsException& e);
+QString describe_settings_keys();
 
 // helpers for update handling
 bool update_available(const multipass::UpdateInfo& update_info);

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -60,11 +60,8 @@ QString cmd::Get::short_help() const
 
 QString cmd::Get::description() const
 {
-    auto desc = QStringLiteral("Get the configuration setting corresponding to the given key.\n\n"
-                               "Keys:");
-    const auto keys = Settings::instance().keys();
-
-    return std::accumulate(cbegin(keys), cend(keys), desc, [](const auto& a, const auto& b) { return a + "\n  " + b; });
+    auto desc = QStringLiteral("Get the configuration setting corresponding to the given key.");
+    return desc + "\n\n" + describe_settings_keys();
 }
 
 mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -55,17 +55,17 @@ std::string cmd::Get::name() const
 
 QString cmd::Get::short_help() const
 {
-    return QStringLiteral("Get a configuration option");
+    return QStringLiteral("Get a configuration setting");
 }
 
 QString cmd::Get::description() const
 {
-    return QStringLiteral("Get the configuration option corresponding to the given key");
+    return QStringLiteral("Get the configuration setting corresponding to the given key");
 }
 
 mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)
 {
-    parser->addPositionalArgument("key", "Path to the option whose configured value should be obtained.", "<key>");
+    parser->addPositionalArgument("key", "Path to the setting whose configured value should be obtained.", "<key>");
 
     auto status = parser->commandParse(this);
     if (status == ParseCode::Ok)
@@ -77,7 +77,7 @@ mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)
         }
         else
         {
-            cerr << "Need exactly one option key.\n";
+            cerr << "Need exactly one setting key.\n";
             status = ParseCode::CommandLineError;
         }
     }

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -60,7 +60,11 @@ QString cmd::Get::short_help() const
 
 QString cmd::Get::description() const
 {
-    return QStringLiteral("Get the configuration setting corresponding to the given key");
+    auto desc = QStringLiteral("Get the configuration setting corresponding to the given key.\n\n"
+                               "Keys:");
+    const auto keys = Settings::instance().keys();
+
+    return std::accumulate(cbegin(keys), cend(keys), desc, [](const auto& a, const auto& b) { return a + "\n  " + b; });
 }
 
 mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)

--- a/src/client/cli/cmd/set.cpp
+++ b/src/client/cli/cmd/set.cpp
@@ -101,7 +101,8 @@ QString cmd::Set::short_help() const
 
 QString cmd::Set::description() const
 {
-    return QStringLiteral("Set, to the given value, the configuration setting corresponding to the given key");
+    auto desc = QStringLiteral("Set, to the given value, the configuration setting corresponding to the given key.");
+    return desc + "\n\n" + describe_settings_keys();
 }
 
 mp::ParseCode cmd::Set::parse_args(mp::ArgParser* parser)

--- a/src/client/cli/cmd/set.cpp
+++ b/src/client/cli/cmd/set.cpp
@@ -96,19 +96,19 @@ std::string cmd::Set::name() const
 
 QString cmd::Set::short_help() const
 {
-    return QStringLiteral("Set a configuration option");
+    return QStringLiteral("Set a configuration setting");
 }
 
 QString cmd::Set::description() const
 {
-    return QStringLiteral("Set, to the given value, the configuration option corresponding to the given key");
+    return QStringLiteral("Set, to the given value, the configuration setting corresponding to the given key");
 }
 
 mp::ParseCode cmd::Set::parse_args(mp::ArgParser* parser)
 {
     parser->addPositionalArgument(
         "keyval",
-        "A key-value pair. The key specifies a path to the option to configure. The value is its intended value.",
+        "A key-value pair. The key specifies a path to the setting to configure. The value is its intended value.",
         "<key>=<value>");
 
     auto status = parser->commandParse(this);

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -29,6 +29,7 @@
 #include <cassert>
 #include <cerrno>
 #include <fstream>
+#include <iterator>
 #include <stdexcept>
 
 namespace mp = multipass;
@@ -130,6 +131,15 @@ QString interpret_bool(QString val)
 mp::Settings::Settings(const Singleton<Settings>::PrivatePass& pass)
     : Singleton<Settings>::Singleton{pass}, defaults{make_defaults()}
 {
+}
+
+std::set<QString> multipass::Settings::keys() const
+{
+    std::set<QString> ret{};
+    std::transform(cbegin(defaults), cend(defaults), std::inserter(ret, begin(ret)),
+                   [](const auto& elem) { return elem.first; }); // I wish get<0> worked here... maybe in C++20
+
+    return ret;
 }
 
 // TODO try installing yaml backend


### PR DESCRIPTION
Addresses #1023 

This lists available configuration keys in `get` and `set`. I ideally they should offer guidance on what each key means and what values are allowed, but that will require more thought.