### PR TITLE
Platform refactor for autostart

### DIFF
--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -78,6 +78,7 @@ void wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::millisecond
                        std::function<void()> const& ensure_vm_is_running = []() {});
 void wait_for_cloud_init(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
                          const SSHKeyProvider& key_provider);
+void link_autostart_file(const QDir& link_dir, const QString& autostart_subdir, const QString& autostart_filename);
 
 template <typename OnTimeoutCallable, typename TryAction, typename... Args>
 void try_action_for(OnTimeoutCallable&& on_timeout, std::chrono::milliseconds timeout, TryAction&& try_action,

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -56,6 +56,7 @@ QDir base_dir(const QString& path);
 multipass::Path make_dir(const QDir& a_dir, const QString& name);
 bool is_dir(const std::string& path);
 QString backend_directory_path(const Path& path, const QString& subdirectory);
+QString find_autostart_target(const QString& subdir, const QString& autostart_filename);
 QString get_driver_str();
 std::string filename_for(const std::string& path);
 QString make_uuid();

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -56,7 +56,6 @@ QDir base_dir(const QString& path);
 multipass::Path make_dir(const QDir& a_dir, const QString& name);
 bool is_dir(const std::string& path);
 QString backend_directory_path(const Path& path, const QString& subdirectory);
-QString find_autostart_target(const QString& subdir, const QString& autostart_filename);
 QString get_driver_str();
 std::string filename_for(const std::string& path);
 QString make_uuid();

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -44,25 +44,6 @@ namespace
 {
 constexpr auto autostart_filename = "multipass.gui.autostart.desktop";
 
-QString find_desktop_target()
-{
-    const auto target_subpath = QDir{mp::client_name}.filePath(autostart_filename);
-    const auto target_path = QStandardPaths::locate(QStandardPaths::GenericDataLocation, target_subpath);
-
-    if (target_path.isEmpty())
-    {
-        QString detail{};
-        for (const auto& path : QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation))
-            detail += QStringLiteral("\n  ") + path + "/" + target_subpath;
-
-        throw mp::AutostartSetupException{
-            fmt::format("could not locate the autostart .desktop file '{}'", autostart_filename),
-            fmt::format("Tried: {}", detail.toStdString())};
-    }
-
-    return target_path;
-}
-
 } // namespace
 
 QString mp::platform::autostart_test_data()
@@ -75,7 +56,7 @@ void mp::platform::setup_gui_autostart_prerequisites()
     const auto config_dir = QDir{QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)};
     const auto autostart_dir = QDir{config_dir.absoluteFilePath("autostart")};
     const auto link_path = autostart_dir.absoluteFilePath(autostart_filename);
-    const auto target_path = find_desktop_target();
+    const auto target_path = mu::find_autostart_target(mp::client_name, autostart_filename);
 
     const auto link_info = QFileInfo{link_path};
     const auto target_info = QFileInfo{target_path};

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -44,29 +44,6 @@ namespace
 {
 constexpr auto autostart_filename = "multipass.gui.autostart.desktop";
 
-void link_autostart_file(const QDir& link_dir, const QString& autostart_subdir, const QString& autostart_filename)
-{
-    const auto link_path = link_dir.absoluteFilePath(autostart_filename);
-    const auto target_path = mu::find_autostart_target(autostart_subdir, autostart_filename);
-
-    const auto link_info = QFileInfo{link_path};
-    const auto target_info = QFileInfo{target_path};
-    auto target_file = QFile{target_path};
-    auto link_file = QFile{link_path};
-
-    if (link_info.isSymLink() && link_info.symLinkTarget() != target_info.absoluteFilePath())
-        link_file.remove(); // get rid of outdated and broken links
-
-    if (!link_file.exists())
-    {
-        link_dir.mkpath(".");
-        if (!target_file.link(link_path))
-
-            throw mp::AutostartSetupException{fmt::format("failed to link file '{}' to '{}'", link_path, target_path),
-                                              fmt::format("Detail: {} (error code {})", strerror(errno), errno)};
-    }
-}
-
 } // namespace
 
 QString mp::platform::autostart_test_data()
@@ -78,7 +55,7 @@ void mp::platform::setup_gui_autostart_prerequisites()
 {
     const auto config_dir = QDir{QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)};
     const auto link_dir = QDir{config_dir.absoluteFilePath("autostart")};
-    link_autostart_file(link_dir, mp::client_name, autostart_filename);
+    mu::link_autostart_file(link_dir, mp::client_name, autostart_filename);
 }
 
 std::string mp::platform::default_server_address()

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -44,19 +44,10 @@ namespace
 {
 constexpr auto autostart_filename = "multipass.gui.autostart.desktop";
 
-} // namespace
-
-QString mp::platform::autostart_test_data()
+void link_autostart_file(const QDir& link_dir, const QString& autostart_subdir, const QString& autostart_filename)
 {
-    return autostart_filename;
-}
-
-void mp::platform::setup_gui_autostart_prerequisites()
-{
-    const auto config_dir = QDir{QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)};
-    const auto autostart_dir = QDir{config_dir.absoluteFilePath("autostart")};
-    const auto link_path = autostart_dir.absoluteFilePath(autostart_filename);
-    const auto target_path = mu::find_autostart_target(mp::client_name, autostart_filename);
+    const auto link_path = link_dir.absoluteFilePath(autostart_filename);
+    const auto target_path = mu::find_autostart_target(autostart_subdir, autostart_filename);
 
     const auto link_info = QFileInfo{link_path};
     const auto target_info = QFileInfo{target_path};
@@ -68,12 +59,26 @@ void mp::platform::setup_gui_autostart_prerequisites()
 
     if (!link_file.exists())
     {
-        autostart_dir.mkpath(".");
+        link_dir.mkpath(".");
         if (!target_file.link(link_path))
 
-            throw AutostartSetupException{fmt::format("failed to link file '{}' to '{}'", link_path, target_path),
-                                          fmt::format("Detail: {} (error code {})", strerror(errno), errno)};
+            throw mp::AutostartSetupException{fmt::format("failed to link file '{}' to '{}'", link_path, target_path),
+                                              fmt::format("Detail: {} (error code {})", strerror(errno), errno)};
     }
+}
+
+} // namespace
+
+QString mp::platform::autostart_test_data()
+{
+    return autostart_filename;
+}
+
+void mp::platform::setup_gui_autostart_prerequisites()
+{
+    const auto config_dir = QDir{QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)};
+    const auto link_dir = QDir{config_dir.absoluteFilePath("autostart")};
+    link_autostart_file(link_dir, mp::client_name, autostart_filename);
 }
 
 std::string mp::platform::default_server_address()

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -51,6 +51,24 @@ auto quote_for(const std::string& arg, mp::utils::QuoteType quote_type)
         return "";
     return arg.find('\'') == std::string::npos ? "'" : "\"";
 }
+
+QString find_autostart_target(const QString& subdir, const QString& autostart_filename)
+{
+    const auto target_subpath = QDir{subdir}.filePath(autostart_filename);
+    const auto target_path = QStandardPaths::locate(QStandardPaths::GenericDataLocation, target_subpath);
+
+    if (target_path.isEmpty())
+    {
+        QString detail{};
+        for (const auto& path : QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation))
+            detail += QStringLiteral("\n  ") + path + "/" + target_subpath;
+
+        throw mp::AutostartSetupException{fmt::format("could not locate the autostart file '{}'", autostart_filename),
+                                          fmt::format("Tried: {}", detail.toStdString())};
+    }
+
+    return target_path;
+}
 } // namespace
 
 QDir mp::utils::base_dir(const QString& path)
@@ -234,24 +252,6 @@ QString mp::utils::backend_directory_path(const mp::Path& path, const QString& s
         return path;
 
     return mp::Path("%1/%2").arg(path).arg(subdirectory);
-}
-
-QString mp::utils::find_autostart_target(const QString& subdir, const QString& autostart_filename)
-{
-    const auto target_subpath = QDir{subdir}.filePath(autostart_filename);
-    const auto target_path = QStandardPaths::locate(QStandardPaths::GenericDataLocation, target_subpath);
-
-    if (target_path.isEmpty())
-    {
-        QString detail{};
-        for (const auto& path : QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation))
-            detail += QStringLiteral("\n  ") + path + "/" + target_subpath;
-
-        throw mp::AutostartSetupException{fmt::format("could not locate the autostart file '{}'", autostart_filename),
-                                          fmt::format("Tried: {}", detail.toStdString())};
-    }
-
-    return target_path;
 }
 
 QString mp::utils::get_driver_str()

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <multipass/constants.h>
+#include <multipass/exceptions/autostart_setup_exception.h>
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
 #include <multipass/settings.h>
@@ -26,6 +27,7 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QProcess>
+#include <QStandardPaths>
 #include <QUuid>
 #include <QtGlobal>
 
@@ -208,6 +210,24 @@ QString mp::utils::backend_directory_path(const mp::Path& path, const QString& s
         return path;
 
     return mp::Path("%1/%2").arg(path).arg(subdirectory);
+}
+
+QString mp::utils::find_autostart_target(const QString& subdir, const QString& autostart_filename)
+{
+    const auto target_subpath = QDir{subdir}.filePath(autostart_filename);
+    const auto target_path = QStandardPaths::locate(QStandardPaths::GenericDataLocation, target_subpath);
+
+    if (target_path.isEmpty())
+    {
+        QString detail{};
+        for (const auto& path : QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation))
+            detail += QStringLiteral("\n  ") + path + "/" + target_subpath;
+
+        throw mp::AutostartSetupException{fmt::format("could not locate the autostart file '{}'", autostart_filename),
+                                          fmt::format("Tried: {}", detail.toStdString())};
+    }
+
+    return target_path;
 }
 
 QString mp::utils::get_driver_str()


### PR DESCRIPTION
This refactors finding and linking of the autostart file, providing a generic utility to reuse in other platform implementations that rely on this mechanism (namely macos).