### PR TITLE
daemon: Force the DeleteLater event to run

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1251,6 +1251,10 @@ try // clang-format on
             {
                 try
                 {
+                    // Force the deleteLater() event to process now to avoid unloading the apparmor profile
+                    // later.  See https://github.com/CanonicalLtd/multipass/issues/1131
+                    QCoreApplication::sendPostedEvents(0, QEvent::DeferredDelete);
+
                     MountReply mount_reply;
                     mount_reply.set_mount_message("Enabling support for mounting");
                     server->Write(mount_reply);

--- a/src/platform/backends/shared/linux/process_factory.cpp
+++ b/src/platform/backends/shared/linux/process_factory.cpp
@@ -45,7 +45,15 @@ public:
 
     ~AppArmoredProcess()
     {
-        apparmor.remove_policy(process_spec->apparmor_profile().toLatin1());
+        try
+        {
+            apparmor.remove_policy(process_spec->apparmor_profile().toLatin1());
+        }
+        catch (const std::exception& e)
+        {
+            // It's not considered an error when an apparmor cannot be removed
+            mpl::log(mpl::Level::info, "apparmor", e.what());
+        }
     }
 
 private:


### PR DESCRIPTION
- If the SSHFSMissingError exception is thrown, the deleteLater() needs to run
  immediately to avoid removing the ssfs_server apparmor profile at the wrong time.
- Catch exception if the apparmor profile cannot be removed.

Fixes #1131