### PR TITLE
console/unix: Only use interactive tty if both stdin & stdout are live

### DIFF
--- a/src/platform/console/unix_console.cpp
+++ b/src/platform/console/unix_console.cpp
@@ -86,7 +86,7 @@ mp::UnixConsole::UnixConsole(ssh_channel channel, UnixTerminal* term)
 {
     setup_console();
 
-    if (term->cin_is_live())
+    if (term->is_live())
     {
         ssh_channel_request_pty(channel);
         change_ssh_pty_size(channel, term->cout_fd());


### PR DESCRIPTION
Fixes #667