### PR TITLE
Move to yaml update info

### DIFF
--- a/src/platform/update/CMakeLists.txt
+++ b/src/platform/update/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(update
   fmt
   rpc
   semver
+  yaml
   Qt5::Core)
 
 target_include_directories(update

--- a/src/platform/update/new_release_monitor.cpp
+++ b/src/platform/update/new_release_monitor.cpp
@@ -71,11 +71,11 @@ public:
         }
         catch (const mp::DownloadException& e)
         {
-            mpl::log(mpl::Level::info, "update", fmt::format("Failed to fetch update info: {}", qPrintable(e.what())));
+            mpl::log(mpl::Level::warning, "update", fmt::format("Failed to fetch update info: {}", e.what()));
         }
-        catch (const std::runtime_error& e)
+        catch (const std::runtime_error& e) // This covers YAML::Exception
         {
-            mpl::log(mpl::Level::info, "update", fmt::format("Failed to parse update info: {}", qPrintable(e.what())));
+            mpl::log(mpl::Level::warning, "update", fmt::format("Failed to parse update info: {}", e.what()));
         }
     }
 signals:

--- a/src/platform/update/new_release_monitor.h
+++ b/src/platform/update/new_release_monitor.h
@@ -44,7 +44,7 @@ class NewReleaseMonitor : public QObject
 {
     Q_OBJECT
 public:
-    static constexpr auto default_update_url = "https://multipass.run/update.json";
+    static constexpr auto default_update_url = "https://multipass.run/update.yaml";
 
     NewReleaseMonitor(const QString& current_version, std::chrono::steady_clock::duration refresh_rate,
                       const QString& update_url = default_update_url);

--- a/tests/test_new_release_monitor.cpp
+++ b/tests/test_new_release_monitor.cpp
@@ -64,7 +64,8 @@ private:
     QTemporaryFile yaml_file;
 };
 
-auto check_for_new_release(QString currentVersion, QString newVersion, QString newVersionUrl = "")
+auto check_for_new_release(QString currentVersion, QString newVersion,
+                           QString newVersionUrl = "https://fake.multipass.url/release")
 {
     QEventLoop e;
     StubUpdateYAML yaml(newVersion, newVersionUrl);

--- a/tests/test_new_release_monitor.cpp
+++ b/tests/test_new_release_monitor.cpp
@@ -81,11 +81,12 @@ auto check_for_new_release(QString currentVersion, QString newVersion,
 
 TEST(NewReleaseMonitor, checks_new_release)
 {
-    auto new_release = check_for_new_release("0.1.0", "0.2.0", "https://something_unique.com");
+    auto url = "https://something_unique.com";
+    auto new_release = check_for_new_release("0.1.0", "0.2.0", url);
 
     ASSERT_TRUE(new_release);
     EXPECT_EQ("0.2.0", new_release->version.toStdString());
-    EXPECT_EQ("https://something_unique.com", new_release->url.toString().toStdString());
+    EXPECT_EQ(url, new_release->url.toString().toStdString());
 }
 
 TEST(NewReleaseMonitor, checks_new_release_when_nothing_new)


### PR DESCRIPTION
As originally requested, I moved the update source to YAML. 

I was just informed we will probably not go with it after all, but I am leaving it here for the record and just in case there is another change of plans.