### PR TITLE
[launch] do not require a TTY for --cloud-init via stdin

### DIFF
--- a/src/platform/console/terminal.cpp
+++ b/src/platform/console/terminal.cpp
@@ -58,11 +58,6 @@ bool mp::Terminal::is_live() const
 
 std::string mp::Terminal::read_all_cin()
 {
-    if (!cin_is_live())
-    {
-        throw std::runtime_error("cannot read from stdin without a TTY");
-    }
-
     std::string content;
     char arr[1024];
     while (!cin().eof())


### PR DESCRIPTION
---
The only place this i used is https://github.com/CanonicalLtd/multipass/blob/a91c9c9a214841ba6f97e5c99b953180f8efd8bc/src/client/cli/cmd/launch.cpp#L177-L187

TTY is not a requirement for stdio, this check is wrong.

To test:
```
$ multipass launch --cloud-init - < file
# before
error loading cloud-init config: cannot read from stdin without a TTY

# after
Launched: …
```