### PR TITLE
[sshfs] fix UID/GID mapping (Fixes #1157)

### DIFF
--- a/src/sshfs_mount/sshfs_server.cpp
+++ b/src/sshfs_mount/sshfs_server.cpp
@@ -83,8 +83,8 @@ int main(int argc, char* argv[])
     const auto username = string(argv[3]);
     const auto source_path = string(argv[4]);
     const auto target_path = string(argv[5]);
-    const unordered_map<int, int> gid_map = deserialise_id_map(argv[6]);
-    const unordered_map<int, int> uid_map = deserialise_id_map(argv[7]);
+    const unordered_map<int, int> uid_map = deserialise_id_map(argv[6]);
+    const unordered_map<int, int> gid_map = deserialise_id_map(argv[7]);
 
     auto logger = std::make_shared<mpl::StandardLogger>(mpl::Level::error); // QUESTION - how to pass verbosity level?
     mpl::set_logger(logger);


### PR DESCRIPTION
---
This is the order in which the process spec [is calling with](https://github.com/CanonicalLtd/multipass/commit/696c51284bc4ad9a04a48fecefe9e27cb2216a56#diff-bc563b8588faba37e88672d27126cc96R52-R53).

This is a hotfix, and we should probably `typedef` `UidMap` and `GidMap` so they don't get mixed up.