### PR TITLE
[doc] Document runtime dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ make
 
 First, install multipass's runtime dependencies. On amd64 architecture, you can achieve that with:
 
-```console
+```
 sudo apt update
 sudo apt install libgl1 libpng16-16 libqt5core5a libqt5gui5 \
     libqt5network5 libqt5widgets5 libxml2 libvirt0 dnsmasq-base \
@@ -159,13 +159,13 @@ sudo apt install libgl1 libpng16-16 libqt5core5a libqt5gui5 \
 ```
 
 Then run multipass's daemon:
-```console
+```
 sudo <multipass>/build/bin/multipassd &
 ```
 
 Copy the desktop file multipass clients expect to find in your home:
 
-```console
+```
 mkdir -p ~/.local/share/multipass/
 cp <multipass>/data/multipass.gui.autostart.desktop ~/.local/share/multipass/
 ```

--- a/README.md
+++ b/README.md
@@ -152,7 +152,10 @@ First, install multipass's runtime dependencies. On amd64 architecture, you can 
 
 ```console
 sudo apt update
-sudo apt install libgl1 libpng16-16 libqt5core5a libqt5gui5 libqt5network5 libqt5widgets5 libxml2 libvirt0 dnsmasq-base dnsmasq-utils qemu-system-x86 qemu-utils libslang2 iproute2 iptables iputils-ping libatm1 libxtables12 xterm
+sudo apt install libgl1 libpng16-16 libqt5core5a libqt5gui5 \
+    libqt5network5 libqt5widgets5 libxml2 libvirt0 dnsmasq-base \
+    dnsmasq-utils qemu-system-x86 qemu-utils libslang2 iproute2 \
+    iptables iputils-ping libatm1 libxtables12 xterm
 ```
 
 Then run multipass's daemon:

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ First, install multipass's runtime dependencies. On amd64 architecture, you can 
 
 ```console
 sudo apt update
-sudo apt install libgl1 libpng16-16 libqt5core5a libqt5gui5 libqt5network5 libqt5widgets5 libxml2 libvirt0 dnsmasq qemu-system-x86 qemu-utils libslang2 iproute2 iptables iputils-ping libatm1 libxtables12 xterm
+sudo apt install libgl1 libpng16-16 libqt5core5a libqt5gui5 libqt5network5 libqt5widgets5 libxml2 libvirt0 dnsmasq-base dnsmasq-utils qemu-system-x86 qemu-utils libslang2 iproute2 iptables iputils-ping libatm1 libxtables12 xterm
 ```
 
 Then run multipass's daemon:

--- a/README.md
+++ b/README.md
@@ -148,11 +148,30 @@ make
 
 ## Running Multipass daemon and client
 
+First, install multipass's runtime dependencies. On amd64 architecture, you can achieve that with:
+
+```console
+sudo apt update
+sudo apt install libgl1 libpng16-16 libqt5core5a libqt5gui5 libqt5network5 libqt5widgets5 libxml2 libvirt0 dnsmasq qemu-system-x86 qemu-utils libslang2 iproute2 iptables iputils-ping libatm1 libxtables12 xterm
 ```
+
+Then run multipass's daemon:
+```console
 sudo <multipass>/build/bin/multipassd &
+```
+
+Copy the desktop file multipass clients expect to find in your home:
+
+```console
 mkdir -p ~/.local/share/multipass/
 cp <multipass>/data/multipass.gui.autostart.desktop ~/.local/share/multipass/
-<multipass>/build/bin/multipass launch --name foo
+```
+
+Finally, use multipass's clients:
+
+```
+<multipass>/build/bin/multipass launch --name foo  # CLI client
+<multipass>/build/bin/multipass.gui                # GUI client
 ```
 
 # More information


### PR DESCRIPTION
Add instructions to install run-time dependencies and split existing running instructions into several steps for coherency.

Fixes #612 