### PR TITLE
[snap] Skim dnsmasq dependency.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -86,7 +86,7 @@ parts:
     - libqt5widgets5
     - libxml2
     - libvirt0
-    - dnsmasq
+    - dnsmasq-base
     source: .
     configflags:
     - -DCMAKE_BUILD_TYPE=RelWithDebInfo


### PR DESCRIPTION
No point depending on the whole dnsmasq daemon. This allows manual runtime dependencies to mimic snaps more closely without interfering with libvirt's own dnsmasq (see https://wiki.libvirt.org/page/Libvirtd_and_dnsmasq).