### PR TITLE
image_vault: Delete old images from the cache

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -701,36 +701,43 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
     // Fire timer every six hours to perform maintenance on source images such as
     // pruning expired images and updating to newly released images.
     connect(&source_images_maintenance_task, &QTimer::timeout, [this]() {
-        QtConcurrent::run([this] {
-            config->vault->prune_expired_images();
+        if (image_update_future.isRunning())
+        {
+            mpl::log(mpl::Level::info, category, "Image updater already running. Skipping…");
+        }
+        else
+        {
+            image_update_future = QtConcurrent::run([this] {
+                config->vault->prune_expired_images();
 
-            auto prepare_action = [this](const VMImage& source_image) -> VMImage {
-                return config->factory->prepare_source_image(source_image);
-            };
+                auto prepare_action = [this](const VMImage& source_image) -> VMImage {
+                    return config->factory->prepare_source_image(source_image);
+                };
 
-            auto download_monitor = [](int download_type, int percentage) {
-                static int last_percentage_logged = -1;
-                if (percentage % 10 == 0)
-                {
-                    // Note: The progress callback may be called repeatedly with the same percentage,
-                    // so this logic is to only log it once
-                    if (last_percentage_logged != percentage)
+                auto download_monitor = [](int download_type, int percentage) {
+                    static int last_percentage_logged = -1;
+                    if (percentage % 10 == 0)
                     {
-                        mpl::log(mpl::Level::info, category, fmt::format("  {}%", percentage));
-                        last_percentage_logged = percentage;
+                        // Note: The progress callback may be called repeatedly with the same percentage,
+                        // so this logic is to only log it once
+                        if (last_percentage_logged != percentage)
+                        {
+                            mpl::log(mpl::Level::info, category, fmt::format("  {}%", percentage));
+                            last_percentage_logged = percentage;
+                        }
                     }
+                    return true;
+                };
+                try
+                {
+                    config->vault->update_images(config->factory->fetch_type(), prepare_action, download_monitor);
                 }
-                return true;
-            };
-            try
-            {
-                config->vault->update_images(config->factory->fetch_type(), prepare_action, download_monitor);
-            }
-            catch (const std::exception& e)
-            {
-                mpl::log(mpl::Level::error, category, fmt::format("Error updating images: {}", e.what()));
-            }
-        });
+                catch (const std::exception& e)
+                {
+                    mpl::log(mpl::Level::error, category, fmt::format("Error updating images: {}", e.what()));
+                }
+            });
+        }
     });
     source_images_maintenance_task.start(config->image_refresh_timer);
 }

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -177,6 +177,7 @@ private:
     std::unordered_map<std::string, QFuture<std::string>> async_running_futures;
     std::mutex start_mutex;
     std::unordered_set<std::string> preparing_instances;
+    QFuture<void> image_update_future;
 };
 } // namespace multipass
 #endif // MULTIPASS_DAEMON_H

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -226,6 +226,18 @@ void verify_image_download(const mp::Path& image_path, const std::string& image_
     }
 }
 
+void delete_image_dir(const mp::Path& image_path)
+{
+    QFileInfo image_file{image_path};
+    if (image_file.exists())
+    {
+        if (image_file.isDir())
+            QDir(image_path).removeRecursively();
+        else
+            image_file.dir().removeRecursively();
+    }
+}
+
 class DeleteOnException
 {
 public:
@@ -498,11 +510,24 @@ void mp::DefaultVMImageVault::prune_expired_images()
         {
             mpl::log(
                 mpl::Level::info, category,
-                fmt::format("Source image {} is expired. Removing it from the cache.\n", record.second.query.release));
+                fmt::format("Source image {} is expired. Removing it from the cache.", record.second.query.release));
             expired_keys.push_back(record.first);
-            QFileInfo image_file{record.second.image.image_path};
-            if (image_file.exists())
-                image_file.dir().removeRecursively();
+            delete_image_dir(record.second.image.image_path);
+        }
+    }
+
+    // Remove any image directories that have no corresponding database entry
+    for (const auto& entry : images_dir.entryInfoList(QDir::AllEntries | QDir::NoDotAndDotDot))
+    {
+        if (std::find_if(prepared_image_records.cbegin(), prepared_image_records.cend(),
+                         [&entry](const std::pair<std::string, VaultRecord>& record) {
+                             return record.second.image.image_path.contains(entry.absoluteFilePath());
+                         }) == prepared_image_records.cend())
+        {
+            mpl::log(mpl::Level::info, category,
+                     fmt::format("Source image {} is no longer valid. Removing it from the cache.",
+                                 entry.absoluteFilePath()));
+            delete_image_dir(entry.absoluteFilePath());
         }
     }
 
@@ -515,7 +540,7 @@ void mp::DefaultVMImageVault::prune_expired_images()
 void mp::DefaultVMImageVault::update_images(const FetchType& fetch_type, const PrepareAction& prepare,
                                             const ProgressMonitor& monitor)
 {
-    mpl::log(mpl::Level::debug, category, "Checking for images to update...");
+    mpl::log(mpl::Level::debug, category, "Checking for images to update…");
 
     std::vector<decltype(prepared_image_records)::key_type> keys_to_update;
     for (const auto& record : prepared_image_records)
@@ -545,6 +570,12 @@ void mp::DefaultVMImageVault::update_images(const FetchType& fetch_type, const P
         try
         {
             fetch_image(fetch_type, record.query, prepare, monitor);
+
+            // Remove old image
+            std::lock_guard lock{fetch_mutex};
+            delete_image_dir(record.image.image_path);
+            prepared_image_records.erase(key);
+            persist_image_records();
         }
         catch (const std::exception& e)
         {

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -728,7 +728,10 @@ mp::VMImage mp::DefaultVMImageVault::finalize_image_records(const Query& query, 
         instance_image_records[query.name] = {vm_image, query, std::chrono::system_clock::now()};
     }
 
-    prepared_image_records[id] = {prepared_image, query, std::chrono::system_clock::now()};
+    // Do not save the instance name for prepared images
+    Query prepared_query{query};
+    prepared_query.name = "";
+    prepared_image_records[id] = {prepared_image, prepared_query, std::chrono::system_clock::now()};
 
     persist_instance_records();
     persist_image_records();


### PR DESCRIPTION
This will delete old images in the cache when updating an image and will also remove
any "leaked" images that are no longer in the database.

Fixes #1014