### PR TITLE
Add update balloon notification

### DIFF
--- a/include/multipass/cli/client_platform.h
+++ b/include/multipass/cli/client_platform.h
@@ -33,6 +33,7 @@ void parse_transfer_entry(const QString& entry, QString& path, QString& instance
 int getuid();
 int getgid();
 void open_multipass_shell(const QString& instance_name);
+QStringList gui_tray_notification_strings();
 }
 }
 }

--- a/src/client/gui/gui_cmd.cpp
+++ b/src/client/gui/gui_cmd.cpp
@@ -208,6 +208,7 @@ void cmd::GuiCmd::update_about_menu()
     {
         update_action.setWhatsThis(QString::fromStdString(reply.update_info().url()));
         tray_icon_menu.insertAction(about_menu.menuAction(), &update_action);
+        tray_icon.showMessage("New Multipass update available", QString::fromStdString(reply.update_info().url()));
     }
     else
     {
@@ -220,6 +221,9 @@ void cmd::GuiCmd::create_menu()
     tray_icon.setContextMenu(&tray_icon_menu);
 
     tray_icon.setIcon(QIcon{":images/multipass-icon.png"});
+
+    QObject::connect(&tray_icon, &QSystemTrayIcon::messageClicked,
+                     [this] { QDesktopServices::openUrl(QUrl(update_action.whatsThis())); });
 
     QObject::connect(&list_watcher, &QFutureWatcher<ListReply>::finished, this, &GuiCmd::update_menu);
 

--- a/src/client/gui/gui_cmd.cpp
+++ b/src/client/gui/gui_cmd.cpp
@@ -106,6 +106,16 @@ mp::ReturnCode cmd::GuiCmd::run(mp::ArgParser* parser)
     create_menu();
     tray_icon.show();
 
+    QFile first_run_file(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/first_run");
+
+    if (!first_run_file.exists())
+    {
+        tray_icon.showMessage("Multipass System Tray Menu", "The Multipass system tray menu is now running",
+                              tray_icon.icon());
+        first_run_file.open(QIODevice::WriteOnly);
+        first_run_file.close();
+    }
+
     return static_cast<ReturnCode>(QCoreApplication::exec());
 }
 

--- a/src/client/gui/gui_cmd.cpp
+++ b/src/client/gui/gui_cmd.cpp
@@ -110,7 +110,11 @@ mp::ReturnCode cmd::GuiCmd::run(mp::ArgParser* parser)
 
     if (!first_run_file.exists())
     {
-        tray_icon.showMessage("Multipass System Tray Menu", "The Multipass system tray menu is now running",
+        // Each platform refers to the "system tray", icons, and the "menu bar" by different terminology.
+        // A platform dependent mechanism is used to get the terms via a QStringList.
+        auto notification_area_terms = mp::cli::platform::gui_tray_notification_strings();
+        tray_icon.showMessage(QString("Multipass is in your %1").arg(notification_area_terms[0]),
+                              QString("Click on the %1 for available options").arg(notification_area_terms[1]),
                               tray_icon.icon());
         first_run_file.open(QIODevice::WriteOnly);
         first_run_file.close();

--- a/src/client/gui/gui_cmd.cpp
+++ b/src/client/gui/gui_cmd.cpp
@@ -111,11 +111,9 @@ mp::ReturnCode cmd::GuiCmd::run(mp::ArgParser* parser)
     if (!first_run_file.exists())
     {
         // Each platform refers to the "system tray", icons, and the "menu bar" by different terminology.
-        // A platform dependent mechanism is used to get the terms via a QStringList.
-        auto notification_area_terms = mp::cli::platform::gui_tray_notification_strings();
-        tray_icon.showMessage(QString("Multipass is in your %1").arg(notification_area_terms[0]),
-                              QString("Click on the %1 for available options").arg(notification_area_terms[1]),
-                              tray_icon.icon());
+        // A platform dependent mechanism is used to get the messages via a QStringList.
+        auto notification_area_strings = mp::cli::platform::gui_tray_notification_strings();
+        tray_icon.showMessage(notification_area_strings[0], notification_area_strings[1], tray_icon.icon());
         first_run_file.open(QIODevice::WriteOnly);
         first_run_file.close();
     }

--- a/src/client/gui/gui_cmd.cpp
+++ b/src/client/gui/gui_cmd.cpp
@@ -221,7 +221,7 @@ void cmd::GuiCmd::update_about_menu()
         update_action.setWhatsThis(QString::fromStdString(reply.update_info().url()));
         tray_icon_menu.insertAction(about_menu.menuAction(), &update_action);
         tray_icon.showMessage("New Multipass update available",
-                              QString("Version %1 is availble. Click for more information.")
+                              QString("Version %1 is available. Click here for more information.")
                                   .arg(QString::fromStdString(reply.update_info().version())));
     }
     else

--- a/src/client/gui/gui_cmd.cpp
+++ b/src/client/gui/gui_cmd.cpp
@@ -25,8 +25,9 @@
 #include <multipass/settings.h>
 #include <multipass/version.h>
 
-#include <QCoreApplication>
+#include <QApplication>
 #include <QDesktopServices>
+#include <QStyle>
 #include <QtConcurrent/QtConcurrent>
 
 namespace mp = multipass;
@@ -206,9 +207,12 @@ void cmd::GuiCmd::update_about_menu()
 
     if (update_available(reply.update_info()))
     {
+        update_action.setIcon(QApplication::style()->standardIcon(QStyle::SP_MessageBoxInformation));
         update_action.setWhatsThis(QString::fromStdString(reply.update_info().url()));
         tray_icon_menu.insertAction(about_menu.menuAction(), &update_action);
-        tray_icon.showMessage("New Multipass update available", QString::fromStdString(reply.update_info().url()));
+        tray_icon.showMessage("New Multipass update available",
+                              QString("Version %1 is availble. Click for more information.")
+                                  .arg(QString::fromStdString(reply.update_info().version())));
     }
     else
     {
@@ -255,7 +259,7 @@ void cmd::GuiCmd::create_menu()
     initiate_about_menu_layout();
 
     menu_update_timer.start(1s);
-    about_update_timer.start(12h);
+    about_update_timer.start(24h);
 }
 
 void cmd::GuiCmd::initiate_menu_layout()

--- a/src/platform/client/client_platform_linux.cpp
+++ b/src/platform/client/client_platform_linux.cpp
@@ -27,3 +27,8 @@ void mcp::open_multipass_shell(const QString& instance_name)
     QProcess::startDetached(
         "xterm", {"-title", instance_name, "-j", "-e", QString("multipass shell %1 || read").arg(instance_name)});
 }
+
+QStringList mcp::gui_tray_notification_strings()
+{
+    return {"System tray", "status icon"};
+}

--- a/src/platform/client/client_platform_linux.cpp
+++ b/src/platform/client/client_platform_linux.cpp
@@ -30,5 +30,5 @@ void mcp::open_multipass_shell(const QString& instance_name)
 
 QStringList mcp::gui_tray_notification_strings()
 {
-    return {"System tray", "status icon"};
+    return {"Multipass is in your System tray", "Click on the status icon for available options"};
 }


### PR DESCRIPTION
Adds a notification for when an update is available.
Adds a first run notification to alert the user that the Multipass tray icon menu is running.

Fixes #1072 

---
The easiest way to test this is on Windows and modify the following files:
- `src/version.h.in`
  -  Change `constexpr auto version_string = "@MULTIPASS_VERSION@";` to `constexpr auto version_string = "0.6.0";` (or a version less than what is currently released).
- `src/client/gui/gui_cmd.cpp`
  - Change `about_update_timer.start(24h);` to `about_update_timer.start(60s);` (or whatever duration you'd like the notification to show).

Also, for the first run notification, due to a bug in Qt, the custom Multipass icon will not show in this notification on Ubuntu.  It should be there for the other platforms though.