### PR TITLE
image_vault: Catch updater errors and continue

### DIFF
--- a/include/multipass/exceptions/unsupported_image_exception.h
+++ b/include/multipass/exceptions/unsupported_image_exception.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_UNSUPPORTED_IMAGE_EXCEPTION_H
+#define MULTIPASS_UNSUPPORTED_IMAGE_EXCEPTION_H
+
+#include <stdexcept>
+
+#include <multipass/format.h>
+
+namespace multipass
+{
+class UnsupportedImageException : public std::runtime_error
+{
+public:
+    UnsupportedImageException(const std::string& release)
+        : runtime_error(fmt::format("The {} release is no longer supported.", release))
+    {
+    }
+};
+} // namespace multipass
+#endif // MULTIPASS_UNSUPPORTED_IMAGE_EXCEPTION_H

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -19,6 +19,7 @@
 #include "json_writer.h"
 
 #include <multipass/exceptions/create_image_exception.h>
+#include <multipass/exceptions/unsupported_image_exception.h>
 #include <multipass/logging/log.h>
 #include <multipass/platform.h>
 #include <multipass/query.h>
@@ -530,10 +531,9 @@ void mp::DefaultVMImageVault::update_images(const FetchType& fetch_type, const P
                     keys_to_update.push_back(record.first);
                 }
             }
-            catch (const std::exception& e)
+            catch (const mp::UnsupportedImageException& e)
             {
-                mpl::log(mpl::Level::warning, category,
-                         fmt::format("Skipping {}: {}", record.second.query.release, e.what()));
+                mpl::log(mpl::Level::warning, category, fmt::format("Skipping update: {}", e.what()));
             }
         }
     }

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -522,10 +522,18 @@ void mp::DefaultVMImageVault::update_images(const FetchType& fetch_type, const P
         if (record.second.query.query_type == Query::Type::Alias &&
             record.first.compare(0, record.second.query.release.length(), record.second.query.release) != 0)
         {
-            auto info = info_for(record.second.query);
-            if (info.id.toStdString() != record.first)
+            try
             {
-                keys_to_update.push_back(record.first);
+                auto info = info_for(record.second.query);
+                if (info.id.toStdString() != record.first)
+                {
+                    keys_to_update.push_back(record.first);
+                }
+            }
+            catch (const std::exception& e)
+            {
+                mpl::log(mpl::Level::warning, category,
+                         fmt::format("Skipping {}: {}", record.second.query.release, e.what()));
             }
         }
     }
@@ -534,7 +542,15 @@ void mp::DefaultVMImageVault::update_images(const FetchType& fetch_type, const P
     {
         const auto& record = prepared_image_records[key];
         mpl::log(mpl::Level::info, category, fmt::format("Updating {} source image to latest", record.query.release));
-        fetch_image(fetch_type, record.query, prepare, monitor);
+        try
+        {
+            fetch_image(fetch_type, record.query, prepare, monitor);
+        }
+        catch (const std::exception& e)
+        {
+            mpl::log(mpl::Level::warning, category,
+                     fmt::format("Cannot update source image {}: {}", record.query.release, e.what()));
+        }
     }
 }
 

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -22,6 +22,7 @@
 #include <multipass/url_downloader.h>
 
 #include <multipass/exceptions/download_exception.h>
+#include <multipass/exceptions/unsupported_image_exception.h>
 
 #include <multipass/format.h>
 
@@ -108,7 +109,7 @@ mp::optional<mp::VMImageInfo> mp::UbuntuVMImageHost::info_for(const Query& query
     if (info)
     {
         if (!info->supported && !query.allow_unsupported)
-            throw std::runtime_error(fmt::format("The {} release is no longer supported.", query.release));
+            throw mp::UnsupportedImageException(query.release);
 
         return with_location_fully_resolved(QString::fromStdString(remote_url_from(remote_name)), *info);
     }

--- a/tests/test_ubuntu_image_host.cpp
+++ b/tests/test_ubuntu_image_host.cpp
@@ -22,6 +22,7 @@
 #include "path.h"
 #include "stub_url_downloader.h"
 
+#include <multipass/exceptions/unsupported_image_exception.h>
 #include <multipass/query.h>
 
 #include <QUrl>
@@ -275,4 +276,11 @@ TEST_F(UbuntuImageHost, handles_and_recovers_from_independent_server_failures)
         url_downloader.mischiefs = i;
         EXPECT_EQ(mpt::count_remotes(host), num_remotes - i);
     }
+}
+
+TEST_F(UbuntuImageHost, throws_unsupported_image_when_image_not_supported)
+{
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+
+    EXPECT_THROW(*host.info_for(make_query("artful", release_remote_spec.first)), mp::UnsupportedImageException);
 }


### PR DESCRIPTION
Catch issues when updating an image, log the issue, and then continue checking other images.

Fixes #1106