### PR TITLE
platform: Do not detect parent dying and send SIGHUP to ssfs_server

### DIFF
--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,8 +12,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
  *
  */
 
@@ -57,7 +55,6 @@ bool is_alias_supported(const std::string& alias, const std::string& remote);
 bool is_remote_supported(const std::string& remote);
 bool is_image_url_supported();
 
-void emit_signal_when_parent_dies();
 int wait_for_quit_signals();
 } // namespace platform
 } // namespace multipass

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -176,8 +176,3 @@ bool mp::platform::is_image_url_supported()
 {
     return true;
 }
-
-void mp::platform::emit_signal_when_parent_dies()
-{
-    prctl(PR_SET_PDEATHSIG, SIGHUP); // ensures if parent dies, this process it sent this signal
-}

--- a/src/sshfs_mount/sshfs_server.cpp
+++ b/src/sshfs_mount/sshfs_server.cpp
@@ -65,8 +65,6 @@ unordered_map<int, int> deserialise_id_map(const char* in)
 
 int main(int argc, char* argv[])
 {
-    mpp::emit_signal_when_parent_dies(); // works on linux only
-
     if (argc != 8)
     {
         cerr << "Incorrect arguments" << endl;


### PR DESCRIPTION
When starting mounts asynchronously, ie, on start, when the thread that starts the mount
exits, this code would send a SIGHUP to sshfs_process, causing it to exit prematurely.

This code is mostly unnecessary since it's only for Linux and systemd takes care of killing
child processes if the main process dies unexpectedly when running the snap.

Fixes #1143