### PR TITLE
[linux] do not fail when AppArmor policy loading fails (Fixes #1216)

### DIFF
--- a/src/platform/backends/shared/basic_process.cpp
+++ b/src/platform/backends/shared/basic_process.cpp
@@ -41,7 +41,7 @@ void mp::BasicProcess::CustomQProcess::setupChildProcess()
     p->setup_child_process();
 }
 
-mp::BasicProcess::BasicProcess(std::unique_ptr<mp::ProcessSpec>&& spec) : process_spec{std::move(spec)}, process{this}
+mp::BasicProcess::BasicProcess(std::shared_ptr<mp::ProcessSpec> spec) : process_spec{spec}, process{this}
 {
     connect(&process, &QProcess::started, this, &mp::Process::started);
     connect(&process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished),

--- a/src/platform/backends/shared/basic_process.h
+++ b/src/platform/backends/shared/basic_process.h
@@ -33,7 +33,7 @@ class BasicProcess : public Process
 {
     Q_OBJECT
 public:
-    BasicProcess(std::unique_ptr<ProcessSpec>&& spec);
+    BasicProcess(std::shared_ptr<ProcessSpec> spec);
     virtual ~BasicProcess();
 
     QString program() const override;
@@ -61,7 +61,7 @@ public:
     ProcessState execute(const int timeout = 30000) override;
 
 protected:
-    const std::unique_ptr<ProcessSpec> process_spec;
+    const std::shared_ptr<ProcessSpec> process_spec;
 
     void setup_child_process() override;
 

--- a/src/platform/backends/shared/linux/apparmor.cpp
+++ b/src/platform/backends/shared/linux/apparmor.cpp
@@ -40,7 +40,7 @@ void throw_if_binary_fails(const char* binary_name, const QStringList& arguments
     process.start(binary_name, arguments);
     if (!process.waitForFinished() || process.exitCode() != 0)
     {
-        throw std::runtime_error(
+        throw mp::AppArmorException(
             fmt::format("AppArmor cannot be configured, the '{}' utility failed to launch with error: {}", binary_name,
                         process.errorString()));
     }
@@ -71,7 +71,7 @@ mp::AppArmor::AppArmor() : apparmor_args{generate_extra_apparmor_args()}
     int ret = aa_is_enabled();
     if (ret < 0)
     {
-        throw std::runtime_error("AppArmor is not enabled");
+        throw mp::AppArmorException("AppArmor is not enabled");
     }
 
     // libapparmor's profile management API is not easy to use, it is handier to use apparmor_profile CLI tool
@@ -93,8 +93,8 @@ void mp::AppArmor::load_policy(const QByteArray& aa_policy) const
 
     if (process.exitCode() != 0)
     {
-        throw std::runtime_error(fmt::format("Failed to load AppArmor policy {}: errno={} ({})", aa_policy,
-                                             process.exitCode(), process.readAll()));
+        throw mp::AppArmorException(fmt::format("Failed to load AppArmor policy {}: errno={} ({})", aa_policy,
+                                                process.exitCode(), process.readAll()));
     }
 }
 
@@ -111,8 +111,8 @@ void mp::AppArmor::remove_policy(const QByteArray& aa_policy) const
 
     if (process.exitCode() != 0)
     {
-        throw std::runtime_error(fmt::format("Failed to remove AppArmor policy {}: errno={} ({})", aa_policy,
-                                             process.exitCode(), process.readAll()));
+        throw mp::AppArmorException(fmt::format("Failed to remove AppArmor policy {}: errno={} ({})", aa_policy,
+                                                process.exitCode(), process.readAll()));
     }
 }
 
@@ -123,7 +123,7 @@ void mp::AppArmor::next_exec_under_policy(const QByteArray& aa_policy_name) cons
 
     if (ret < 0)
     {
-        throw std::runtime_error(
+        throw mp::AppArmorException(
             fmt::format("Failed to apply AppArmor policy {}: errno={} ({})", aa_policy_name, errno, strerror(errno)));
     }
 }

--- a/src/platform/backends/shared/linux/apparmor.h
+++ b/src/platform/backends/shared/linux/apparmor.h
@@ -37,6 +37,14 @@ private:
     const QStringList apparmor_args;
 };
 
+class AppArmorException : public std::runtime_error
+{
+public:
+    AppArmorException(const std::string& msg) : runtime_error{msg}
+    {
+    }
+};
+
 } // namespace multipass
 
 #endif // MULTIPASS_APPARMOR_CONFINEMENT_H

--- a/src/platform/backends/shared/linux/process_factory.cpp
+++ b/src/platform/backends/shared/linux/process_factory.cpp
@@ -18,6 +18,7 @@
 #include "process_factory.h"
 #include "basic_process.h"
 #include "simple_process_spec.h"
+#include <multipass/format.h>
 #include <multipass/logging/log.h>
 #include <multipass/process_spec.h>
 #include <multipass/utils.h>
@@ -74,8 +75,16 @@ mp::optional<mp::AppArmor> create_apparmor()
     }
     else
     {
-        mpl::log(mpl::Level::info, "apparmor", "Using AppArmor support");
-        return mp::AppArmor{};
+        try
+        {
+            mpl::log(mpl::Level::info, "apparmor", "Using AppArmor support");
+            return mp::AppArmor{};
+        }
+        catch (mp::AppArmorException& e)
+        {
+            mpl::log(mpl::Level::warning, "apparmor", fmt::format("Failed to enable AppArmor: {}", e.what()));
+            return mp::nullopt;
+        }
     }
 }
 } // namespace
@@ -90,7 +99,16 @@ std::unique_ptr<mp::Process> mp::ProcessFactory::create_process(std::unique_ptr<
 {
     if (apparmor && !process_spec->apparmor_profile().isNull())
     {
-        return std::make_unique<AppArmoredProcess>(apparmor.value(), std::move(process_spec));
+        try
+        {
+            return std::make_unique<AppArmoredProcess>(apparmor.value(), std::move(process_spec));
+        }
+        catch (const mp::AppArmorException& e)
+        {
+            // TODO: This won't fly in strict mode (#1074), since we'll be confined by snapd
+            mpl::log(mpl::Level::warning, "apparmor", e.what());
+            return std::make_unique<BasicProcess>(std::move(process_spec));
+        }
     }
     else
     {

--- a/src/platform/backends/shared/linux/process_factory.cpp
+++ b/src/platform/backends/shared/linux/process_factory.cpp
@@ -31,8 +31,8 @@ namespace
 class AppArmoredProcess : public mp::BasicProcess
 {
 public:
-    AppArmoredProcess(const mp::AppArmor& aa, std::unique_ptr<mp::ProcessSpec>&& spec)
-        : mp::BasicProcess{std::move(spec)}, apparmor{aa}
+    AppArmoredProcess(const mp::AppArmor& aa, std::shared_ptr<mp::ProcessSpec> spec)
+        : mp::BasicProcess{spec}, apparmor{aa}
     {
         apparmor.load_policy(process_spec->apparmor_profile().toLatin1());
     }
@@ -99,15 +99,16 @@ std::unique_ptr<mp::Process> mp::ProcessFactory::create_process(std::unique_ptr<
 {
     if (apparmor && !process_spec->apparmor_profile().isNull())
     {
+        std::shared_ptr<ProcessSpec> spec = std::move(process_spec);
         try
         {
-            return std::make_unique<AppArmoredProcess>(apparmor.value(), std::move(process_spec));
+            return std::make_unique<AppArmoredProcess>(apparmor.value(), spec);
         }
         catch (const mp::AppArmorException& e)
         {
             // TODO: This won't fly in strict mode (#1074), since we'll be confined by snapd
             mpl::log(mpl::Level::warning, "apparmor", e.what());
-            return std::make_unique<BasicProcess>(std::move(process_spec));
+            return std::make_unique<BasicProcess>(spec);
         }
     }
     else


### PR DESCRIPTION
---
To test:
```shell
multipass stop --all
sudo modprobe -r kvm_intel
sudo modprobe kvm_intel nested=1
multipass start
multipass shell primary

# inside the instance
wget \
  https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.0.21/linux-headers-5.0.21-050021_5.0.21-050021.201906040731_all.deb \
  https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.0.21/linux-headers-5.0.21-050021-generic_5.0.21-050021.201906040731_amd64.deb \
  https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.0.21/linux-image-unsigned-5.0.21-050021-generic_5.0.21-050021.201906040731_amd64.deb \
  https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.0.21/linux-modules-5.0.21-050021-generic_5.0.21-050021.201906040731_amd64.deb
sudo dpkg -i *.deb
sudo reboot

# enter the instance again
multipass shell primary

# inside the instance, ensure the new kernel is loaded
uname -a

sudo snap install multipass --beta --classic

# this will fail
multipass launch snapcraft:core18 --mem 512M

# refresh to this PR
sudo snap refresh multipass --channel edge/pr1218

# this will now work :)
multipass launch snapcraft:core18 --mem 512M

# you can see the AppArmor warnings (they fired before the launch) in journalctl
journalctl -u snap.multipass*
```