### PR TITLE
[proc] Mention program name in process error

### DIFF
--- a/src/platform/backends/shared/basic_process.cpp
+++ b/src/platform/backends/shared/basic_process.cpp
@@ -144,6 +144,11 @@ mp::ProcessState mp::BasicProcess::process_state() const
     return state;
 }
 
+QString mp::BasicProcess::error_string() const
+{
+    return QString{"program: %1; error: %2"}.arg(process_spec->program(), process.errorString());
+}
+
 bool mp::BasicProcess::running() const
 {
     return process.state() == QProcess::Running;
@@ -184,11 +189,6 @@ mp::ProcessState mp::BasicProcess::execute(const int timeout)
 
     exit_state.exit_code = process.exitCode();
     return exit_state;
-}
-
-QString mp::BasicProcess::error_string() const
-{
-    return QString{"program: %1; error: %2"}.arg(process_spec->program(), process.errorString());
 }
 
 void mp::BasicProcess::setup_child_process()

--- a/src/platform/backends/shared/basic_process.h
+++ b/src/platform/backends/shared/basic_process.h
@@ -62,6 +62,7 @@ public:
 protected:
     const std::unique_ptr<ProcessSpec> process_spec;
 
+    QString error_string() const;
     void setup_child_process() override;
 
     class CustomQProcess : public QProcess

--- a/src/platform/backends/shared/basic_process.h
+++ b/src/platform/backends/shared/basic_process.h
@@ -50,6 +50,7 @@ public:
 
     bool running() const override;
     ProcessState process_state() const override;
+    QString error_string() const;
 
     QByteArray read_all_standard_output() override;
     QByteArray read_all_standard_error() override;
@@ -62,7 +63,6 @@ public:
 protected:
     const std::unique_ptr<ProcessSpec> process_spec;
 
-    QString error_string() const;
     void setup_child_process() override;
 
     class CustomQProcess : public QProcess

--- a/tests/test_basic_process.cpp
+++ b/tests/test_basic_process.cpp
@@ -190,3 +190,39 @@ TEST_F(BasicProcessTest, process_state_when_runs_and_stops_immediately)
 
     EXPECT_FALSE(process_state.error);
 }
+
+TEST_F(BasicProcessTest, error_string_when_not_run)
+{
+    const auto program = "foo";
+    mp::BasicProcess process{mp::simple_process_spec(program)};
+    EXPECT_THAT(process.error_string().toStdString(), HasSubstr(program));
+    EXPECT_THAT(process.error_string().toStdString(), HasSubstr("Unknown"));
+}
+
+TEST_F(BasicProcessTest, error_string_when_completing_successfully)
+{
+    const auto program = "mock_process";
+    mp::BasicProcess process{mp::simple_process_spec(program, {"0"})};
+
+    EXPECT_TRUE(process.execute().completed_successfully());
+    EXPECT_THAT(process.error_string().toStdString(), HasSubstr(program));
+    EXPECT_THAT(process.error_string().toStdString(), HasSubstr("Unknown"));
+}
+
+TEST_F(BasicProcessTest, error_string_when_crashing)
+{
+    const auto program = "mock_process";
+    mp::BasicProcess process(mp::simple_process_spec(program));
+
+    EXPECT_FALSE(process.execute().completed_successfully());
+    EXPECT_THAT(process.error_string().toStdString(), HasSubstr(program));
+}
+
+TEST_F(BasicProcessTest, error_string_when_missing_command)
+{
+    const auto program = "no_bin_named_like_this";
+    mp::BasicProcess process{mp::simple_process_spec(program)};
+
+    EXPECT_FALSE(process.execute().completed_successfully());
+    EXPECT_THAT(process.error_string().toStdString(), HasSubstr(program));
+}


### PR DESCRIPTION
Add the program name to process error messages. This makes it easier to
quickly understand what process failed. Fixes #613 as a particular case.